### PR TITLE
fix: use node url in graphiql apiUrl

### DIFF
--- a/pkg/apihandler/api.go
+++ b/pkg/apihandler/api.go
@@ -15,6 +15,7 @@ type Logging struct {
 
 type Options struct {
 	ServerUrl string
+	NodeUrl   string
 	Listener  *Listener
 	Logging   Logging
 }

--- a/pkg/apihandler/apihandler.go
+++ b/pkg/apihandler/apihandler.go
@@ -297,6 +297,7 @@ func (r *Builder) BuildAndMountApiHandler(ctx context.Context, router *mux.Route
 			log:           r.log,
 			html:          graphiql.GetGraphiqlPlaygroundHTML(),
 			apiPathPrefix: api.PathPrefix,
+			nodeUrl:       api.Options.NodeUrl,
 		}
 		r.router.Methods(http.MethodGet, http.MethodOptions).Path(apiPath).Handler(graphqlPlaygroundHandler)
 		r.log.Debug("registered GraphQLPlaygroundHandler",
@@ -632,17 +633,12 @@ func (r *Builder) configureCache(api *Api) (err error) {
 type GraphQLPlaygroundHandler struct {
 	log           abstractlogger.Logger
 	html          string
+	nodeUrl       string
 	apiPathPrefix string
 }
 
 func (h *GraphQLPlaygroundHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-
-	protocol := "http"
-	if r.TLS != nil {
-		protocol = "https"
-	}
-
-	apiURL := protocol + "://" + path.Join(r.Host, h.apiPathPrefix)
+	apiURL := fmt.Sprintf("%s/%s", strings.TrimSuffix(h.nodeUrl, "/"), strings.TrimPrefix(h.apiPathPrefix, "/"))
 
 	tpl := strings.Replace(h.html, "{{apiURL}}", apiURL, 1)
 	resp := []byte(tpl)

--- a/pkg/node/config.go
+++ b/pkg/node/config.go
@@ -52,6 +52,7 @@ func CreateConfig(graphConfig *wgpb.WunderGraphConfiguration) WunderNodeConfig {
 			Webhooks:             graphConfig.Api.Webhooks,
 			Options: &apihandler.Options{
 				ServerUrl: loadvariable.String(graphConfig.Api.ServerOptions.ServerUrl),
+				NodeUrl:   loadvariable.String(graphConfig.Api.NodeOptions.NodeUrl),
 				Listener:  listener,
 				Logging: apihandler.Logging{
 					Level: logLevel,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `make test`
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)

<!--
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->
