### PR TITLE
Fixed cli terminated problem on Windows

### DIFF
--- a/packages/wunderctl/src/cli.ts
+++ b/packages/wunderctl/src/cli.ts
@@ -11,7 +11,7 @@ export const cli = async () => {
 
 	const [, , ...args] = process.argv;
 
-	const subprocess = execa(file, args);
+	const subprocess = execa(file, args, {windowsHide: false});
 	subprocess.stdout?.pipe(process.stdout);
 	subprocess.stderr?.pipe(process.stderr);
 


### PR DESCRIPTION
This issue is caused by execa settings.

On Windows, do not create a new console window. Please note this also prevents CTRL-C [from working](https://github.com/nodejs/node/issues/29837) on Windows.