### PR TITLE
fix: s3 upload client

### DIFF
--- a/.github/workflows/engine-ci.yaml
+++ b/.github/workflows/engine-ci.yaml
@@ -36,6 +36,15 @@ env:
 jobs:
   build_test:
     runs-on: ubuntu-latest
+    services:
+      minio:
+        image: minio/minio:edge-cicd
+        ports:
+          - 9000:9000
+        env:
+          MINIO_ROOT_USER: minio
+          MINIO_ROOT_PASSWORD: minio123
+        options: --name=minio --health-cmd "curl http://localhost:9000/minio/health/live"
     steps:
       - uses: actions/checkout@v3
         with:
@@ -55,6 +64,14 @@ jobs:
           version: '3.x'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - run: wget https://dl.min.io/client/mc/release/linux-amd64/mc
+      - run: chmod +x ./mc
+      - run: ./mc alias set minio http://127.0.0.1:9000 minio minio123
+      - run: ./mc admin user add minio test 12345678
+      - run: ./mc admin policy set minio readwrite user=test
+      - run: ./mc admin user info minio test
+      - run: ./mc mb --ignore-existing minio/uploads
+      - run: ./mc policy set public minio/uploads
       - run: pnpm install --ignore-scripts
       - run: make engine-dev
       - run: make test-go

--- a/.github/workflows/engine-ci.yaml
+++ b/.github/workflows/engine-ci.yaml
@@ -64,14 +64,7 @@ jobs:
           version: '3.x'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - run: wget https://dl.min.io/client/mc/release/linux-amd64/mc
-      - run: chmod +x ./mc
-      - run: ./mc alias set minio http://127.0.0.1:9000 minio minio123
-      - run: ./mc admin user add minio test 12345678
-      - run: ./mc admin policy set minio readwrite user=test
-      - run: ./mc admin user info minio test
-      - run: ./mc mb --ignore-existing minio/uploads
-      - run: ./mc policy set public minio/uploads
+      - run: make bootstrap-minio
       - run: pnpm install --ignore-scripts
       - run: make engine-dev
       - run: make test-go

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ out
 *.logs
 examples/**/*lock*
 /wunderctl
+scripts/mc
 
 # Logs
 logs

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ engine-dev: codegen
 check-setup:
 	$(shell ./scripts/check-setup.sh)
 
+bootstrap-minio:
+	./scripts/minio-setup.sh
+
 test-go:
 	go test ./...
 
@@ -56,4 +59,4 @@ update-examples:
 	cd examples && rm -rf simple && mkdir simple && cd simple && wunderctl init
 
 
-.PHONY: codegen build run tag install-proto format-templates dev all check-local docs wunderctl build-docs
+.PHONY: codegen build run tag install-proto format-templates dev all check-local docs wunderctl build-docs bootstrap-minio

