### PR TITLE
fix: incorrect go code generated from JSON models

### DIFF
--- a/.github/workflows/packages-ci.yaml
+++ b/.github/workflows/packages-ci.yaml
@@ -40,6 +40,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      - uses: ./.github/actions/go
+        with:
+          working-directory: ${{ env.WORKING_DIRECTORY }}
+
       - uses: ./.github/actions/node
         with:
           working-directory: ${{ env.WORKING_DIRECTORY }}

--- a/packages/golang-client/src/index.ts
+++ b/packages/golang-client/src/index.ts
@@ -21,6 +21,23 @@ const defaultTemplateConfig: GolangClientTemplateConfig = {
 	packageName: 'client',
 };
 
+/**
+ * Formats a given string with each line prepended by its line number
+ * (starting at 1).
+ *
+ * @remarks
+ * Lines are split by \r?\n, then joined by \n
+ *
+ * @param code - The code to split and prepend line numbers to
+ * @returns A string with the line annotated code
+ */
+function linefy(code: string): string {
+	return code
+		.split(/\r?\n/)
+		.map((line, idx) => `${idx + 1}: ${line}`)
+		.join('\n');
+}
+
 const gofmt = (code: string) => {
 	try {
 		// check if gofmt is installed
@@ -32,12 +49,13 @@ const gofmt = (code: string) => {
 			return formatter.stdout;
 		}
 	} catch (e: any) {
-		// we silently ignore the error on purpose
-		// It's not a must to prettify the code
+		// If the error is due to gofmt not being installed, we ignore it
+		// on purpose. Otherwise we throw an error with both the code and
+		// the error message returned by gofmt.
 		if (e instanceof Error && e.message.indexOf('ENOENT') >= 0) {
 			console.error('gofmt is not installed. If you want to prettify the generated code, please install gofmt');
 		} else {
-			throw e;
+			throw new Error(`failed to format:\n${linefy(code)}\n\n${e}`);
 		}
 	}
 	return code;

--- a/packages/golang-client/src/index.ts
+++ b/packages/golang-client/src/index.ts
@@ -34,7 +34,11 @@ const gofmt = (code: string) => {
 	} catch (e: any) {
 		// we silently ignore the error on purpose
 		// It's not a must to prettify the code
-		console.error('gofmt is not installed. If you want to prettify the generated code, please install gofmt');
+		if (e instanceof Error && e.message.indexOf('ENOENT') >= 0) {
+			console.error('gofmt is not installed. If you want to prettify the generated code, please install gofmt');
+		} else {
+			throw e;
+		}
 	}
 	return code;
 };

--- a/packages/golang-client/src/index.ts
+++ b/packages/golang-client/src/index.ts
@@ -249,7 +249,7 @@ const JSONSchemaToGolangStruct = (schema: JSONSchema, structName: string, withEr
 			},
 			leave: (name, isRequired, isArray) => {
 				if (name) {
-					out += ` \`json:"${name},omitempty"\` `;
+					out += ` \`json:"${name},omitempty"\`\n`;
 				}
 			},
 		},


### PR DESCRIPTION
- fix: don't swallow gofmt errors, except gofmt being not present
- fix: go code generated from JSON mdel was missing a \n after slices

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `make test`
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)

<!--
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->
