### PR TITLE
chore: increase go linter timeout in CI to 2 minutes

### DIFF
--- a/.github/workflows/engine-ci.yaml
+++ b/.github/workflows/engine-ci.yaml
@@ -9,6 +9,7 @@ on:
       - 'types/**/*'
       - 'go.mod'
       - 'go.sum'
+      - '.github/workflows/engine-ci.yaml'
       - '!examples/**/*'
       - '!**/*.md'
   pull_request:
@@ -20,6 +21,7 @@ on:
       - 'types/**/*'
       - 'go.mod'
       - 'go.sum'
+      - '.github/workflows/engine-ci.yaml'
       - '!examples/**/*'
       - '!**/*.md'
 

--- a/.github/workflows/engine-ci.yaml
+++ b/.github/workflows/engine-ci.yaml
@@ -73,6 +73,9 @@ jobs:
 
       - name: Linters
         uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.50
+          args: --timeout 2m
 
       - name: Run unit and integration tests
         run: make test-go


### PR DESCRIPTION
1 minute seems a bit tight and is timing out from time to time.
Also, pin the golangci version to avoid having a new release trigger new
errors.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->


<!--
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->
