### PR TITLE
feat: improve error message when graphql introspection fails

### DIFF
--- a/packages/default-testapp/.wundergraph/wundergraph.config.ts
+++ b/packages/default-testapp/.wundergraph/wundergraph.config.ts
@@ -25,7 +25,7 @@ const jsp = introspect.openApi({
 
 const countries = introspect.graphql({
 	apiNamespace: 'countries',
-	url: 'https://countries.trevorblades.com/',
+	url: 'https://countries.trevorblades.comm/',
 });
 
 const myApplication = new Application({

--- a/packages/sdk/src/definition/index.ts
+++ b/packages/sdk/src/definition/index.ts
@@ -14,7 +14,7 @@ import { mergeApis } from './merge';
 import * as fs from 'fs';
 import { openApiSpecificationToRESTApiObject } from '../v2openapi';
 import { renameTypeFields, renameTypes } from '../graphql/renametypes';
-import axios, { AxiosRequestConfig } from 'axios';
+import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
 import {
 	ArgumentSource,
 	ConfigurationVariable,
@@ -928,9 +928,20 @@ const introspectGraphQLAPI = async (
 	}
 
 	// TODO single place where a HTTP client is configured for all data sources
-	const res = await axios.post(resolveVariable(introspection.url), data, opts);
+	let res: AxiosResponse | undefined;
+	try {
+		res = await axios.post(resolveVariable(introspection.url), data, opts);
+	} catch (e: any) {
+		console.log(`introspection failed, error: ${e.message}`);
+		process.exit(1);
+	}
+	if (res === undefined) {
+		console.log('introspection failed, no response');
+		process.exit(1);
+	}
 	if (res.status !== 200) {
-		return Promise.reject(`introspection failed, response code: ${res.status}, message: ${res.statusText}`);
+		console.log(`introspection failed, response code: ${res.status}, message: ${res.statusText}`);
+		process.exit(1);
 	}
 	return buildClientSchema(res.data.data);
 };

--- a/packages/sdk/src/definition/index.ts
+++ b/packages/sdk/src/definition/index.ts
@@ -932,15 +932,25 @@ const introspectGraphQLAPI = async (
 	try {
 		res = await axios.post(resolveVariable(introspection.url), data, opts);
 	} catch (e: any) {
-		console.log(`introspection failed, error: ${e.message}`);
+		console.log(
+			`introspection failed (url: ${introspection.url}, namespace: ${introspection.apiNamespace || ''}), error: ${
+				e.message
+			}`
+		);
 		process.exit(1);
 	}
 	if (res === undefined) {
-		console.log('introspection failed, no response');
+		console.log(
+			"introspection failed (url: ${introspection.url}, namespace: ${introspection.apiNamespace || ''}), no response"
+		);
 		process.exit(1);
 	}
 	if (res.status !== 200) {
-		console.log(`introspection failed, response code: ${res.status}, message: ${res.statusText}`);
+		console.log(
+			`introspection failed (url: ${introspection.url}, namespace: ${
+				introspection.apiNamespace || ''
+			}), response code: ${res.status}, message: ${res.statusText}`
+		);
 		process.exit(1);
 	}
 	return buildClientSchema(res.data.data);


### PR DESCRIPTION
This PR improves error messages when running `wunderctl up`.
Originally, we've just thrown an Error / Rejected Promise, which results in a very verbose error message where it's hard to find the real issue.

With this change, we'll catch the error, do a simple console.log of the error message and exit with code 1, stopping `wunderctl up` immediately. This gives a simple and clear error message.