### PR TITLE
fix(sdk/client): include extra headers from constructor

### DIFF
--- a/packages/sdk/src/client/client.test.ts
+++ b/packages/sdk/src/client/client.test.ts
@@ -1,9 +1,9 @@
-import { Client, OperationRequestOptions } from './index';
+import { Client, ClientConfig, OperationRequestOptions } from './index';
 import nock from 'nock';
 import fetch from 'node-fetch';
 import { ResponseError } from './ResponseError';
 
-const newClient = () => {
+const newClient = (overrides?: Partial<ClientConfig>) => {
 	return new Client({
 		sdkVersion: '1.0.0',
 		baseURL: 'https://api.com',
@@ -21,19 +21,25 @@ const newClient = () => {
 				requiresAuthentication: false,
 			},
 		},
+		...overrides,
 	});
 };
 
 describe('Client', () => {
 	describe('Utility', () => {
 		test('Should be able to set extra headers', async () => {
-			const client = newClient();
+			const client = newClient({
+				extraHeaders: {
+					'X-Test-From-Constructor': 'extra-header',
+				},
+			});
 
 			const scope = nock('https://api.com')
 				.matchHeader('accept', 'application/json')
 				.matchHeader('content-type', 'application/json')
 				.matchHeader('WG-SDK-Version', '1.0.0')
 				.matchHeader('X-Test', 'test')
+				.matchHeader('X-Test-From-Constructor', 'extra-header')
 				.get('/app/operations/Weather')
 				.query({ wg_api_hash: '123', wg_variables: '{}' })
 				.once()

--- a/packages/sdk/src/client/client.ts
+++ b/packages/sdk/src/client/client.ts
@@ -23,6 +23,8 @@ export class Client {
 		this.baseHeaders = {
 			'WG-SDK-Version': options.sdkVersion,
 		};
+
+		this.extraHeaders = { ...options.extraHeaders };
 	}
 
 	private readonly baseHeaders: Headers = {};


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

`WunderGraphClient` should include `extraHeaders` passed into the constructor.
This should also fix the issue where `extraHeaders` passed into the `WunderGraphProvider` are ignored.

#### Checklist

- [x] run `make test`
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)

<!--
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->
