### PR TITLE
feat: add dev mode so that cookie secrets stay static

### DIFF
--- a/cli/commands/up.go
+++ b/cli/commands/up.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"context"
 	"fmt"
-	"github.com/wundergraph/wundergraph/pkg/webhooks"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -11,6 +10,8 @@ import (
 	"runtime"
 	"sync"
 	"syscall"
+
+	"github.com/wundergraph/wundergraph/pkg/webhooks"
 
 	"github.com/jensneuse/abstractlogger"
 	"github.com/spf13/cobra"
@@ -300,6 +301,7 @@ var upCmd = &cobra.Command{
 				node.WithHooksSecret(secret),
 				node.WithIntrospection(true),
 				node.WithGitHubAuthDemo(GitHubAuthDemo),
+				node.WithDevMode(),
 			)
 			if err != nil {
 				log.Fatal("startBlocking", abstractlogger.Error(err))

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -90,6 +90,7 @@ type options struct {
 	insecureCookies         bool
 	hooksSecret             []byte
 	githubAuthDemo          GitHubAuthDemo
+	devMode                 bool
 }
 
 type Option func(options *options)
@@ -103,6 +104,15 @@ func WithStaticWunderNodeConfig(config wgpb.WunderNodeConfig) Option {
 func WithGitHubAuthDemo(authDemo GitHubAuthDemo) Option {
 	return func(options *options) {
 		options.githubAuthDemo = authDemo
+	}
+}
+
+// WithDevMode will set cookie secrets to a static, insecure, string
+// This way, you stay logged in during development
+// Should never be used in production
+func WithDevMode() Option {
+	return func(options *options) {
+		options.devMode = true
 	}
 }
 
@@ -335,6 +345,7 @@ func (n *Node) startServer(nodeConfig wgpb.WunderNodeConfig) {
 			GitHubAuthDemoClientID:     n.options.githubAuthDemo.ClientID,
 			GitHubAuthDemoClientSecret: n.options.githubAuthDemo.ClientSecret,
 			HookServerURL:              api.HooksServerURL,
+			DevMode:                    n.options.devMode,
 		}
 
 		builder := apihandler.NewBuilder(n.pool, n.log, loader, hooksClient, builderConfig)


### PR DESCRIPTION
This allows you to run `wunderctl up` and never get logged out of the application during development.