### PR TITLE
fix: avoid logging file contents during uploads (#201)

### DIFF
--- a/packages/sdk/src/client/client.ts
+++ b/packages/sdk/src/client/client.ts
@@ -307,6 +307,9 @@ export class Client {
 	 * of file IDs that can be used to download the files from your S3 bucket.
 	 */
 	public async uploadFiles(config: UploadRequestOptions): Promise<UploadResponse> {
+		// XXX: apihandler.go uses the Content-Type header to detect file uploads
+		// and omit them from the logging messages. Any changes to the upload
+		// mechanism should also update apihandler.go accordingly.
 		const formData = new FormData();
 		for (const [_, file] of Object.entries(config.files)) {
 			if (file instanceof Blob) {

--- a/packages/sdk/src/client/client.ts
+++ b/packages/sdk/src/client/client.ts
@@ -307,9 +307,6 @@ export class Client {
 	 * of file IDs that can be used to download the files from your S3 bucket.
 	 */
 	public async uploadFiles(config: UploadRequestOptions): Promise<UploadResponse> {
-		// XXX: apihandler.go uses the Content-Type header to detect file uploads
-		// and omit them from the logging messages. Any changes to the upload
-		// mechanism should also update apihandler.go accordingly.
 		const formData = new FormData();
 		for (const [_, file] of Object.entries(config.files)) {
 			if (file instanceof Blob) {

--- a/pkg/apihandler/apihandler.go
+++ b/pkg/apihandler/apihandler.go
@@ -306,6 +306,7 @@ func shouldLogRequestBody(request *http.Request) bool {
 	return !strings.HasPrefix(request.Header.Get("Content-Type"), "multipart/")
 }
 
+// returns a middleware that logs all requests to the given io.Writer
 func logRequestMiddleware(logger io.Writer) mux.MiddlewareFunc {
 	return func(handler http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {

--- a/pkg/apihandler/apihandler.go
+++ b/pkg/apihandler/apihandler.go
@@ -203,27 +203,9 @@ func (r *Builder) BuildAndMountApiHandler(ctx context.Context, router *mux.Route
 		})
 	}
 
-	r.router.Use(func(handler http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
-			if r.enableDebugMode {
-				// If the request looks like a file upload, avoid printing the whole
-				// encoded file as a debug message.
-				// File upload is handled in packages/sdk/client.ts, make sure to keep both in sync.
-				isMultipart := strings.HasPrefix(request.Header.Get("Content-Type"), "multipart/")
-				suffix := ""
-				if isMultipart {
-					suffix = "<multipart content omitted>"
-				}
-				requestDump, err := httputil.DumpRequest(request, !isMultipart)
-				if err == nil {
-					fmt.Printf("\n\n--- ClientRequest start ---\n\n%s%s\n\n\n\n--- ClientRequest end ---\n\n",
-						string(requestDump), suffix,
-					)
-				}
-			}
-			handler.ServeHTTP(w, request)
-		})
-	})
+	if r.enableDebugMode {
+		r.router.Use(logRequestMiddleware(os.Stderr))
+	}
 
 	if api.CorsConfiguration != nil {
 		corsMiddleware := cors.New(cors.Options{
@@ -316,6 +298,31 @@ func (r *Builder) BuildAndMountApiHandler(ctx context.Context, router *mux.Route
 	}
 
 	return streamClosers, err
+}
+
+func shouldLogRequestBody(request *http.Request) bool {
+	// If the request looks like a file upload, avoid printing the whole
+	// encoded file as a debug message.
+	return !strings.HasPrefix(request.Header.Get("Content-Type"), "multipart/")
+}
+
+func logRequestMiddleware(logger io.Writer) mux.MiddlewareFunc {
+	return func(handler http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+			logBody := shouldLogRequestBody(request)
+			suffix := ""
+			if !logBody {
+				suffix = "<body omitted>"
+			}
+			requestDump, err := httputil.DumpRequest(request, logBody)
+			if err == nil {
+				fmt.Fprintf(logger, "\n\n--- ClientRequest start ---\n\n%s%s\n\n\n\n--- ClientRequest end ---\n\n",
+					string(requestDump), suffix,
+				)
+			}
+			handler.ServeHTTP(w, request)
+		})
+	}
 }
 
 func mergeRequiredFields(fields plan.FieldConfigurations, fieldsRequired plan.FieldConfigurations) plan.FieldConfigurations {

--- a/pkg/apihandler/apihandler.go
+++ b/pkg/apihandler/apihandler.go
@@ -303,7 +303,7 @@ func (r *Builder) BuildAndMountApiHandler(ctx context.Context, router *mux.Route
 func shouldLogRequestBody(request *http.Request) bool {
 	// If the request looks like a file upload, avoid printing the whole
 	// encoded file as a debug message.
-	return !strings.HasPrefix(request.Header.Get("Content-Type"), "multipart/")
+	return !strings.HasPrefix(request.Header.Get("Content-Type"), "multipart/form-data")
 }
 
 // returns a middleware that logs all requests to the given io.Writer

--- a/pkg/apihandler/apihandler_test.go
+++ b/pkg/apihandler/apihandler_test.go
@@ -1,9 +1,11 @@
 package apihandler
 
 import (
+	"bytes"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -13,13 +15,13 @@ import (
 	"github.com/wundergraph/graphql-go-tools/pkg/engine/plan"
 	"github.com/wundergraph/graphql-go-tools/pkg/engine/resolve"
 
+	"github.com/wundergraph/wundergraph/pkg/apicache"
 	"github.com/wundergraph/wundergraph/pkg/authentication"
 	"github.com/wundergraph/wundergraph/pkg/inputvariables"
 	"github.com/wundergraph/wundergraph/pkg/interpolate"
+	"github.com/wundergraph/wundergraph/pkg/pool"
 	"github.com/wundergraph/wundergraph/pkg/postresolvetransform"
 	"github.com/wundergraph/wundergraph/pkg/wgpb"
-	"github.com/wundergraph/wundergraph/pkg/apicache"
-	"github.com/wundergraph/wundergraph/pkg/pool"
 )
 
 type FakeResolver struct {
@@ -263,4 +265,37 @@ func TestQueryHandler_Caching(t *testing.T) {
 	res.Body().Empty()
 
 	assert.Equal(t, 2, resolver.invocations)
+}
+
+func TestLogMiddleware_Debug(t *testing.T) {
+	const (
+		testFileContents     = "this_should_be_omitted"
+		testFormContents     = "this_should_be_logged"
+		responseBodyContents = "hello"
+	)
+	var buf bytes.Buffer
+	middleware := logRequestMiddleware(&buf)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, responseBodyContents)
+	})
+
+	srv := httptest.NewServer(middleware(handler))
+	defer srv.Close()
+
+	e := httpexpect.WithConfig(httpexpect.Config{
+		BaseURL:  srv.URL,
+		Reporter: httpexpect.NewAssertReporter(t),
+	})
+
+	e.POST("/").WithMultipart().WithFileBytes("file", "file.txt", []byte(testFileContents)).Expect().Body().Contains(responseBodyContents)
+	if strings.Contains(buf.String(), testFileContents) {
+		t.Error("log message contains file")
+	}
+	buf.Reset()
+
+	e.POST("/").WithForm(map[string]string{"value": testFormContents}).Expect().Body().Contains(responseBodyContents)
+	if !strings.Contains(buf.String(), testFormContents) {
+		t.Error("log message does not contain form field")
+	}
 }


### PR DESCRIPTION
If the request is multipart, don't log the body contents. This doesn't prevent logging the file in absolutely all cases (e.g. a PUT with the contents as the body), but it will omit the messages as long as the upload comes from the WunderGraph SDK. Added notes in both places to make sure they're kept in sync.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `make test`
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x ] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)
