### PR TITLE
feat: make WunderGraphConfigApplicationConfig.cors optional

### DIFF
--- a/packages/sdk/src/configure/index.ts
+++ b/packages/sdk/src/configure/index.ts
@@ -86,7 +86,7 @@ export interface WunderGraphConfigApplicationConfig {
 	codeGenerators?: CodeGen[];
 	options?: NodeOptions;
 	server?: WunderGraphHooksAndServerConfig;
-	cors: WunderGraphCorsConfiguration;
+	cors?: WunderGraphCorsConfiguration;
 	s3UploadProvider?: S3Provider;
 	operations?: OperationsConfiguration;
 	authorization?: {
@@ -318,12 +318,12 @@ const resolveConfig = async (config: WunderGraphConfigApplicationConfig): Promis
 	};
 
 	const cors: CorsConfiguration = {
-		maxAge: config.cors.maxAge || 60,
-		allowedHeaders: config.cors.allowedHeaders || [],
-		allowedMethods: config.cors.allowedMethods || [],
-		exposedHeaders: config.cors.exposedHeaders || [],
-		allowCredentials: config.cors.allowCredentials || false,
-		allowedOrigins: config.cors.allowedOrigins
+		maxAge: config.cors?.maxAge || 60,
+		allowedHeaders: config.cors?.allowedHeaders || [],
+		allowedMethods: config.cors?.allowedMethods || [],
+		exposedHeaders: config.cors?.exposedHeaders || [],
+		allowCredentials: config.cors?.allowCredentials || false,
+		allowedOrigins: (config.cors?.allowedOrigins || [])
 			.map((origin) =>
 				typeof origin === 'string' && origin.endsWith('/') ? origin.substring(0, origin.length - 1) : origin
 			)

--- a/packages/sdk/src/configure/index.ts
+++ b/packages/sdk/src/configure/index.ts
@@ -323,7 +323,7 @@ const resolveConfig = async (config: WunderGraphConfigApplicationConfig): Promis
 		allowedMethods: config.cors?.allowedMethods || [],
 		exposedHeaders: config.cors?.exposedHeaders || [],
 		allowCredentials: config.cors?.allowCredentials || false,
-		allowedOrigins: (config.cors?.allowedOrigins || [])
+		allowedOrigins: (config.cors?.allowedOrigins || [new EnvironmentVariable('WG_ALLOWED_ORIGIN', '*')])
 			.map((origin) =>
 				typeof origin === 'string' && origin.endsWith('/') ? origin.substring(0, origin.length - 1) : origin
 			)


### PR DESCRIPTION
If nothing is provided, default to allowing all origins

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `make test`
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [x] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)

<!--
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->
