### PR TITLE
fix: introspection, infinite loop in file changes

### DIFF
--- a/packages/sdk/src/definition/__snapshots__/index.test.ts.snap
+++ b/packages/sdk/src/definition/__snapshots__/index.test.ts.snap
@@ -7,20 +7,20 @@ GraphQLApi {
       "ChildNodes": [
         {
           "fieldNames": [
-            "id",
             "displayName",
+            "hasVerifiedEmail",
+            "id",
             "isLoggedIn",
           ],
-          "typeName": "api_User",
+          "typeName": "api_RegisteredUser",
         },
         {
           "fieldNames": [
-            "id",
             "displayName",
+            "id",
             "isLoggedIn",
-            "hasVerifiedEmail",
           ],
-          "typeName": "api_RegisteredUser",
+          "typeName": "api_User",
         },
       ],
       "Custom": {
@@ -79,17 +79,17 @@ GraphQLApi {
   user: User
 }
 
-interface User {
-  id: ID!
+type RegisteredUser implements User {
   displayName: String!
+  hasVerifiedEmail: Boolean!
+  id: ID!
   isLoggedIn: Boolean!
 }
 
-type RegisteredUser implements User {
-  id: ID!
+interface User {
   displayName: String!
+  id: ID!
   isLoggedIn: Boolean!
-  hasVerifiedEmail: Boolean!
 }",
       },
       "Directives": [],
@@ -122,26 +122,26 @@ type RegisteredUser implements User {
   api_user: api_User
 }
 
-interface api_User {
-  id: ID!
+type api_RegisteredUser implements api_User {
   displayName: String!
+  hasVerifiedEmail: Boolean!
+  id: ID!
   isLoggedIn: Boolean!
 }
 
-type api_RegisteredUser implements api_User {
-  id: ID!
+interface api_User {
   displayName: String!
+  id: ID!
   isLoggedIn: Boolean!
-  hasVerifiedEmail: Boolean!
 }",
   "Types": [
     {
-      "renameTo": "User",
-      "typeName": "api_User",
-    },
-    {
       "renameTo": "RegisteredUser",
       "typeName": "api_RegisteredUser",
+    },
+    {
+      "renameTo": "User",
+      "typeName": "api_User",
     },
   ],
   "interpolateVariableDefinitionAsJSON": [],

--- a/packages/sdk/src/definition/graphql-introspection.ts
+++ b/packages/sdk/src/definition/graphql-introspection.ts
@@ -1,6 +1,13 @@
 import { fetchFederationServiceSDL, isFederationService } from './federation-introspection';
 import { configuration } from '../graphql/configuration';
-import { buildClientSchema, buildSchema, getIntrospectionQuery, GraphQLSchema, parse } from 'graphql';
+import {
+	buildClientSchema,
+	buildSchema,
+	getIntrospectionQuery,
+	GraphQLSchema,
+	parse,
+	lexicographicSortSchema,
+} from 'graphql';
 import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
 import { ConfigurationVariableKind, DataSourceKind, HTTPHeader, HTTPMethod } from '@wundergraph/protobuf';
 import { cleanupSchema } from '../graphql/schema';
@@ -62,7 +69,8 @@ export const introspectGraphql = async (introspection: GraphQLIntrospection): Pr
 		const headers = mapHeaders(headersBuilder);
 		const introspectionHeaders = resolveGraphqlIntrospectionHeaders(mapHeaders(introspectionHeadersBuilder));
 
-		const schema = await introspectGraphQLSchema(introspection, introspectionHeaders);
+		let schema = await introspectGraphQLSchema(introspection, introspectionHeaders);
+		schema = lexicographicSortSchema(schema);
 		const federationEnabled = isFederationService(schema);
 		const schemaSDL = cleanupSchema(
 			schema,


### PR DESCRIPTION

#### Checklist

- [ ] run `make test`
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)

When we add a datasource that creates non-deterministic introspection results when the same data is in a different order. 
As a result, the introspection cache is always 'uniq' which causes infinite `watcher` calls . 
