### PR TITLE
fix: avoid overwriting the shared graphql_datasource.Factory instance

### DIFF
--- a/pkg/datasources/database/datasource.go
+++ b/pkg/datasources/database/datasource.go
@@ -877,7 +877,7 @@ type Factory struct {
 	Log           abstractlogger.Logger
 }
 
-func (f *Factory) WithHTTPClient(client *http.Client) *Factory {
+func (f *Factory) CopyWithHTTPClient(client *http.Client) *Factory {
 	return &Factory{
 		Client:        client,
 		engineFactory: f.engineFactory,

--- a/pkg/datasources/oas/oas_datasource.go
+++ b/pkg/datasources/oas/oas_datasource.go
@@ -49,7 +49,7 @@ type Factory struct {
 	Client *http.Client
 }
 
-func (f *Factory) WithHTTPClient(client *http.Client) *Factory {
+func (f *Factory) CopyWithHTTPClient(client *http.Client) *Factory {
 	return &Factory{
 		Client: client,
 	}

--- a/pkg/engineconfigloader/engineconfigloader.go
+++ b/pkg/engineconfigloader/engineconfigloader.go
@@ -169,7 +169,7 @@ func (d *DefaultFactoryResolver) Resolve(ds *wgpb.DataSourceConfiguration) (plan
 			if err != nil {
 				return nil, err
 			}
-			return d.rest.WithHTTPClient(client), nil
+			return d.rest.CopyWithHTTPClient(client), nil
 		}
 		return d.rest, nil
 	case wgpb.DataSourceKind_STATIC:
@@ -185,7 +185,7 @@ func (d *DefaultFactoryResolver) Resolve(ds *wgpb.DataSourceConfiguration) (plan
 			if err != nil {
 				return nil, err
 			}
-			return d.database.WithHTTPClient(client), nil
+			return d.database.CopyWithHTTPClient(client), nil
 		}
 		return d.database, nil
 	default:

--- a/pkg/engineconfigloader/engineconfigloader.go
+++ b/pkg/engineconfigloader/engineconfigloader.go
@@ -164,7 +164,9 @@ func (d *DefaultFactoryResolver) Resolve(ds *wgpb.DataSourceConfiguration) (plan
 			if err != nil {
 				return nil, err
 			}
-			d.graphql.HTTPClient = client
+			graphql := *d.graphql
+			graphql.HTTPClient = client
+			return &graphql, nil
 		}
 		return d.graphql, nil
 	case wgpb.DataSourceKind_REST:


### PR DESCRIPTION
As pointed by Sergey, this is shared among the different data sources so
we can't overwrite it. Make a copy and overwrite its HTTPClient field in
it.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `make test`
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [x] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)

<!--
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->
