### PR TITLE
fix: generate outfile directory should be consistent

### DIFF
--- a/cli/commands/generate.go
+++ b/cli/commands/generate.go
@@ -40,7 +40,7 @@ Use this command if you only want to generate the configuration`,
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 		defer cancel()
 
-		configOutFile := path.Join("generated", "bundle", "config.js")
+		configOutFile := path.Join(WunderGraphDir, "generated", "bundle", "config.js")
 
 		configRunner := scriptrunner.NewScriptRunner(&scriptrunner.Config{
 			Name:          "config-runner",
@@ -71,7 +71,7 @@ Use this command if you only want to generate the configuration`,
 
 		if codeServerFilePath != "" {
 			serverOutFile := path.Join(WunderGraphDir, "generated", "bundle", "server.js")
-			webhooksOutDir := path.Join("generated", "bundle", "webhooks")
+			webhooksOutDir := path.Join(WunderGraphDir, "generated", "bundle", "webhooks")
 			webhooksDir := path.Join(WunderGraphDir, webhooks.WebhookDirectoryName)
 
 			var webhooksBundler *bundler.Bundler


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

The generated output files should all be written to a consistent `generated` directory.

#### Checklist

- [x] run `make test`
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)

<!--
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->
