### PR TITLE
fix: openapi introspection defect

### DIFF
--- a/packages/sdk/src/v2openapi/index.ts
+++ b/packages/sdk/src/v2openapi/index.ts
@@ -1117,7 +1117,7 @@ class RESTApiBuilder {
 					const trimmed = current.substring(1, current.length - 1);
 					return prev + 'By' + trimmed[0].toUpperCase() + trimmed.substring(1);
 				}
-				return prev + (current[0] || '').toUpperCase() + current.substring(1);
+				return prev + current[0]?.toUpperCase() + current.substring(1);
 			});
 		return hTTPMethodToJSON(verb).toLowerCase() + formattedPath[0].toUpperCase() + formattedPath.substring(1);
 	};

--- a/packages/sdk/src/v2openapi/index.ts
+++ b/packages/sdk/src/v2openapi/index.ts
@@ -1131,7 +1131,7 @@ class RESTApiBuilder {
 				const trimmed = current.substring(1, current.length - 1);
 				return prev + trimmed[0].toUpperCase() + trimmed.substring(1);
 			}
-			return prev + (current[0] || '').toUpperCase() + current.substring(1);
+			return prev + current[0]?.toUpperCase() + current.substring(1);
 		});
 		return hTTPMethodToJSON(verb).toLowerCase() + formattedPath[0] + formattedPath.substring(1) + 'Input';
 	}

--- a/packages/sdk/src/v2openapi/index.ts
+++ b/packages/sdk/src/v2openapi/index.ts
@@ -1117,7 +1117,7 @@ class RESTApiBuilder {
 					const trimmed = current.substring(1, current.length - 1);
 					return prev + 'By' + trimmed[0].toUpperCase() + trimmed.substring(1);
 				}
-				return prev + current[0].toUpperCase() + current.substring(1);
+				return prev + (current[0] || '').toUpperCase() + current.substring(1);
 			});
 		return hTTPMethodToJSON(verb).toLowerCase() + formattedPath[0].toUpperCase() + formattedPath.substring(1);
 	};
@@ -1131,7 +1131,7 @@ class RESTApiBuilder {
 				const trimmed = current.substring(1, current.length - 1);
 				return prev + trimmed[0].toUpperCase() + trimmed.substring(1);
 			}
-			return prev + current[0].toUpperCase() + current.substring(1);
+			return prev + (current[0] || '').toUpperCase() + current.substring(1);
 		});
 		return hTTPMethodToJSON(verb).toLowerCase() + formattedPath[0] + formattedPath.substring(1) + 'Input';
 	}


### PR DESCRIPTION
fix issue when current[0] is undefined

example:

C:\Working\_wundergraphTest\node_modules\@wundergraph\sdk\dist\v2openapi\index.js:1002
            return prev + current[0].toUpperCase() + current.substring(1);
                                     ^

TypeError: Cannot read properties of undefined (reading 'toUpperCase')
    at C:\Working\_wundergraphTest\node_modules\@wundergraph\sdk\dist\v2openapi\index.js:1002:38
    at Array.reduce (<anonymous>)
    at RESTApiBuilder.resolveArgumentName (C:\Working\_wundergraphTest\node_modules\@wundergraph\sdk\dist\v2openapi\index.js:997:47)
    at RESTApiBuilder.traversePath (C:\Working\_wundergraphTest\node_modules\@wundergraph\sdk\dist\v2openapi\index.js:225:43)
    at C:\Working\_wundergraphTest\node_modules\@wundergraph\sdk\dist\v2openapi\index.js:47:26
    at Array.forEach (<anonymous>)
    at RESTApiBuilder.build (C:\Working\_wundergraphTest\node_modules\@wundergraph\sdk\dist\v2openapi\index.js:38:42)
    at openApiSpecificationToRESTApiObject (C:\Working\_wundergraphTest\node_modules\@wundergraph\sdk\dist\v2openapi\index.js:26:28)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async Object.openApi (C:\Working\_wundergraphTest\node_modules\@wundergraph\sdk\dist\definition\index.js:501:16)
2022-06-27T10:03:16-04:00       error   Config Bundler: error executing script  {"bundler": "config", "error": "exit status 1"}

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `make test`
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)

<!--
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->
