### PR TITLE
feat: add flag for disabling environment loading from file

### DIFF
--- a/cli/commands/root.go
+++ b/cli/commands/root.go
@@ -182,8 +182,8 @@ func init() {
 	viper.SetDefault("API_URL", "https://api.wundergraph.com")
 
 	rootCmd.PersistentFlags().StringVarP(&rootFlags.CliLogLevel, "cli-log-level", "l", "info", "sets the CLI log level")
-	rootCmd.PersistentFlags().BoolVar(&disableEnvFile, "no-env", false, "disables loading environment variables from a file")
-	rootCmd.PersistentFlags().StringVarP(&DotEnvFile, "env", "e", defaultDotEnvFilename, "allows you to set environment variables from an env file")
+	rootCmd.PersistentFlags().BoolVar(&disableEnvFile, "no-env-file", false, "disables loading environment variables from a file")
+	rootCmd.PersistentFlags().StringVarP(&DotEnvFile, "env-file", "e", defaultDotEnvFilename, "allows you to set environment variables from an env file")
 	rootCmd.PersistentFlags().BoolVar(&rootFlags.DebugMode, "debug", false, "enables the debug mode so that all requests and responses will be logged")
 	rootCmd.PersistentFlags().BoolVar(&rootFlags.PrettyLogs, "pretty-logging", false, "switches to human readable format")
 	rootCmd.PersistentFlags().StringVar(&_wunderGraphDirConfig, "wundergraph-dir", files.WunderGraphDirName, "path to your .wundergraph directory")

--- a/cli/commands/up.go
+++ b/cli/commands/up.go
@@ -294,7 +294,6 @@ var upCmd = &cobra.Command{
 
 func init() {
 	upCmd.PersistentFlags().BoolVar(&upCmdPrettyLogging, "pretty-logging", true, "switches the logging to human readable format")
-	upCmd.PersistentFlags().StringVar(&upCmdEnvFile, "env-file", ".env", "allows you to set environment variables from an env file")
 
 	rootCmd.AddCommand(upCmd)
 }

--- a/cli/commands/up.go
+++ b/cli/commands/up.go
@@ -24,6 +24,7 @@ import (
 const UpCmdName = "up"
 
 var upCmdPrettyLogging bool
+var upCmdEnvFile string
 
 // upCmd represents the up command
 var upCmd = &cobra.Command{
@@ -293,6 +294,7 @@ var upCmd = &cobra.Command{
 
 func init() {
 	upCmd.PersistentFlags().BoolVar(&upCmdPrettyLogging, "pretty-logging", true, "switches the logging to human readable format")
+	upCmd.PersistentFlags().StringVar(&upCmdEnvFile, "env-file", ".env", "allows you to set environment variables from an env file")
 
 	rootCmd.AddCommand(upCmd)
 }


### PR DESCRIPTION
- Add --no-env, which disables the .env file
- Refactor the checks for environment files that do not exist and
report a failure if the environment file is set to something else than
the default, but does not exist.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->


<!--
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->
