### PR TITLE
fix: don't (re-)fetch user server & client-side when authentication is disabled

### DIFF
--- a/packages/nextjs-testapp/.wundergraph/operations/ProtectedWeather.graphql
+++ b/packages/nextjs-testapp/.wundergraph/operations/ProtectedWeather.graphql
@@ -1,25 +1,25 @@
-query ($forCity: String!) {
-  getCityByName: weather_getCityByName(name: $forCity) {
-    name
-    coord {
-      lat
-      lon
-    }
-    weather {
-      summary {
-        title
-        description
-        icon
-      }
-      temperature {
-        actual
-        min
-        max
-      }
-      wind {
-        speed
-        deg
-      }
-    }
-  }
+query ($forCity: String!) @rbac(requireMatchAll: [admin]) {
+	getCityByName: weather_getCityByName(name: $forCity) {
+		name
+		coord {
+			lat
+			lon
+		}
+		weather {
+			summary {
+				title
+				description
+				icon
+			}
+			temperature {
+				actual
+				min
+				max
+			}
+			wind {
+				speed
+				deg
+			}
+		}
+	}
 }

--- a/packages/nextjs-testapp/.wundergraph/wundergraph.config.ts
+++ b/packages/nextjs-testapp/.wundergraph/wundergraph.config.ts
@@ -142,7 +142,7 @@ configureWunderGraphApplication({
 	authentication: {
 		cookieBased: {
 			providers: [authProviders.demo()],
-			authorizedRedirectUris: ['http://localhost:3000/authentication'],
+			authorizedRedirectUris: ['http://localhost:3000/authentication', 'http://localhost:3003/auth-test'],
 		},
 	},
 	/*links: [

--- a/packages/nextjs-testapp/.wundergraph/wundergraph.config.ts
+++ b/packages/nextjs-testapp/.wundergraph/wundergraph.config.ts
@@ -137,7 +137,7 @@ configureWunderGraphApplication({
 	],
 	cors: {
 		...cors.allowAll,
-		allowedOrigins: process.env.NODE_ENV === 'production' ? ['http://localhost:3000'] : ['http://localhost:3000'],
+		allowedOrigins: ['http://localhost:3003'],
 	},
 	authentication: {
 		cookieBased: {

--- a/packages/nextjs-testapp/.wundergraph/wundergraph.server.ts
+++ b/packages/nextjs-testapp/.wundergraph/wundergraph.server.ts
@@ -17,26 +17,7 @@ const testEnum = new GraphQLEnumType({
 
 export default configureWunderGraphServer<HooksConfig, InternalClient>(() => ({
 	hooks: {
-		authentication: {
-			async revalidate(): Promise<AuthenticationResponse> {
-				return {
-					status: 'ok',
-					user: {
-						name: 'test',
-					},
-				};
-			},
-
-			async postAuthentication(hook) {},
-			async mutatingPostAuthentication(hook): Promise<AuthenticationResponse> {
-				return {
-					status: 'ok',
-					user: {
-						name: 'test',
-					},
-				};
-			},
-		},
+		authentication: {},
 		queries: {
 			FakeWeather: {
 				mockResolve: async (hook) => {

--- a/packages/nextjs-testapp/.wundergraph/wundergraph.server.ts
+++ b/packages/nextjs-testapp/.wundergraph/wundergraph.server.ts
@@ -17,7 +17,17 @@ const testEnum = new GraphQLEnumType({
 
 export default configureWunderGraphServer<HooksConfig, InternalClient>(() => ({
 	hooks: {
-		authentication: {},
+		authentication: {
+			mutatingPostAuthentication: async (hook) => {
+				return {
+					status: 'ok',
+					user: {
+						...hook.user,
+						roles: ['user', 'admin'],
+					},
+				};
+			},
+		},
 		queries: {
 			FakeWeather: {
 				mockResolve: async (hook) => {

--- a/packages/nextjs-testapp/package.json
+++ b/packages/nextjs-testapp/package.json
@@ -19,11 +19,11 @@
     "dev": "concurrently \"npm run nextDev\" \"npm run wundergraph\" \"npm run browser\"",
     "wundergraph": "cd .wundergraph && wunderctl up --debug",
     "generate": "cd .wundergraph && wunderctl generate",
-    "browser": "wait-on \"http-get://localhost:3000\" && wait-on \"http-get://localhost:9991\" && open-cli http://localhost:3000",
+    "browser": "wait-on \"http-get://localhost:3003\" && wait-on \"http-get://localhost:9991\" && open-cli http://localhost:3003",
     "build": "next build",
     "check": "tsc --noEmit",
-    "nextDev": "next dev",
-    "start": "next start",
+    "nextDev": "next dev --port 3003",
+    "start": "next start --port 3003",
     "wunderctl": "wunderctl"
   },
   "dependencies": {

--- a/packages/nextjs-testapp/pages/auth-test.tsx
+++ b/packages/nextjs-testapp/pages/auth-test.tsx
@@ -1,0 +1,18 @@
+import { AuthProvider, useWunderGraph, withWunderGraph } from '../components/generated/nextjs';
+
+const Page = () => {
+	const { user, login, logout } = useWunderGraph();
+	return (
+		<div>
+			<h1>Auth Test</h1>
+			<p>This is a test page for the auth component.</p>
+			<p>{'user: ' + JSON.stringify(user)}</p>
+			<br />
+			<button onClick={() => login(AuthProvider.github)}>Login</button>
+			<br />
+			<button onClick={() => logout()}>Logout</button>
+		</div>
+	);
+};
+
+export default withWunderGraph(Page);

--- a/packages/nextjs-testapp/pages/auth-test.tsx
+++ b/packages/nextjs-testapp/pages/auth-test.tsx
@@ -1,6 +1,11 @@
-import { AuthProvider, useWunderGraph, withWunderGraph } from '../components/generated/nextjs';
+import { AuthProvider, useQuery, useWunderGraph, withWunderGraph } from '../components/generated/nextjs';
 
 const Page = () => {
+	const weather = useQuery.ProtectedWeather({
+		input: {
+			forCity: 'Berlin',
+		},
+	});
 	const { user, login, logout } = useWunderGraph();
 	return (
 		<div>
@@ -11,6 +16,8 @@ const Page = () => {
 			<button onClick={() => login(AuthProvider.github)}>Login</button>
 			<br />
 			<button onClick={() => logout()}>Logout</button>
+			<br />
+			<p>{JSON.stringify(weather)}</p>
 		</div>
 	);
 };

--- a/packages/nextjs/src/handlebar.template.ts
+++ b/packages/nextjs/src/handlebar.template.ts
@@ -32,6 +32,7 @@ const defaultWunderGraphContextProperties: WunderGraphContextProperties<Role> = 
 			applicationPath: "{{applicationPath}}",
 			baseURL: "{{baseURL}}",
 			sdkVersion: "{{sdkVersion}}",
+    	authenticationEnabled: {{hasAuthProviders}},
     },
     user: null,
     setUser: value => {},

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -454,7 +454,7 @@ export class Client<Role> {
 		const query = this.queryString({
 			redirect_uri: redirectURI || window.location.toString(),
 		});
-		window.location.replace(`${this.baseURL}/${this.applicationPath}/auth/cookie/authorize/${authProviderID}${query}`);
+		window.location.assign(`${this.baseURL}/${this.applicationPath}/auth/cookie/authorize/${authProviderID}${query}`);
 	};
 
 	public logout = async (options?: LogoutOptions): Promise<boolean> => {


### PR DESCRIPTION
This PR improves the nextjs package.

When no authentication provider is configured (cookie based auth), there's no need to fetch the user server-side as well as client-side, incl. re-fetching. This PR disables all user fetches in this case.