### PR TITLE
refactor: use graphql playground instead of graphiql

### DIFF
--- a/pkg/apihandler/apihandler.go
+++ b/pkg/apihandler/apihandler.go
@@ -278,12 +278,15 @@ func (r *Builder) BuildAndMountApiHandler(ctx context.Context, router *mux.Route
 			abstractlogger.String("path", path.Join(api.PathPrefix, apiPath)),
 		)
 
-		graphqlPlaygroundHandler := &GraphQLPlaygroundHandler{
-			log:           r.log,
-			html:          graphiql.GetGraphiqlPlaygroundHTML(),
-			apiPathPrefix: api.GetPathPrefix(),
+		if err := registerGraphqlPlaygroundHandler(r.router, api.PathPrefix, apiPath); err != nil {
+			graphqlPlaygroundHandler := &GraphQLPlaygroundHandler{
+				log:           r.log,
+				html:          graphiql.GetGraphiqlPlaygroundHTML(),
+				apiPathPrefix: api.GetPathPrefix(),
+			}
+			r.router.Methods(http.MethodGet, http.MethodOptions).Path(apiPath).Handler(graphqlPlaygroundHandler)
 		}
-		r.router.Methods(http.MethodGet, http.MethodOptions).Path(apiPath).Handler(graphqlPlaygroundHandler)
+
 		r.log.Debug("registered GraphQLPlaygroundHandler",
 			abstractlogger.String("method", http.MethodGet),
 			abstractlogger.String("path", path.Join(api.PathPrefix, apiPath)),

--- a/pkg/apihandler/playgroundhandler.go
+++ b/pkg/apihandler/playgroundhandler.go
@@ -1,0 +1,29 @@
+package apihandler
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/wundergraph/graphql-go-tools/pkg/playground"
+)
+
+func registerGraphqlPlaygroundHandler(router *mux.Router, pathPrefix string, apiPath string) (err error) {
+	p := playground.New(playground.Config{
+		PathPrefix:                      "",
+		PlaygroundPath:                  apiPath,
+		GraphqlEndpointPath:             apiPath,
+		GraphQLSubscriptionEndpointPath: apiPath,
+	})
+
+	handlers, err := p.Handlers()
+
+	if err != nil {
+		return err
+	}
+
+	for i := range handlers {
+		router.Methods(http.MethodGet, http.MethodOptions).Path(handlers[i].Path).Handler(handlers[i].Handler)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Use graphql playground (from graphql-go-tools library) instead of graphiql