### PR TITLE
fix(watcher): make webhooks and fragments directory optional

### DIFF
--- a/cli/commands/generate.go
+++ b/cli/commands/generate.go
@@ -88,7 +88,6 @@ Use this command if you only want to generate the configuration`,
 				EntryPoints:   []string{serverEntryPointFilename},
 				OutFile:       serverOutFile,
 				Logger:        log,
-				WatchPaths:    []string{},
 			})
 
 			onAfterBuild = func() {
@@ -127,7 +126,6 @@ Use this command if you only want to generate the configuration`,
 			EntryPoints:   []string{configEntryPointFilename},
 			OutFile:       configOutFile,
 			Logger:        log,
-			WatchPaths:    []string{},
 			IgnorePaths: []string{
 				"generated",
 				"node_modules",

--- a/cli/commands/up.go
+++ b/cli/commands/up.go
@@ -129,7 +129,9 @@ var upCmd = &cobra.Command{
 				AbsWorkingDir: entryPoints.WunderGraphDirAbs,
 				OutFile:       serverOutFile,
 				Logger:        log,
-				WatchPaths:    []string{configJsonPath},
+				WatchPaths: []*watcher.WatchPath{
+					{Path: configJsonPath},
+				},
 			})
 
 			if files.DirectoryExists(webhooksDir) {
@@ -227,15 +229,15 @@ var upCmd = &cobra.Command{
 			AbsWorkingDir: entryPoints.WunderGraphDirAbs,
 			OutFile:       configOutFile,
 			Logger:        log,
-			WatchPaths: []string{
-				path.Join(entryPoints.WunderGraphDirAbs, "operations"),
-				path.Join(entryPoints.WunderGraphDirAbs, "fragments"),
+			WatchPaths: []*watcher.WatchPath{
+				{Path: path.Join(entryPoints.WunderGraphDirAbs, "operations"), Optional: true},
+				{Path: path.Join(entryPoints.WunderGraphDirAbs, "fragments"), Optional: true},
 				// all webhook filenames are stored in the config
 				// we are going to create HTTP routes on the node for all of them
-				webhooksDir,
+				{Path: webhooksDir, Optional: true},
 				// a new cache entry is generated as soon as the introspection "poller" detects a change in the API dependencies
 				// in that case we want to rerun the script to build a new config
-				introspectionCacheDir,
+				{Path: introspectionCacheDir},
 			},
 			IgnorePaths: []string{
 				"node_modules",
@@ -250,8 +252,8 @@ var upCmd = &cobra.Command{
 
 		configFileChangeChan := make(chan struct{})
 		configWatcher := watcher.NewWatcher("config", &watcher.Config{
-			WatchPaths: []string{
-				configJsonPath,
+			WatchPaths: []*watcher.WatchPath{
+				{Path: configJsonPath},
 			},
 		}, log)
 

--- a/pkg/bundler/bundler.go
+++ b/pkg/bundler/bundler.go
@@ -22,7 +22,7 @@ type Bundler struct {
 	name                  string
 	entryPoints           []string
 	absWorkingDir         string
-	watchPaths            []string
+	watchPaths            []*watcher.WatchPath
 	ignorePaths           []string
 	log                   abstractlogger.Logger
 	skipWatchOnEntryPoint bool
@@ -41,7 +41,7 @@ type Config struct {
 	AbsWorkingDir         string
 	SkipWatchOnEntryPoint bool
 	EntryPoints           []string
-	WatchPaths            []string
+	WatchPaths            []*watcher.WatchPath
 	IgnorePaths           []string
 	OutFile               string
 	OutDir                string
@@ -105,7 +105,7 @@ func (b *Bundler) Watch(ctx context.Context) {
 			abstractlogger.String("bundlerName", b.name),
 			abstractlogger.String("outFile", b.outFile),
 			abstractlogger.Strings("externalImports", b.externalImports),
-			abstractlogger.Strings("watchPaths", b.watchPaths),
+			abstractlogger.Any("watchPaths", b.watchPaths),
 			abstractlogger.Strings("fileLoaders", b.fileLoaders),
 		)
 		b.watch(ctx, b.buildResult.Rebuild)
@@ -175,7 +175,7 @@ func (b *Bundler) initialBuild() api.BuildResult {
 			// check if the path already exist
 			exists := false
 			for _, watchPath := range b.watchPaths {
-				if watchPath == file {
+				if watchPath.Path == file {
 					exists = true
 					break
 				}
@@ -185,7 +185,7 @@ func (b *Bundler) initialBuild() api.BuildResult {
 					// each plugin runs on a separate go routine
 					b.mu.Lock()
 					defer b.mu.Unlock()
-					b.watchPaths = append(b.watchPaths, file)
+					b.watchPaths = append(b.watchPaths, &watcher.WatchPath{Path: file})
 				} else {
 					b.log.Error("Bundler watching limit exceeded", abstractlogger.String("bundlerName", b.name), abstractlogger.Int("limit", watchFileLimit), abstractlogger.Error(err))
 				}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `make test`
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)

<!--
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

Fix #138 