--- a/pkg/s3uploadclient/helpers_test.go
+++ b/pkg/s3uploadclient/helpers_test.go
@@ -1,0 +1,56 @@
+package s3uploadclient_test
+
+import (
+	"bytes"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/wundergraph/wundergraph/pkg/s3uploadclient"
+	"github.com/wundergraph/wundergraph/pkg/s3uploadclient/testdata"
+)
+
+func initClient() *s3uploadclient.S3UploadClient {
+	client, err := s3uploadclient.NewS3UploadClient("127.0.0.1:9000", s3uploadclient.Options{
+		BucketName:      "uploads",
+		BucketLocation:  "eu-central-1",
+		AccessKeyID:     "test",
+		SecretAccessKey: "12345678",
+		UseSSL:          false,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return client
+}
+
+func prepareRequest() (*httptest.ResponseRecorder, *http.Request) {
+	// construct multipart form
+	var buff bytes.Buffer
+	w := multipart.NewWriter(&buff)
+
+	fw, err := w.CreateFormFile("files", "testdata.json")
+	if err != nil {
+		panic(err)
+	}
+
+	if _, err := io.Copy(fw, testdata.GetUploadData()); err != nil {
+		panic(err)
+	}
+
+	w.Close()
+
+	// prepare request
+	wr := httptest.NewRecorder()
+
+	req, err := http.NewRequest("POST", "http://localhost:3003", &buff)
+	if err != nil {
+		panic(err)
+	}
+
+	req.Header.Add("Content-Type", w.FormDataContentType())
+
+	return wr, req
+}

--- a/pkg/s3uploadclient/s3uploadclient_test.go
+++ b/pkg/s3uploadclient/s3uploadclient_test.go
@@ -7,7 +7,6 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -66,32 +65,16 @@ func initClient() *s3uploadclient.S3UploadClient {
 }
 
 func prepareRequest() (*httptest.ResponseRecorder, *http.Request) {
-	file, err := os.CreateTemp("", "testdata.*.json")
-	if err != nil {
-		panic(err)
-	}
-	defer os.Remove(file.Name())
-
-	_, err = io.Copy(file, bytes.NewReader([]byte(testData)))
-	if err != nil {
-		panic(err)
-	}
-
-	_, err = file.Seek(0, io.SeekStart)
-	if err != nil {
-		panic(err)
-	}
-
 	// construct multipart form
 	var buff bytes.Buffer
 	w := multipart.NewWriter(&buff)
 
-	fw, err := w.CreateFormFile("files", file.Name())
+	fw, err := w.CreateFormFile("files", "testdata.json")
 	if err != nil {
 		panic(err)
 	}
 
-	if _, err := io.Copy(fw, file); err != nil {
+	if _, err := io.Copy(fw, bytes.NewReader([]byte(testData))); err != nil {
 		panic(err)
 	}
 

--- a/pkg/s3uploadclient/s3uploadclient_test.go
+++ b/pkg/s3uploadclient/s3uploadclient_test.go
@@ -1,36 +1,13 @@
 package s3uploadclient_test
 
 import (
-	"bytes"
 	"encoding/json"
-	"io"
-	"mime/multipart"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wundergraph/wundergraph/pkg/s3uploadclient"
 )
-
-const testData = `
-{
-  "data": {
-    "__schema": {
-      "queryType": {
-        "name": "Query"
-      },
-      "mutationType": {
-        "name": "Mutation"
-      },
-      "subscriptionType": {
-        "name": "Subscription"
-      }
-    }
-  }
-}
-`
 
 func TestS3UploadClient_UploadFile(t *testing.T) {
 	client := initClient()
@@ -47,48 +24,4 @@ func TestS3UploadClient_UploadFile(t *testing.T) {
 
 	require.NotEmpty(t, resp)
 	assert.Equal(t, "cec8f2d4d95a43d0.json", resp[0].Key)
-}
-
-func initClient() *s3uploadclient.S3UploadClient {
-	client, err := s3uploadclient.NewS3UploadClient("127.0.0.1:9000", s3uploadclient.Options{
-		BucketName:      "uploads",
-		BucketLocation:  "eu-central-1",
-		AccessKeyID:     "test",
-		SecretAccessKey: "12345678",
-		UseSSL:          false,
-	})
-	if err != nil {
-		panic(err)
-	}
-
-	return client
-}
-
-func prepareRequest() (*httptest.ResponseRecorder, *http.Request) {
-	// construct multipart form
-	var buff bytes.Buffer
-	w := multipart.NewWriter(&buff)
-
-	fw, err := w.CreateFormFile("files", "testdata.json")
-	if err != nil {
-		panic(err)
-	}
-
-	if _, err := io.Copy(fw, bytes.NewReader([]byte(testData))); err != nil {
-		panic(err)
-	}
-
-	w.Close()
-
-	// prepare request
-	wr := httptest.NewRecorder()
-
-	req, err := http.NewRequest("POST", "http://localhost:3003", &buff)
-	if err != nil {
-		panic(err)
-	}
-
-	req.Header.Add("Content-Type", w.FormDataContentType())
-
-	return wr, req
 }

--- a/pkg/s3uploadclient/s3uploadclient_test.go
+++ b/pkg/s3uploadclient/s3uploadclient_test.go
@@ -1,0 +1,111 @@
+package s3uploadclient_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wundergraph/wundergraph/pkg/s3uploadclient"
+)
+
+const testData = `
+{
+  "data": {
+    "__schema": {
+      "queryType": {
+        "name": "Query"
+      },
+      "mutationType": {
+        "name": "Mutation"
+      },
+      "subscriptionType": {
+        "name": "Subscription"
+      }
+    }
+  }
+}
+`
+
+func TestS3UploadClient_UploadFile(t *testing.T) {
+	client := initClient()
+	w, r := prepareRequest()
+
+	client.UploadFile(w, r)
+
+	res := w.Result()
+	defer res.Body.Close()
+
+	resp := make([]s3uploadclient.UploadedFile, 0)
+	err := json.NewDecoder(res.Body).Decode(&resp)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, resp)
+	assert.Equal(t, "cec8f2d4d95a43d0.json", resp[0].Key)
+}
+
+func initClient() *s3uploadclient.S3UploadClient {
+	client, err := s3uploadclient.NewS3UploadClient("127.0.0.1:9000", s3uploadclient.Options{
+		BucketName:      "uploads",
+		BucketLocation:  "eu-central-1",
+		AccessKeyID:     "test",
+		SecretAccessKey: "12345678",
+		UseSSL:          false,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return client
+}
+
+func prepareRequest() (*httptest.ResponseRecorder, *http.Request) {
+	file, err := os.CreateTemp("", "testdata.*.json")
+	if err != nil {
+		panic(err)
+	}
+	defer os.Remove(file.Name())
+
+	_, err = io.Copy(file, bytes.NewReader([]byte(testData)))
+	if err != nil {
+		panic(err)
+	}
+
+	_, err = file.Seek(0, io.SeekStart)
+	if err != nil {
+		panic(err)
+	}
+
+	// construct multipart form
+	var buff bytes.Buffer
+	w := multipart.NewWriter(&buff)
+
+	fw, err := w.CreateFormFile("files", file.Name())
+	if err != nil {
+		panic(err)
+	}
+
+	if _, err := io.Copy(fw, file); err != nil {
+		panic(err)
+	}
+
+	w.Close()
+
+	// prepare request
+	wr := httptest.NewRecorder()
+
+	req, err := http.NewRequest("POST", "http://localhost:3003", &buff)
+	if err != nil {
+		panic(err)
+	}
+
+	req.Header.Add("Content-Type", w.FormDataContentType())
+
+	return wr, req
+}

--- a/pkg/s3uploadclient/testdata/testdata.go
+++ b/pkg/s3uploadclient/testdata/testdata.go
@@ -1,0 +1,28 @@
+package testdata
+
+import (
+	"bytes"
+	"io"
+)
+
+const testData = `
+{
+  "data": {
+    "__schema": {
+      "queryType": {
+        "name": "Query"
+      },
+      "mutationType": {
+        "name": "Mutation"
+      },
+      "subscriptionType": {
+        "name": "Subscription"
+      }
+    }
+  }
+}
+`
+
+func GetUploadData() io.Reader {
+	return bytes.NewReader([]byte(testData))
+}

--- a/scripts/minio-setup.sh
+++ b/scripts/minio-setup.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
 
-if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-	wget https://dl.min.io/client/mc/release/linux-amd64/mc -P scripts/
-elif [[ "$OSTYPE" == "darwin"* ]]; then
-	if [[ $(uname -p) == "arm" ]]; then
-		wget https://dl.min.io/client/mc/release/darwin-arm64/mc -P scripts/
-  elif [[ $(uname -p) == "i386" ]]; then  
-  	wget https://dl.min.io/client/mc/release/darwin-amd64/mc -P scripts/
-  fi
+set -e
+
+if ! [[ -x scripts/mc ]]; then
+	if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+		wget https://dl.min.io/client/mc/release/linux-amd64/mc -P scripts/
+	elif [[ "$OSTYPE" == "darwin"* ]]; then
+		if [[ $(uname -p) == "arm" ]]; then
+			wget https://dl.min.io/client/mc/release/darwin-arm64/mc -P scripts/
+		elif [[ $(uname -p) == "i386" ]]; then
+			wget https://dl.min.io/client/mc/release/darwin-amd64/mc -P scripts/
+		fi
+	fi
 fi
 
 chmod +x ./scripts/mc
@@ -17,5 +21,3 @@ chmod +x ./scripts/mc
 ./scripts/mc admin user info minio test
 ./scripts/mc mb --ignore-existing minio/uploads
 ./scripts/mc policy set public minio/uploads
-
-rm scripts/mc

--- a/scripts/minio-setup.sh
+++ b/scripts/minio-setup.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+	wget https://dl.min.io/client/mc/release/linux-amd64/mc -P scripts/
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+	if [[ $(uname -p) == "arm" ]]; then
+		wget https://dl.min.io/client/mc/release/darwin-arm64/mc -P scripts/
+  elif [[ $(uname -p) == "i386" ]]; then  
+  	wget https://dl.min.io/client/mc/release/darwin-amd64/mc -P scripts/
+  fi
+fi
+
+chmod +x ./scripts/mc
+./scripts/mc alias set minio http://127.0.0.1:9000 minio minio123
+./scripts/mc admin user add minio test 12345678
+./scripts/mc admin policy set minio readwrite user=test
+./scripts/mc admin user info minio test
+./scripts/mc mb --ignore-existing minio/uploads
+./scripts/mc policy set public minio/uploads
+
+rm scripts/mc


### PR DESCRIPTION
Bug description
------
 - It's impossible to upload small files, like the ssh public key in my case. 
 - It's impossible to upload files when the boundary prefix is followed by a double dash, space, tab, cr, nl, or end of input. 
 
In both these cases, EOF error returned within the response.  This is not correct, EOF should not be treated as an error in this case. 

There are a few issues with the existing implementation: 

```golang
contentTypeBuff := make([]byte, 512) // too much
_, err := part.Read(contentTypeBuff)
if err != nil {
        // io.EOF error should be handled  
	return nil, err
}
filetype := http.DetectContentType(contentTypeBuff) 
recycled := io.MultiReader(bytes.NewReader(contentTypeBuff), part)
```

```multipart.Part``` ```Read```  reads the body of a part, after its headers (!), and could return EOF.  Which is not handled, but if it would be handled like: ```if err != io.EOF { return nil, err }```  uploaded data could be corrupted (first case in bug description) because of preallocated bytes in ```contentTypeBuff```,  and it will not be possible to detect the correct content type. 

Solution
------

 - ```multipart.Part``` comes with prepopulated headers, in most cases, it should be enough to get content type.
 -  if we couldn't find the content type based on the file header, try based on the extension
 -  additionally, I removed the extra step with temp file creation, which makes upload a bit faster. 

TODO:
 - tests?
  

#### Checklist

- [x] run `make test`
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)

