### PR TITLE
fix: make WunderGraphDir not mandatory for all cmds

### DIFF
--- a/cli/commands/add.go
+++ b/cli/commands/add.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/wundergraph/wundergraph/pkg/files"
 	"github.com/wundergraph/wundergraph/pkg/manifest"
 )
 
@@ -17,8 +18,12 @@ var addCmd = &cobra.Command{
 	Args:    cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, dependencies []string) error {
 		client := InitWunderGraphApiClient()
-		man := manifest.New(log, client, WunderGraphDir)
-		err := man.Load()
+		wunderGraphDir, err := files.FindWunderGraphDir(_wunderGraphDirConfig)
+		if err != nil {
+			return err
+		}
+		man := manifest.New(log, client, wunderGraphDir)
+		err = man.Load()
 		if err != nil {
 			return fmt.Errorf("unable to load wundergraph.manifest.json")
 		}

--- a/cli/commands/generate.go
+++ b/cli/commands/generate.go
@@ -28,14 +28,18 @@ var generateCmd = &cobra.Command{
 	Long: `In contrast to wunderctl up, it only generates all files in ./generated but doesn't start WunderGraph or the hooks.
 Use this command if you only want to generate the configuration`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		wunderGraphDir, err := files.FindWunderGraphDir(_wunderGraphDirConfig)
+		if err != nil {
+			return err
+		}
 		// only validate if the file exists
-		_, err := files.CodeFilePath(WunderGraphDir, configEntryPointFilename)
+		_, err = files.CodeFilePath(wunderGraphDir, configEntryPointFilename)
 		if err != nil {
 			return err
 		}
 
 		// optional, no error check
-		codeServerFilePath, _ := files.CodeFilePath(WunderGraphDir, serverEntryPointFilename)
+		codeServerFilePath, _ := files.CodeFilePath(wunderGraphDir, serverEntryPointFilename)
 
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 		defer cancel()
@@ -46,14 +50,14 @@ Use this command if you only want to generate the configuration`,
 			Name:          "config-runner",
 			Executable:    "node",
 			ScriptArgs:    []string{configOutFile},
-			AbsWorkingDir: WunderGraphDir,
+			AbsWorkingDir: wunderGraphDir,
 			Logger:        log,
 			ScriptEnv: append(
 				os.Environ(),
 				// Run scripts in prod mode
 				"NODE_ENV=production",
 				fmt.Sprintf("WUNDERGRAPH_PUBLISH_API=%t", generateAndPublish),
-				fmt.Sprintf("WG_DIR_ABS=%s", WunderGraphDir),
+				fmt.Sprintf("WG_DIR_ABS=%s", wunderGraphDir),
 			),
 		})
 		defer func() {
@@ -70,21 +74,21 @@ Use this command if you only want to generate the configuration`,
 		var onAfterBuild func() error
 
 		if codeServerFilePath != "" {
-			serverOutFile := path.Join(WunderGraphDir, "generated", "bundle", "server.js")
+			serverOutFile := path.Join(wunderGraphDir, "generated", "bundle", "server.js")
 			webhooksOutDir := path.Join("generated", "bundle", "webhooks")
-			webhooksDir := path.Join(WunderGraphDir, webhooks.WebhookDirectoryName)
+			webhooksDir := path.Join(wunderGraphDir, webhooks.WebhookDirectoryName)
 
 			var webhooksBundler *bundler.Bundler
 
 			if files.DirectoryExists(webhooksDir) {
-				webhookPaths, err := webhooks.GetWebhooks(WunderGraphDir)
+				webhookPaths, err := webhooks.GetWebhooks(wunderGraphDir)
 				if err != nil {
 					return err
 				}
 				webhooksBundler = bundler.NewBundler(bundler.Config{
 					Name:          "webhooks-bundler",
 					EntryPoints:   webhookPaths,
-					AbsWorkingDir: WunderGraphDir,
+					AbsWorkingDir: wunderGraphDir,
 					OutDir:        webhooksOutDir,
 					Logger:        log,
 					OnAfterBundle: func() error {
@@ -96,7 +100,7 @@ Use this command if you only want to generate the configuration`,
 
 			hooksBundler := bundler.NewBundler(bundler.Config{
 				Name:          "server-bundler",
-				AbsWorkingDir: WunderGraphDir,
+				AbsWorkingDir: wunderGraphDir,
 				EntryPoints:   []string{serverEntryPointFilename},
 				OutFile:       serverOutFile,
 				Logger:        log,
@@ -149,7 +153,7 @@ Use this command if you only want to generate the configuration`,
 
 		configBundler := bundler.NewBundler(bundler.Config{
 			Name:          "config-bundler",
-			AbsWorkingDir: WunderGraphDir,
+			AbsWorkingDir: wunderGraphDir,
 			EntryPoints:   []string{configEntryPointFilename},
 			OutFile:       configOutFile,
 			Logger:        log,

--- a/cli/commands/install-prisma-dependencies.go
+++ b/cli/commands/install-prisma-dependencies.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"github.com/spf13/cobra"
 	"github.com/wundergraph/wundergraph/pkg/datasources/database"
+	"github.com/wundergraph/wundergraph/pkg/files"
 )
 
 // introspectCmd represents the introspect command
@@ -10,7 +11,11 @@ var ensurePrismaCmd = &cobra.Command{
 	Use:   "installPrismaDependencies",
 	Short: "Installs Prisma Dependency",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return database.InstallPrismaDependencies(log, WunderGraphDir)
+		wunderGraphDir, err := files.FindWunderGraphDir(_wunderGraphDirConfig)
+		if err != nil {
+			return err
+		}
+		return database.InstallPrismaDependencies(log, wunderGraphDir)
 	},
 }
 

--- a/cli/commands/mongodb.go
+++ b/cli/commands/mongodb.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"github.com/wundergraph/wundergraph/pkg/files"
 
 	"github.com/wundergraph/wundergraph/pkg/datasources/database"
 )
@@ -15,13 +16,17 @@ var mongoDbCmd = &cobra.Command{
 	Example: `wunderctl mongodb mongodb+srv://test:test@cluster0.ns1yp.mongodb.net/myFirstDatabase`,
 	Args:    cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		wunderGraphDir, err := files.FindWunderGraphDir(_wunderGraphDirConfig)
+		if err != nil {
+			return err
+		}
 		databaseURL := args[0]
 		introspectionSchema := fmt.Sprintf(`datasource db {
   provider = "mongodb"
   url      = "%s"
 }
 `, databaseURL)
-		prismaSchema, graphqlSDL, dmmf, err := database.IntrospectPrismaDatabase(introspectionSchema, WunderGraphDir, log)
+		prismaSchema, graphqlSDL, dmmf, err := database.IntrospectPrismaDatabase(introspectionSchema, wunderGraphDir, log)
 		if err != nil {
 			return err
 		}

--- a/cli/commands/mysql.go
+++ b/cli/commands/mysql.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/wundergraph/wundergraph/pkg/datasources/database"
+	"github.com/wundergraph/wundergraph/pkg/files"
 )
 
 // postgresCmd represents the postgres command
@@ -14,12 +15,16 @@ var mysqlCmd = &cobra.Command{
 	Example: `wunderctl introspect mysql mysql://user:password@localhost:5432/database`,
 	Args:    cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		wunderGraphDir, err := files.FindWunderGraphDir(_wunderGraphDirConfig)
+		if err != nil {
+			return err
+		}
 		databaseURL := args[0]
 		introspectionSchema := fmt.Sprintf(`datasource db {
 			provider = "mysql"
 			url      = "%s"
 		}`, databaseURL)
-		prismaSchema, graphqlSDL, dmmf, err := database.IntrospectPrismaDatabase(introspectionSchema, WunderGraphDir, log)
+		prismaSchema, graphqlSDL, dmmf, err := database.IntrospectPrismaDatabase(introspectionSchema, wunderGraphDir, log)
 		if err != nil {
 			return err
 		}

--- a/cli/commands/node.go
+++ b/cli/commands/node.go
@@ -31,7 +31,11 @@ var nodeStartCmd = &cobra.Command{
 			wunderctl node start
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		configFile := path.Join(WunderGraphDir, "generated", configJsonFilename)
+		wunderGraphDir, err := files.FindWunderGraphDir(_wunderGraphDirConfig)
+		if err != nil {
+			return err
+		}
+		configFile := path.Join(wunderGraphDir, "generated", configJsonFilename)
 		if !files.FileExists(configFile) {
 			return fmt.Errorf("could not find configuration file: %s", configFile)
 		}
@@ -56,7 +60,7 @@ var nodeStartCmd = &cobra.Command{
 		defer stop()
 
 		wunderNodeConfig := node.CreateConfig(&graphConfig)
-		n := node.New(ctx, BuildInfo, WunderGraphDir, log)
+		n := node.New(ctx, BuildInfo, wunderGraphDir, log)
 
 		go func() {
 			err := n.StartBlocking(

--- a/cli/commands/planetscale.go
+++ b/cli/commands/planetscale.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 
 	"github.com/spf13/cobra"
+	"github.com/wundergraph/wundergraph/pkg/files"
 
 	"github.com/wundergraph/wundergraph/pkg/datasources/database"
 )
@@ -17,6 +18,11 @@ var planetscaleCmd = &cobra.Command{
 	Example: `wunderctl introspect planetscale mysql://xxx:pscale_pw_xxx@fwsbiox1njhc.eu-west-3.psdb.cloud/test?sslaccept=strict`,
 	Args:    cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		wunderGraphDir, err := files.FindWunderGraphDir(_wunderGraphDirConfig)
+		if err != nil {
+			return err
+		}
+
 		databaseURL := args[0]
 		parsed, err := url.Parse(databaseURL)
 		if err != nil {
@@ -29,7 +35,7 @@ var planetscaleCmd = &cobra.Command{
 			provider = "mysql"
 			url      = "%s"
 		}`, parsed.String())
-		prismaSchema, graphqlSDL, dmmf, err := database.IntrospectPrismaDatabase(introspectionSchema, WunderGraphDir, log)
+		prismaSchema, graphqlSDL, dmmf, err := database.IntrospectPrismaDatabase(introspectionSchema, wunderGraphDir, log)
 		if err != nil {
 			return err
 		}

--- a/cli/commands/postgres.go
+++ b/cli/commands/postgres.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"github.com/wundergraph/wundergraph/pkg/files"
 
 	"github.com/wundergraph/wundergraph/pkg/datasources/database"
 )
@@ -22,12 +23,17 @@ var postgresCmd = &cobra.Command{
 	Example: `wunderctl introspect postgresql postgresql://user:password@localhost:5432/database?schema=public`,
 	Args:    cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		wunderGraphDir, err := files.FindWunderGraphDir(_wunderGraphDirConfig)
+		if err != nil {
+			return err
+		}
+
 		databaseURL := args[0]
 		introspectionSchema := fmt.Sprintf(`datasource db {
 			provider = "postgresql"
 			url      = "%s"
 		}`, databaseURL)
-		prismaSchema, graphqlSDL, dmmf, err := database.IntrospectPrismaDatabase(introspectionSchema, WunderGraphDir, log)
+		prismaSchema, graphqlSDL, dmmf, err := database.IntrospectPrismaDatabase(introspectionSchema, wunderGraphDir, log)
 		if err != nil {
 			return err
 		}

--- a/cli/commands/publish.go
+++ b/cli/commands/publish.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/wundergraph/wundergraph/pkg/files"
 	"github.com/wundergraph/wundergraph/pkg/v2wundergraphapi"
 )
 
@@ -22,6 +23,11 @@ The APIs to publish need to be generated into the .wundergraph/generated directo
 	Example: `wunderctl publish organization/api`,
 	Args:    cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		wunderGraphDir, err := files.FindWunderGraphDir(_wunderGraphDirConfig)
+		if err != nil {
+			return err
+		}
+
 		var client *v2wundergraphapi.Client
 		if serviceToken != "" {
 			client = InitWunderGraphApiClientWithToken(serviceToken)
@@ -39,7 +45,7 @@ The APIs to publish need to be generated into the .wundergraph/generated directo
 			api := orgAndApi[1]
 			apiName := fmt.Sprintf("%s/%s", org, api)
 			fileName := fmt.Sprintf("%s.%s.api.json", org, api)
-			filePath := path.Join(WunderGraphDir, "generated", fileName)
+			filePath := path.Join(wunderGraphDir, "generated", fileName)
 
 			if _, err := os.Stat(filePath); os.IsNotExist(err) {
 				_, _ = red.Printf("API file does not exist: %s\n", filePath)

--- a/cli/commands/remove.go
+++ b/cli/commands/remove.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/wundergraph/wundergraph/pkg/files"
 	"github.com/wundergraph/wundergraph/pkg/manifest"
 )
 
@@ -15,9 +16,15 @@ var removeCmd = &cobra.Command{
 	Example: `wunderctl remove spacex/spacex`,
 	Args:    cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, dependencies []string) error {
+
+		wunderGraphDir, err := files.FindWunderGraphDir(_wunderGraphDirConfig)
+		if err != nil {
+			return err
+		}
+
 		client := InitWunderGraphApiClient()
-		man := manifest.New(log, client, WunderGraphDir)
-		err := man.Load()
+		man := manifest.New(log, client, wunderGraphDir)
+		err = man.Load()
 		if err != nil {
 			return fmt.Errorf("unable to load wundergraph.manifest.json")
 		}

--- a/cli/commands/root.go
+++ b/cli/commands/root.go
@@ -41,7 +41,6 @@ var (
 	jsonEncodedLogging    bool
 	serviceToken          string
 	_wunderGraphDirConfig string
-	WunderGraphDir        string
 
 	red    = color.New(color.FgHiRed)
 	green  = color.New(color.FgHiGreen)
@@ -64,19 +63,13 @@ You can opt out of this by setting the following environment variable: WUNDERGRA
 `,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 
-		var err error
-		WunderGraphDir, err = files.FindWunderGraphDir(_wunderGraphDirConfig)
-		if err != nil {
-			return err
-		}
-
 		if enableDebugMode {
 			log = buildLogger(abstractlogger.DebugLevel)
 		} else {
 			log = buildLogger(findLogLevel(abstractlogger.ErrorLevel))
 		}
 
-		err = godotenv.Load(DotEnvFile)
+		err := godotenv.Load(DotEnvFile)
 		if err != nil {
 			if _, ok := err.(*fs.PathError); ok {
 				log.Debug("starting without env file")
@@ -94,8 +87,12 @@ You can opt out of this by setting the following environment variable: WUNDERGRA
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		client := InitWunderGraphApiClient()
-		man := manifest.New(log, client, WunderGraphDir)
-		err := man.Load()
+		wunderGraphDir, err := files.FindWunderGraphDir(_wunderGraphDirConfig)
+		if err != nil {
+			return err
+		}
+		man := manifest.New(log, client, wunderGraphDir)
+		err = man.Load()
 		if err != nil {
 			return fmt.Errorf("unable to load wundergraph.manifest.json")
 		}

--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -27,13 +27,18 @@ var serverStartCmd = &cobra.Command{
 			wunderctl server start
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		configFile := path.Join(WunderGraphDir, "generated", configJsonFilename)
+		wunderGraphDir, err := files.FindWunderGraphDir(_wunderGraphDirConfig)
+		if err != nil {
+			return err
+		}
+
+		configFile := path.Join(wunderGraphDir, "generated", configJsonFilename)
 		if !files.FileExists(configFile) {
 			return fmt.Errorf("could not find configuration file: %s", configFile)
 		}
 
 		serverScriptFile := path.Join("generated", "bundle", "server.js")
-		serverExecutablePath := path.Join(WunderGraphDir, serverScriptFile)
+		serverExecutablePath := path.Join(wunderGraphDir, serverScriptFile)
 		if !files.FileExists(serverExecutablePath) {
 			return fmt.Errorf(`hooks server executable "%s" not found`, serverExecutablePath)
 		}
@@ -42,7 +47,7 @@ var serverStartCmd = &cobra.Command{
 		defer stop()
 
 		srvCfg := &helpers.ServerRunConfig{
-			WunderGraphDirAbs: WunderGraphDir,
+			WunderGraphDirAbs: _wunderGraphDirConfig,
 			ServerScriptFile:  serverScriptFile,
 			Production:        true,
 		}

--- a/cli/commands/sqlite.go
+++ b/cli/commands/sqlite.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/wundergraph/wundergraph/pkg/datasources/database"
+	"github.com/wundergraph/wundergraph/pkg/files"
 )
 
 // postgresCmd represents the postgres command
@@ -14,12 +15,17 @@ var sqliteCmd = &cobra.Command{
 	Example: `wunderctl introspect sqlite file:./dev.db`,
 	Args:    cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		wunderGraphDir, err := files.FindWunderGraphDir(_wunderGraphDirConfig)
+		if err != nil {
+			return err
+		}
+
 		databaseURL := args[0]
 		introspectionSchema := fmt.Sprintf(`datasource db {
 			provider = "sqlite"
 			url      = "%s"
 		}`, databaseURL)
-		prismaSchema, graphqlSDL, dmmf, err := database.IntrospectPrismaDatabase(introspectionSchema, WunderGraphDir, log)
+		prismaSchema, graphqlSDL, dmmf, err := database.IntrospectPrismaDatabase(introspectionSchema, wunderGraphDir, log)
 		if err != nil {
 			return err
 		}

--- a/cli/commands/sqlserver.go
+++ b/cli/commands/sqlserver.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"github.com/wundergraph/wundergraph/pkg/files"
 
 	"github.com/wundergraph/wundergraph/pkg/datasources/database"
 )
@@ -15,12 +16,17 @@ var sqlserverCmd = &cobra.Command{
 	Example: `Introspect sqlserver sqlserver://localhost:1433;database=wundergraph;schema=wg;user=SA;password=secure_Password;encrypt=true;trustServerCertificate=true`,
 	Args:    cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		wunderGraphDir, err := files.FindWunderGraphDir(_wunderGraphDirConfig)
+		if err != nil {
+			return err
+		}
+
 		databaseURL := args[0]
 		introspectionSchema := fmt.Sprintf(`datasource db {
 			provider = "sqlserver"
 			url      = "%s"
 		}`, databaseURL)
-		prismaSchema, graphqlSDL, dmmf, err := database.IntrospectPrismaDatabase(introspectionSchema, WunderGraphDir, log)
+		prismaSchema, graphqlSDL, dmmf, err := database.IntrospectPrismaDatabase(introspectionSchema, wunderGraphDir, log)
 		if err != nil {
 			return err
 		}

--- a/cli/commands/start.go
+++ b/cli/commands/start.go
@@ -34,7 +34,12 @@ just running the engine as efficiently as possible without the dev overhead.
 If used without --exclude-server, make sure the server is available in this directory:
 {entrypoint}/bundle/server.js or override it with --server-entrypoint.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		configFile := path.Join(WunderGraphDir, "generated", configJsonFilename)
+		wunderGraphDir, err := files.FindWunderGraphDir(_wunderGraphDirConfig)
+		if err != nil {
+			return err
+		}
+
+		configFile := path.Join(wunderGraphDir, "generated", configJsonFilename)
 		if !files.FileExists(configFile) {
 			return fmt.Errorf("could not find configuration file: %s", configFile)
 		}
@@ -47,13 +52,13 @@ If used without --exclude-server, make sure the server is available in this dire
 			defer cancel()
 
 			serverScriptFile := path.Join("generated", "bundle", "server.js")
-			serverExecutablePath := path.Join(WunderGraphDir, "generated", "bundle", "server.js")
+			serverExecutablePath := path.Join(wunderGraphDir, "generated", "bundle", "server.js")
 			if !files.FileExists(serverExecutablePath) {
-				return fmt.Errorf(`hooks server build artifact "%s" not found. Please use --exclude-server to disable the server`, path.Join(WunderGraphDir, serverScriptFile))
+				return fmt.Errorf(`hooks server build artifact "%s" not found. Please use --exclude-server to disable the server`, path.Join(wunderGraphDir, serverScriptFile))
 			}
 
 			srvCfg := &helpers.ServerRunConfig{
-				WunderGraphDirAbs: WunderGraphDir,
+				WunderGraphDirAbs: wunderGraphDir,
 				ServerScriptFile:  serverScriptFile,
 				Production:        true,
 			}
@@ -83,7 +88,7 @@ If used without --exclude-server, make sure the server is available in this dire
 		}
 
 		configFileChangeChan := make(chan struct{})
-		n := node.New(nodeCtx, BuildInfo, WunderGraphDir, log)
+		n := node.New(nodeCtx, BuildInfo, wunderGraphDir, log)
 
 		go func() {
 			err := n.StartBlocking(


### PR DESCRIPTION
Some cmds, like `init` don't require the existence of the `.wundergraph` directory.
We always checked for this and failed if we didn't find it, which is wrong for init.