### PR TITLE
feat: refactor cache handling, move storage out of generated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# WunderGraph
+**/.wundergraph/cache/

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,7 +5,8 @@ pnpm-lock.yaml
 *lock.json
 
 # WunderGraph
-generated
+**/.wundergraph/cache
+**/.wundergraph/generated
 
 # Next.js build output
 .next

--- a/cli/commands/generate.go
+++ b/cli/commands/generate.go
@@ -19,6 +19,7 @@ import (
 
 var (
 	generateAndPublish bool
+	cacheFallback      bool
 )
 
 // generateCmd represents the generate command
@@ -57,6 +58,8 @@ Use this command if you only want to generate the configuration`,
 				// Run scripts in prod mode
 				"NODE_ENV=production",
 				fmt.Sprintf("WUNDERGRAPH_PUBLISH_API=%t", generateAndPublish),
+				fmt.Sprintf("WG_ENABLE_INTROSPECTION_CACHE=%t", !disableCache),
+				fmt.Sprintf("WG_USE_INTROSPECTION_CACHE_EXCLUSIVELY=%t", !cacheFallback),
 				fmt.Sprintf("WG_DIR_ABS=%s", wunderGraphDir),
 			),
 		})
@@ -172,5 +175,6 @@ Use this command if you only want to generate the configuration`,
 
 func init() {
 	generateCmd.Flags().BoolVarP(&generateAndPublish, "publish", "p", false, "publish the generated API immediately")
+	generateCmd.Flags().BoolVar(&cacheFallback, "cache-fallback", false, "fallback to introspection if cache fails")
 	rootCmd.AddCommand(generateCmd)
 }

--- a/cli/commands/generate.go
+++ b/cli/commands/generate.go
@@ -19,7 +19,7 @@ import (
 
 var (
 	generateAndPublish bool
-	cacheFallback      bool
+	offline            bool
 )
 
 // generateCmd represents the generate command
@@ -59,7 +59,7 @@ Use this command if you only want to generate the configuration`,
 				"NODE_ENV=production",
 				fmt.Sprintf("WUNDERGRAPH_PUBLISH_API=%t", generateAndPublish),
 				fmt.Sprintf("WG_ENABLE_INTROSPECTION_CACHE=%t", !disableCache),
-				fmt.Sprintf("WG_USE_INTROSPECTION_CACHE_EXCLUSIVELY=%t", !cacheFallback),
+				fmt.Sprintf("WG_ENABLE_INTROSPECTION_OFFLINE=%t", offline),
 				fmt.Sprintf("WG_DIR_ABS=%s", wunderGraphDir),
 			),
 		})
@@ -175,6 +175,6 @@ Use this command if you only want to generate the configuration`,
 
 func init() {
 	generateCmd.Flags().BoolVarP(&generateAndPublish, "publish", "p", false, "publish the generated API immediately")
-	generateCmd.Flags().BoolVar(&cacheFallback, "cache-fallback", false, "fallback to introspection if cache fails")
+	generateCmd.Flags().BoolVar(&offline, "offline", false, "offline mode, return an error instead of hitting the network")
 	rootCmd.AddCommand(generateCmd)
 }

--- a/cli/commands/generate.go
+++ b/cli/commands/generate.go
@@ -178,6 +178,6 @@ var generateCmd = &cobra.Command{
 
 func init() {
 	generateCmd.Flags().BoolVarP(&generateAndPublish, "publish", "p", false, "publish the generated API immediately")
-	generateCmd.Flags().BoolVar(&offline, "offline", false, "offline mode, return an error instead of hitting the network")
+	generateCmd.Flags().BoolVar(&offline, "offline", false, "disables loading resources from the network")
 	rootCmd.AddCommand(generateCmd)
 }

--- a/cli/commands/generate.go
+++ b/cli/commands/generate.go
@@ -25,9 +25,12 @@ var (
 // generateCmd represents the generate command
 var generateCmd = &cobra.Command{
 	Use:   "generate",
-	Short: "Runs the code generation process once",
-	Long: `In contrast to wunderctl up, it only generates all files in ./generated but doesn't start WunderGraph or the hooks.
-Use this command if you only want to generate the configuration`,
+	Short: "Generate the production config",
+	Long: `Generate the production config to start the node and hook component
+ with 'wunderctl start' or individually with 'wunderctl node start', 'wunderctl
+ server start'. All files are stored to .wundergraph/generated. The local
+ introspection cache has precedence. You can overwrite this behavior by passing
+ --no-cache to the command`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		wunderGraphDir, err := files.FindWunderGraphDir(_wunderGraphDirConfig)
 		if err != nil {

--- a/cli/commands/generate.go
+++ b/cli/commands/generate.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"time"
 
 	"github.com/jensneuse/abstractlogger"
 	"github.com/spf13/cobra"
@@ -45,8 +44,7 @@ var generateCmd = &cobra.Command{
 		// optional, no error check
 		codeServerFilePath, _ := files.CodeFilePath(wunderGraphDir, serverEntryPointFilename)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-		defer cancel()
+		ctx := context.Background()
 
 		configOutFile := path.Join("generated", "bundle", "config.js")
 

--- a/cli/commands/root.go
+++ b/cli/commands/root.go
@@ -145,7 +145,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&enableDebugMode, "debug", false, "enables the debug mode so that all requests and responses will be logged")
 	rootCmd.PersistentFlags().BoolVar(&jsonEncodedLogging, "json-encoded-logging", false, "switches the logging to json encoded logging")
 	rootCmd.PersistentFlags().StringVar(&_wunderGraphDirConfig, "wundergraph-dir", files.WunderGraphDirName, "path to your .wundergraph directory")
-	rootCmd.PersistentFlags().BoolVar(&disableCache, "no-cache", false, "Disable cache")
+	rootCmd.PersistentFlags().BoolVar(&disableCache, "no-cache", false, "disables local caches")
 }
 
 func buildLogger(level abstractlogger.Level) abstractlogger.Logger {

--- a/cli/commands/root.go
+++ b/cli/commands/root.go
@@ -145,7 +145,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&enableDebugMode, "debug", false, "enables the debug mode so that all requests and responses will be logged")
 	rootCmd.PersistentFlags().BoolVar(&jsonEncodedLogging, "json-encoded-logging", false, "switches the logging to json encoded logging")
 	rootCmd.PersistentFlags().StringVar(&_wunderGraphDirConfig, "wundergraph-dir", files.WunderGraphDirName, "path to your .wundergraph directory")
-	rootCmd.PersistentFlags().BoolVar(&disableCache, "no-cache", false, "Enable cache")
+	rootCmd.PersistentFlags().BoolVar(&disableCache, "no-cache", false, "Disable cache")
 }
 
 func buildLogger(level abstractlogger.Level) abstractlogger.Logger {

--- a/cli/commands/root.go
+++ b/cli/commands/root.go
@@ -1,10 +1,12 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"net/http"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/fatih/color"
@@ -39,6 +41,7 @@ var (
 	serviceToken          string
 	_wunderGraphDirConfig string
 	disableCache          bool
+	clearCache            bool
 
 	red    = color.New(color.FgHiRed)
 	green  = color.New(color.FgHiGreen)
@@ -71,16 +74,27 @@ You can opt out of this by setting the following environment variable: WUNDERGRA
 		if err != nil {
 			if _, ok := err.(*fs.PathError); ok {
 				log.Debug("starting without env file")
-				return nil
+			} else {
+				log.Fatal("error loading env file",
+					abstractlogger.Error(err))
 			}
-			log.Fatal("error loading env file",
-				abstractlogger.Error(err),
-			)
 		} else {
 			log.Debug("env file successfully loaded",
 				abstractlogger.String("file", DotEnvFile),
 			)
 		}
+
+		if clearCache {
+			wunderGraphDir, err := files.FindWunderGraphDir(_wunderGraphDirConfig)
+			if err != nil {
+				return err
+			}
+			cacheDir := filepath.Join(wunderGraphDir, "cache")
+			if err := os.RemoveAll(cacheDir); err != nil && !errors.Is(err, os.ErrNotExist) {
+				return err
+			}
+		}
+
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -146,6 +160,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&jsonEncodedLogging, "json-encoded-logging", false, "switches the logging to json encoded logging")
 	rootCmd.PersistentFlags().StringVar(&_wunderGraphDirConfig, "wundergraph-dir", files.WunderGraphDirName, "path to your .wundergraph directory")
 	rootCmd.PersistentFlags().BoolVar(&disableCache, "no-cache", false, "disables local caches")
+	rootCmd.PersistentFlags().BoolVar(&clearCache, "clear-cache", false, "clears local caches during startup")
 }
 
 func buildLogger(level abstractlogger.Level) abstractlogger.Logger {

--- a/cli/commands/root.go
+++ b/cli/commands/root.go
@@ -38,7 +38,7 @@ var (
 	jsonEncodedLogging    bool
 	serviceToken          string
 	_wunderGraphDirConfig string
-	enableCache           bool
+	disableCache          bool
 
 	red    = color.New(color.FgHiRed)
 	green  = color.New(color.FgHiGreen)
@@ -65,12 +65,6 @@ You can opt out of this by setting the following environment variable: WUNDERGRA
 			log = buildLogger(abstractlogger.DebugLevel)
 		} else {
 			log = buildLogger(findLogLevel(abstractlogger.ErrorLevel))
-		}
-
-		if enableCache {
-			if err := os.Setenv("WG_ENABLE_INTROSPECTION_CACHE", "true"); err != nil {
-				return err
-			}
 		}
 
 		err := godotenv.Load(DotEnvFile)
@@ -151,7 +145,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&enableDebugMode, "debug", false, "enables the debug mode so that all requests and responses will be logged")
 	rootCmd.PersistentFlags().BoolVar(&jsonEncodedLogging, "json-encoded-logging", false, "switches the logging to json encoded logging")
 	rootCmd.PersistentFlags().StringVar(&_wunderGraphDirConfig, "wundergraph-dir", files.WunderGraphDirName, "path to your .wundergraph directory")
-	rootCmd.PersistentFlags().BoolVar(&enableCache, "cache", false, "Enable cache")
+	rootCmd.PersistentFlags().BoolVar(&disableCache, "no-cache", false, "Enable cache")
 }
 
 func buildLogger(level abstractlogger.Level) abstractlogger.Logger {

--- a/cli/commands/root.go
+++ b/cli/commands/root.go
@@ -38,6 +38,7 @@ var (
 	jsonEncodedLogging    bool
 	serviceToken          string
 	_wunderGraphDirConfig string
+	enableCache           bool
 
 	red    = color.New(color.FgHiRed)
 	green  = color.New(color.FgHiGreen)
@@ -64,6 +65,12 @@ You can opt out of this by setting the following environment variable: WUNDERGRA
 			log = buildLogger(abstractlogger.DebugLevel)
 		} else {
 			log = buildLogger(findLogLevel(abstractlogger.ErrorLevel))
+		}
+
+		if enableCache {
+			if err := os.Setenv("WG_ENABLE_INTROSPECTION_CACHE", "true"); err != nil {
+				return err
+			}
 		}
 
 		err := godotenv.Load(DotEnvFile)
@@ -144,6 +151,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&enableDebugMode, "debug", false, "enables the debug mode so that all requests and responses will be logged")
 	rootCmd.PersistentFlags().BoolVar(&jsonEncodedLogging, "json-encoded-logging", false, "switches the logging to json encoded logging")
 	rootCmd.PersistentFlags().StringVar(&_wunderGraphDirConfig, "wundergraph-dir", files.WunderGraphDirName, "path to your .wundergraph directory")
+	rootCmd.PersistentFlags().BoolVar(&enableCache, "cache", false, "Enable cache")
 }
 
 func buildLogger(level abstractlogger.Level) abstractlogger.Logger {

--- a/cli/commands/up.go
+++ b/cli/commands/up.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -20,10 +19,6 @@ import (
 	"github.com/wundergraph/wundergraph/pkg/scriptrunner"
 	"github.com/wundergraph/wundergraph/pkg/watcher"
 	"github.com/wundergraph/wundergraph/pkg/webhooks"
-)
-
-var (
-	keepIntrospectionCache bool
 )
 
 // upCmd represents the up command
@@ -64,11 +59,6 @@ var upCmd = &cobra.Command{
 		)
 
 		introspectionCacheDir := path.Join(wunderGraphDir, "cache", "introspection")
-		if !keepIntrospectionCache {
-			if err := os.RemoveAll(introspectionCacheDir); err != nil && !errors.Is(err, os.ErrNotExist) {
-				return err
-			}
-		}
 
 		configJsonPath := path.Join(wunderGraphDir, "generated", configJsonFilename)
 		webhooksDir := path.Join(wunderGraphDir, webhooks.WebhookDirectoryName)
@@ -284,5 +274,4 @@ var upCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(upCmd)
-	upCmd.Flags().BoolVar(&keepIntrospectionCache, "keep-introspection-cache", false, "avoid clearing the introspection cache on startup")
 }

--- a/cli/commands/up.go
+++ b/cli/commands/up.go
@@ -62,7 +62,7 @@ var upCmd = &cobra.Command{
 			abstractlogger.String("builtBy", BuildInfo.BuiltBy),
 		)
 
-		introspectionCacheDir := path.Join(wunderGraphDir, "generated", "introspection", "cache")
+		introspectionCacheDir := path.Join(wunderGraphDir, "introspection", "cache")
 		_, errIntrospectionDir := os.Stat(introspectionCacheDir)
 		if errIntrospectionDir == nil {
 			if clearIntrospectionCache {

--- a/cli/commands/up.go
+++ b/cli/commands/up.go
@@ -9,7 +9,6 @@ import (
 	"path"
 	"sync"
 	"syscall"
-	"time"
 
 	"github.com/jensneuse/abstractlogger"
 	"github.com/spf13/cobra"
@@ -24,8 +23,7 @@ import (
 )
 
 var (
-	keepIntrospectionCache          bool
-	introspectionCacheClearInterval int
+	keepIntrospectionCache bool
 )
 
 // upCmd represents the up command
@@ -70,16 +68,6 @@ var upCmd = &cobra.Command{
 			if err := os.RemoveAll(introspectionCacheDir); err != nil && !errors.Is(err, os.ErrNotExist) {
 				return err
 			}
-		}
-
-		if introspectionCacheClearInterval > 0 {
-			go func() {
-				for range time.Tick(time.Second * time.Duration(introspectionCacheClearInterval)) {
-					if err := os.RemoveAll(introspectionCacheDir); err != nil && !errors.Is(err, os.ErrNotExist) {
-						fmt.Fprintf(os.Stderr, "error clearing introspection cache: %s\n", err)
-					}
-				}
-			}()
 		}
 
 		configJsonPath := path.Join(wunderGraphDir, "generated", configJsonFilename)
@@ -297,5 +285,4 @@ var upCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(upCmd)
 	upCmd.Flags().BoolVar(&keepIntrospectionCache, "keep-introspection-cache", false, "avoid clearing the introspection cache on startup")
-	upCmd.Flags().IntVar(&introspectionCacheClearInterval, "cache-clear-interval", 5, "interval to clear the instrospection cache periodically, in seconds - 0 to disable")
 }

--- a/cli/commands/up.go
+++ b/cli/commands/up.go
@@ -62,7 +62,7 @@ var upCmd = &cobra.Command{
 			abstractlogger.String("builtBy", BuildInfo.BuiltBy),
 		)
 
-		introspectionCacheDir := path.Join(wunderGraphDir, "introspection", "cache")
+		introspectionCacheDir := path.Join(wunderGraphDir, "cache", "introspection")
 		_, errIntrospectionDir := os.Stat(introspectionCacheDir)
 		if errIntrospectionDir == nil {
 			if clearIntrospectionCache {

--- a/cli/commands/up.go
+++ b/cli/commands/up.go
@@ -93,18 +93,7 @@ var upCmd = &cobra.Command{
 			AbsWorkingDir: wunderGraphDir,
 			ScriptArgs:    []string{configOutFile},
 			Logger:        log,
-			FirstRunEnv: append(os.Environ(),
-				// when the user runs `wunderctl up` for the first time, we revalidate the cache
-				// so the user can be sure that the introspection is up-to-date. In case of an API is not available
-				// we will fall back to the cached introspection (when available)
-				"WG_ENABLE_INTROSPECTION_CACHE=false",
-				// this option allows us to make different decision for the first run
-				// for example, we decide to not use the cache, but we will prefill the cache
-				"WG_DEV_FIRST_RUN=true",
-				fmt.Sprintf("WG_DIR_ABS=%s", wunderGraphDir),
-			),
 			ScriptEnv: append(os.Environ(),
-				"WG_ENABLE_INTROSPECTION_CACHE=true",
 				fmt.Sprintf("WG_DIR_ABS=%s", wunderGraphDir),
 			),
 		})

--- a/cli/commands/up.go
+++ b/cli/commands/up.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -63,18 +64,10 @@ var upCmd = &cobra.Command{
 		)
 
 		introspectionCacheDir := path.Join(wunderGraphDir, "cache", "introspection")
-		_, errIntrospectionDir := os.Stat(introspectionCacheDir)
-		if errIntrospectionDir == nil {
-			if clearIntrospectionCache {
-				err = os.RemoveAll(introspectionCacheDir)
-				if err != nil {
-					return err
-				}
+		if clearIntrospectionCache {
+			if err := os.RemoveAll(introspectionCacheDir); err != nil && !errors.Is(err, os.ErrNotExist) {
+				return err
 			}
-		}
-		err = os.MkdirAll(introspectionCacheDir, os.ModePerm)
-		if err != nil {
-			return err
 		}
 
 		configJsonPath := path.Join(wunderGraphDir, "generated", configJsonFilename)

--- a/docs-website/src/pages/docs/wundergraph-config-ts-reference/configure-introspection.md
+++ b/docs-website/src/pages/docs/wundergraph-config-ts-reference/configure-introspection.md
@@ -25,7 +25,7 @@ That's why we've introduced introspection caching.
 
 {% callout type="warning" %}
 By default, every data source is introspected exactly once.
-The result is cached in the `.wundergraph/introspection/cache` directory.
+The result is cached in the `.wundergraph/cache/introspection` directory.
 {% /callout %}
 
 If a cache entry is found for a data source,

--- a/docs-website/src/pages/docs/wundergraph-config-ts-reference/configure-introspection.md
+++ b/docs-website/src/pages/docs/wundergraph-config-ts-reference/configure-introspection.md
@@ -28,12 +28,14 @@ By default, every data source is introspected exactly once.
 The result is cached in the `.wundergraph/cache/introspection` directory.
 {% /callout %}
 
-If a cache entry is found for a data source,
-it's always used instead of introspecting the data source again.
+When caching is enabled, if a cache entry is found for a data source,
+it's always used instead of introspecting the data source again. Cache is
+optional and might be turned off globally using the `--no-cache` flag.
 
 ## Clearing the Cache
 
-It's possible to clear the cache by running `wunderctl up --clear-introspection-cache`.
+`wunderctl up` will clear the cache when it starts up. To clear the cache again,
+just restart it.
 
 ## Enable Introspection Polling
 
@@ -56,7 +58,7 @@ const spaceX = introspect.graphql({
 
 ## Disable Introspection Caching
 
-It's also possible to disable introspection caching.
+It's also possible to disable introspection caching for a given data source.
 Set `disableCache` to true, and `wunderctl up` will ignore the cache for this data source.
 
 ```typescript

--- a/docs-website/src/pages/docs/wundergraph-config-ts-reference/configure-introspection.md
+++ b/docs-website/src/pages/docs/wundergraph-config-ts-reference/configure-introspection.md
@@ -25,7 +25,7 @@ That's why we've introduced introspection caching.
 
 {% callout type="warning" %}
 By default, every data source is introspected exactly once.
-The result is cached in the `.wundergraph/generated/introspection` directory.
+The result is cached in the `.wundergraph/introspection/cache` directory.
 {% /callout %}
 
 If a cache entry is found for a data source,

--- a/docs-website/src/pages/docs/wundergraph-config-ts-reference/configure-introspection.md
+++ b/docs-website/src/pages/docs/wundergraph-config-ts-reference/configure-introspection.md
@@ -34,8 +34,23 @@ optional and might be turned off globally using the `--no-cache` flag.
 
 ## Clearing the Cache
 
-`wunderctl up` will clear the cache when it starts up. To clear the cache again,
-just restart it.
+Cache can be emptied when `wunderctl` starts by using the `--clear-cache`
+flag. Additionally, `wunderctl up` will automatically clear the cache
+when it starts up. To clear the cache again, just restart it.
+
+## Pregenerating the Cache
+
+For CI environments that cannot perform network requests, it might be
+useful to generate the cache contents and make the tests run offline.
+
+To populate the cache contents run `wunderctl generate --clear-cache`.
+This will delete any previous cache, introspect the data sources, and
+finally write the cache entries. `.wunderctl/cache` can then be stored
+and deployed to CI runners.
+
+To verify that your tests can run without fetching data from the network
+in a connected machine, the `--offline` flag can be used to disable loading
+remote resources.
 
 ## Enable Introspection Polling
 

--- a/examples/apollo-federation/.gitignore
+++ b/examples/apollo-federation/.gitignore
@@ -3,13 +3,14 @@
 .vscode
 .idea
 
+# WunderGraph build output
+.wundergraph/cache
+.wundergraph/generated
+
 # dependencies
 node_modules
 /.pnp
 .pnp.js
-
-# WunderGraph build output
-.wundergraph/generated
 
 # testing
 /coverage

--- a/examples/auth0-oidc-authentication/.gitignore
+++ b/examples/auth0-oidc-authentication/.gitignore
@@ -3,13 +3,14 @@
 .vscode
 .idea
 
+# WunderGraph build output
+.wundergraph/cache
+.wundergraph/generated
+
 # dependencies
 node_modules
 /.pnp
 .pnp.js
-
-# WunderGraph build output
-.wundergraph/generated
 
 # testing
 /coverage

--- a/examples/caching/.gitignore
+++ b/examples/caching/.gitignore
@@ -3,13 +3,14 @@
 .vscode
 .idea
 
+# WunderGraph build output
+.wundergraph/cache
+.wundergraph/generated
+
 # dependencies
 node_modules
 /.pnp
 .pnp.js
-
-# WunderGraph build output
-.wundergraph/generated
 
 # testing
 /coverage

--- a/examples/cross-api-joins/.gitignore
+++ b/examples/cross-api-joins/.gitignore
@@ -4,6 +4,7 @@
 .idea
 
 # WunderGraph build output
+.wundergraph/cache
 .wundergraph/generated
 
 # dependencies

--- a/examples/faunadb-nextjs/.gitignore
+++ b/examples/faunadb-nextjs/.gitignore
@@ -3,13 +3,14 @@
 .vscode
 .idea
 
+# WunderGraph build output
+.wundergraph/cache
+.wundergraph/generated
+
 # dependencies
 node_modules
 /.pnp
 .pnp.js
-
-# WunderGraph build output
-.wundergraph/generated
 
 # testing
 /coverage

--- a/examples/fragments/.gitignore
+++ b/examples/fragments/.gitignore
@@ -4,6 +4,7 @@
 .idea
 
 # WunderGraph build output
+.wundergraph/cache
 .wundergraph/generated
 
 # dependencies

--- a/examples/golang-client/.gitignore
+++ b/examples/golang-client/.gitignore
@@ -4,6 +4,7 @@
 .idea
 
 # WunderGraph build output
+.wundergraph/cache
 .wundergraph/generated
 
 # dependencies

--- a/examples/graphql-sse-subscriptions/.gitignore
+++ b/examples/graphql-sse-subscriptions/.gitignore
@@ -4,6 +4,7 @@
 .idea
 
 # WunderGraph build output
+.wundergraph/cache
 .wundergraph/generated
 
 # dependencies

--- a/examples/graphql-yoga-sse-subscriptions/.gitignore
+++ b/examples/graphql-yoga-sse-subscriptions/.gitignore
@@ -4,6 +4,7 @@
 .idea
 
 # WunderGraph build output
+.wundergraph/cache
 .wundergraph/generated
 
 # dependencies

--- a/examples/hooks/.gitignore
+++ b/examples/hooks/.gitignore
@@ -3,13 +3,14 @@
 .vscode
 .idea
 
+# WunderGraph build output
+.wundergraph/cache
+.wundergraph/generated
+
 # dependencies
 node_modules
 /.pnp
 .pnp.js
-
-# WunderGraph build output
-.wundergraph/generated
 
 # testing
 /coverage

--- a/examples/inject-bearer/.gitignore
+++ b/examples/inject-bearer/.gitignore
@@ -3,13 +3,14 @@
 .vscode
 .idea
 
+# WunderGraph build output
+.wundergraph/cache
+.wundergraph/generated
+
 # dependencies
 node_modules
 /.pnp
 .pnp.js
-
-# WunderGraph build output
-.wundergraph/generated
 
 # testing
 /coverage

--- a/examples/keycloak-oidc-authentication/.gitignore
+++ b/examples/keycloak-oidc-authentication/.gitignore
@@ -3,13 +3,14 @@
 .vscode
 .idea
 
+# WunderGraph build output
+.wundergraph/cache
+.wundergraph/generated
+
 # dependencies
 node_modules
 /.pnp
 .pnp.js
-
-# WunderGraph build output
-.wundergraph/generated
 
 # testing
 /coverage

--- a/examples/migrate-from-apollo/.gitignore
+++ b/examples/migrate-from-apollo/.gitignore
@@ -3,13 +3,14 @@
 .vscode
 .idea
 
+# WunderGraph build output
+.wundergraph/cache
+.wundergraph/generated
+
 # dependencies
 node_modules
 /.pnp
 .pnp.js
-
-# WunderGraph build output
-.wundergraph/generated
 
 # testing
 /coverage

--- a/examples/nextjs-postgres-prisma/.gitignore
+++ b/examples/nextjs-postgres-prisma/.gitignore
@@ -3,13 +3,14 @@
 .vscode
 .idea
 
+# WunderGraph build output
+.wundergraph/cache
+.wundergraph/generated
+
 # dependencies
 node_modules
 /.pnp
 .pnp.js
-
-# WunderGraph build output
-.wundergraph/generated
 
 # testing
 /coverage

--- a/examples/nextjs-postgres-user-filters/.gitignore
+++ b/examples/nextjs-postgres-user-filters/.gitignore
@@ -3,13 +3,14 @@
 .vscode
 .idea
 
+# WunderGraph build output
+.wundergraph/cache
+.wundergraph/generated
+
 # dependencies
 node_modules
 /.pnp
 .pnp.js
-
-# WunderGraph build output
-.wundergraph/generated
 
 # testing
 /coverage

--- a/examples/nextjs-swr/.gitignore
+++ b/examples/nextjs-swr/.gitignore
@@ -3,13 +3,14 @@
 .vscode
 .idea
 
+# WunderGraph build output
+.wundergraph/cache
+.wundergraph/generated
+
 # dependencies
 node_modules
 /.pnp
 .pnp.js
-
-# WunderGraph build output
-.wundergraph/generated
 
 # testing
 /coverage

--- a/examples/nextjs/.gitignore
+++ b/examples/nextjs/.gitignore
@@ -3,13 +3,14 @@
 .vscode
 .idea
 
+# WunderGraph build output
+.wundergraph/cache
+.wundergraph/generated
+
 # dependencies
 node_modules
 /.pnp
 .pnp.js
-
-# WunderGraph build output
-.wundergraph/generated
 
 # testing
 /coverage

--- a/examples/postgres/.gitignore
+++ b/examples/postgres/.gitignore
@@ -4,6 +4,7 @@
 .idea
 
 # WunderGraph build output
+.wundergraph/cache
 .wundergraph/generated
 
 # dependencies

--- a/examples/publish-install-api/.gitignore
+++ b/examples/publish-install-api/.gitignore
@@ -4,6 +4,7 @@
 .idea
 
 # WunderGraph build output
+.wundergraph/cache
 .wundergraph/generated
 
 # dependencies

--- a/examples/rbac/.gitignore
+++ b/examples/rbac/.gitignore
@@ -3,13 +3,14 @@
 .vscode
 .idea
 
+# WunderGraph build output
+.wundergraph/cache
+.wundergraph/generated
+
 # dependencies
 node_modules
 /.pnp
 .pnp.js
-
-# WunderGraph build output
-.wundergraph/generated
 
 # testing
 /coverage

--- a/examples/simple/.gitignore
+++ b/examples/simple/.gitignore
@@ -4,6 +4,7 @@
 .idea
 
 # WunderGraph build output
+.wundergraph/cache
 .wundergraph/generated
 
 # dependencies

--- a/examples/webhooks/.gitignore
+++ b/examples/webhooks/.gitignore
@@ -3,13 +3,14 @@
 .vscode
 .idea
 
+# WunderGraph build output
+.wundergraph/cache
+.wundergraph/generated
+
 # dependencies
 node_modules
 /.pnp
 .pnp.js
-
-# WunderGraph build output
-.wundergraph/generated
 
 # testing
 /coverage

--- a/packages/sdk/src/definition/index.ts
+++ b/packages/sdk/src/definition/index.ts
@@ -43,8 +43,7 @@ import { IGraphqlIntrospectionHeadersBuilder, IHeadersBuilder } from './headers-
 
 // Use UPPERCASE for environment variables
 export const WG_DATA_SOURCE_POLLING_MODE = process.env['WG_DATA_SOURCE_POLLING_MODE'] === 'true';
-export const WG_ENABLE_INTROSPECTION_CACHE = process.env['WG_ENABLE_INTROSPECTION_CACHE'] === 'true';
-export const WG_DEV_FIRST_RUN = process.env['WG_DEV_FIRST_RUN'] === 'true';
+export const WG_DISABLE_INTROSPECTION_CACHE = process.env['WG_DISABLE_INTROSPECTION_CACHE'] === 'true';
 
 export interface ApplicationConfig {
 	name: string;

--- a/packages/sdk/src/definition/index.ts
+++ b/packages/sdk/src/definition/index.ts
@@ -45,7 +45,7 @@ import { IGraphqlIntrospectionHeadersBuilder, IHeadersBuilder } from './headers-
 export const WG_DATA_SOURCE_POLLING_MODE = process.env['WG_DATA_SOURCE_POLLING_MODE'] === 'true';
 export const WG_ENABLE_INTROSPECTION_CACHE = process.env['WG_ENABLE_INTROSPECTION_CACHE'] === 'true';
 // Only use the instrospection cache, return an error when hitting the network
-export const WG_USE_INTROSPECTION_CACHE_EXCLUSIVELY = process.env['WG_USE_INTROSPECTION_CACHE_EXCLUSIVELY'] === 'true';
+export const WG_ENABLE_INTROSPECTION_OFFLINE = process.env['WG_ENABLE_INTROSPECTION_OFFLINE'] === 'true';
 
 export interface ApplicationConfig {
 	name: string;

--- a/packages/sdk/src/definition/index.ts
+++ b/packages/sdk/src/definition/index.ts
@@ -43,7 +43,7 @@ import { IGraphqlIntrospectionHeadersBuilder, IHeadersBuilder } from './headers-
 
 // Use UPPERCASE for environment variables
 export const WG_DATA_SOURCE_POLLING_MODE = process.env['WG_DATA_SOURCE_POLLING_MODE'] === 'true';
-export const WG_DISABLE_INTROSPECTION_CACHE = process.env['WG_DISABLE_INTROSPECTION_CACHE'] === 'true';
+export const WG_ENABLE_INTROSPECTION_CACHE = process.env['WG_ENABLE_INTROSPECTION_CACHE'] === 'true';
 
 export interface ApplicationConfig {
 	name: string;

--- a/packages/sdk/src/definition/index.ts
+++ b/packages/sdk/src/definition/index.ts
@@ -44,6 +44,8 @@ import { IGraphqlIntrospectionHeadersBuilder, IHeadersBuilder } from './headers-
 // Use UPPERCASE for environment variables
 export const WG_DATA_SOURCE_POLLING_MODE = process.env['WG_DATA_SOURCE_POLLING_MODE'] === 'true';
 export const WG_ENABLE_INTROSPECTION_CACHE = process.env['WG_ENABLE_INTROSPECTION_CACHE'] === 'true';
+// Only use the instrospection cache, return an error when hitting the network
+export const WG_USE_INTROSPECTION_CACHE_EXCLUSIVELY = process.env['WG_USE_INTROSPECTION_CACHE_EXCLUSIVELY'] === 'true';
 
 export interface ApplicationConfig {
 	name: string;

--- a/packages/sdk/src/definition/introspection-cache.ts
+++ b/packages/sdk/src/definition/introspection-cache.ts
@@ -146,7 +146,9 @@ export const introspectWithCache = async <Introspection extends IntrospectionCon
 		try {
 			const cacheEntry = toCacheEntry<A>(api);
 			await writeIntrospectionCacheFile(cacheKey, JSON.stringify(cacheEntry));
-		} catch (e) {}
+		} catch (e) {
+			console.log(`Error storing cache: ${e}`);
+		}
 	}
 
 	return api;

--- a/packages/sdk/src/definition/introspection-cache.ts
+++ b/packages/sdk/src/definition/introspection-cache.ts
@@ -162,7 +162,11 @@ export const introspectWithCache = async <Introspection extends IntrospectionCon
 	 */
 
 	if (WG_ENABLE_INTROSPECTION_OFFLINE) {
-		throw new Error(`Could not load introspection from cache`);
+		throw new Error(
+			`Could not load introspection from cache for ${JSON.stringify(
+				introspection
+			)} and network requests are disabled in offline mode`
+		);
 	}
 
 	const api = await generator(introspection);

--- a/packages/sdk/src/definition/introspection-cache.ts
+++ b/packages/sdk/src/definition/introspection-cache.ts
@@ -5,6 +5,7 @@ import {
 	IntrospectionConfiguration,
 	WG_DATA_SOURCE_POLLING_MODE,
 	WG_ENABLE_INTROSPECTION_CACHE,
+	WG_USE_INTROSPECTION_CACHE_EXCLUSIVELY,
 } from './index';
 import path from 'path';
 import fsP from 'fs/promises';
@@ -156,9 +157,14 @@ export const introspectWithCache = async <Introspection extends IntrospectionCon
 	}
 
 	/*
-	 * At this point, we don't have a cache entry for this. Generate
-	 * introspection from scratch. Then cache it
+	 * At this point, we don't have a cache entry for this. If we're in cache exclusive
+	 * mode, fail here. Otherwise generate introspection from scratch. Then cache it.
 	 */
+
+	if (WG_USE_INTROSPECTION_CACHE_EXCLUSIVELY) {
+		throw new Error(`Could not load introspection from cache`);
+	}
+
 	const api = await generator(introspection);
 
 	/*

--- a/packages/sdk/src/definition/introspection-cache.ts
+++ b/packages/sdk/src/definition/introspection-cache.ts
@@ -43,7 +43,7 @@ export function fromCacheEntry<A extends ApiType>(cache: IntrospectionCacheFile<
 }
 
 export const readIntrospectionCacheFile = async (cacheKey: string): Promise<string> => {
-	const cacheFile = path.join('generated', 'introspection', 'cache', `${cacheKey}.json`);
+	const cacheFile = path.join('introspection', 'cache', `${cacheKey}.json`);
 	if (fs.existsSync(cacheFile)) {
 		return fsP.readFile(cacheFile, 'utf8');
 	}
@@ -51,7 +51,7 @@ export const readIntrospectionCacheFile = async (cacheKey: string): Promise<stri
 };
 
 export const writeIntrospectionCacheFile = async (cacheKey: string, content: string): Promise<void> => {
-	const cacheFile = path.join('generated', 'introspection', 'cache', `${cacheKey}.json`);
+	const cacheFile = path.join('introspection', 'cache', `${cacheKey}.json`);
 	return fsP.writeFile(cacheFile, content, { encoding: 'utf8' });
 };
 

--- a/packages/sdk/src/definition/introspection-cache.ts
+++ b/packages/sdk/src/definition/introspection-cache.ts
@@ -7,7 +7,6 @@ import {
 	WG_DISABLE_INTROSPECTION_CACHE,
 } from './index';
 import path from 'path';
-import fs from 'fs';
 import fsP from 'fs/promises';
 import { FieldConfiguration, TypeConfiguration } from '@wundergraph/protobuf';
 import objectHash from 'object-hash';
@@ -44,10 +43,15 @@ export function fromCacheEntry<A extends ApiType>(cache: IntrospectionCacheFile<
 
 export const readIntrospectionCacheFile = async (cacheKey: string): Promise<string> => {
 	const cacheFile = path.join('cache', 'introspection', `${cacheKey}.json`);
-	if (fs.existsSync(cacheFile)) {
-		return fsP.readFile(cacheFile, 'utf8');
+	try {
+		return await fsP.readFile(cacheFile, 'utf8');
+	} catch (e) {
+		if (e instanceof Error && e.message.startsWith('ENOENT')) {
+			// File does not exist
+			return '';
+		}
+		throw e;
 	}
-	return '';
 };
 
 export const writeIntrospectionCacheFile = async (cacheKey: string, content: string): Promise<void> => {

--- a/packages/sdk/src/definition/introspection-cache.ts
+++ b/packages/sdk/src/definition/introspection-cache.ts
@@ -4,7 +4,7 @@ import {
 	DataSource,
 	IntrospectionConfiguration,
 	WG_DATA_SOURCE_POLLING_MODE,
-	WG_DISABLE_INTROSPECTION_CACHE,
+	WG_ENABLE_INTROSPECTION_CACHE,
 } from './index';
 import path from 'path';
 import fsP from 'fs/promises';
@@ -118,9 +118,6 @@ export const introspectWithCache = async <Introspection extends IntrospectionCon
 	introspection: Introspection,
 	generator: (introspection: Introspection) => Promise<Api<A>>
 ): Promise<Api<A>> => {
-	const isIntrospectionDisabledBySource = introspection.introspection?.disableCache === true;
-	const isIntrospectionDisabledByEnv = WG_DISABLE_INTROSPECTION_CACHE;
-	const isIntrospectionCacheEnabled = !isIntrospectionDisabledBySource && !isIntrospectionDisabledByEnv;
 	const cacheKey = objectHash(introspection);
 
 	/**
@@ -141,6 +138,10 @@ export const introspectWithCache = async <Introspection extends IntrospectionCon
 		}
 		return {} as Api<A>;
 	}
+
+	const isIntrospectionDisabledBySource = introspection.introspection?.disableCache === true;
+	const isIntrospectionEnabledByEnv = WG_ENABLE_INTROSPECTION_CACHE;
+	const isIntrospectionCacheEnabled = !isIntrospectionDisabledBySource && isIntrospectionEnabledByEnv;
 
 	/**
 	 * As long as the cache is enabled, always try to hit it first

--- a/packages/sdk/src/definition/introspection-cache.ts
+++ b/packages/sdk/src/definition/introspection-cache.ts
@@ -5,7 +5,7 @@ import {
 	IntrospectionConfiguration,
 	WG_DATA_SOURCE_POLLING_MODE,
 	WG_ENABLE_INTROSPECTION_CACHE,
-	WG_USE_INTROSPECTION_CACHE_EXCLUSIVELY,
+	WG_ENABLE_INTROSPECTION_OFFLINE,
 } from './index';
 import path from 'path';
 import fsP from 'fs/promises';
@@ -161,7 +161,7 @@ export const introspectWithCache = async <Introspection extends IntrospectionCon
 	 * mode, fail here. Otherwise generate introspection from scratch. Then cache it.
 	 */
 
-	if (WG_USE_INTROSPECTION_CACHE_EXCLUSIVELY) {
+	if (WG_ENABLE_INTROSPECTION_OFFLINE) {
 		throw new Error(`Could not load introspection from cache`);
 	}
 

--- a/packages/sdk/src/definition/introspection-cache.ts
+++ b/packages/sdk/src/definition/introspection-cache.ts
@@ -43,7 +43,7 @@ export function fromCacheEntry<A extends ApiType>(cache: IntrospectionCacheFile<
 }
 
 export const readIntrospectionCacheFile = async (cacheKey: string): Promise<string> => {
-	const cacheFile = path.join('introspection', 'cache', `${cacheKey}.json`);
+	const cacheFile = path.join('cache', 'introspection', `${cacheKey}.json`);
 	if (fs.existsSync(cacheFile)) {
 		return fsP.readFile(cacheFile, 'utf8');
 	}
@@ -51,7 +51,7 @@ export const readIntrospectionCacheFile = async (cacheKey: string): Promise<stri
 };
 
 export const writeIntrospectionCacheFile = async (cacheKey: string, content: string): Promise<void> => {
-	const cacheFile = path.join('introspection', 'cache', `${cacheKey}.json`);
+	const cacheFile = path.join('cache', 'introspection', `${cacheKey}.json`);
 	return fsP.writeFile(cacheFile, content, { encoding: 'utf8' });
 };
 

--- a/testapps/default/.gitignore
+++ b/testapps/default/.gitignore
@@ -3,6 +3,7 @@
 .idea
 
 # WunderGraph build output
+.wundergraph/cache
 .wundergraph/generated
 components/generated
 !components/generated/.gitkeep

--- a/testapps/mtls/.gitignore
+++ b/testapps/mtls/.gitignore
@@ -3,6 +3,7 @@
 .idea
 
 # WunderGraph build output
+.wundergraph/cache
 .wundergraph/generated
 components/generated
 !components/generated/.gitkeep

--- a/testapps/nextjs/.gitignore
+++ b/testapps/nextjs/.gitignore
@@ -8,6 +8,7 @@
 .pnp.js
 
 # WunderGraph build output
+.wundergraph/cache
 .wundergraph/generated
 components/generated/*
 !components/generated/.gitkeep

--- a/testapps/postgres/.gitignore
+++ b/testapps/postgres/.gitignore
@@ -4,6 +4,7 @@
 .idea
 
 # WunderGraph build output
+.wundergraph/cache
 .wundergraph/generated
 
 # dependencies


### PR DESCRIPTION
- feat: move introspection cache to .wundergraph/introspection/cache
- feat: prioritize cache during introspection

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `make test`
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)

<!--
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->
