### PR TITLE
fix: operation metadata in react provider

### DIFF
--- a/packages/sdk/src/codegen/templates/typescript/react.native.provider.template.ts
+++ b/packages/sdk/src/codegen/templates/typescript/react.native.provider.template.ts
@@ -22,6 +22,15 @@ export interface Config {
     };
 }
 
+const operationMetadata: OperationMetadata = {
+{{#each allOperations}}
+    {{operationName}}: {
+        requiresAuthentication: {{requiresAuthentication}}
+        }
+    {{#unless @last}},{{/unless}}
+{{/each}}
+}
+
 export const WunderGraphContext = createContext<Config | undefined>(undefined);
 
 export interface Props {
@@ -40,7 +49,7 @@ export const WunderGraphProvider: FunctionComponent<Props> = ({
     const [refetchMountedQueries, setRefetchMountedQueries] = useState(new Date());
     const queryCache: {[key:string]:Object} = {};
     const client = useMemo<Client>(() => {
-        const client = new Client({baseURL: endpoint, extraHeaders});
+        const client = new Client({baseURL: endpoint, extraHeaders, operationMetadata});
         client.setLogoutCallback(()=>{
             Object.keys(queryCache).forEach(key => {
                 delete queryCache[key];

--- a/packages/sdk/src/codegen/templates/typescript/react.provider.template.ts
+++ b/packages/sdk/src/codegen/templates/typescript/react.provider.template.ts
@@ -21,6 +21,15 @@ export interface Config {
     };
 }
 
+const operationMetadata: OperationMetadata = {
+{{#each allOperations}}
+    {{operationName}}: {
+        requiresAuthentication: {{requiresAuthentication}}
+        }
+    {{#unless @last}},{{/unless}}
+{{/each}}
+}
+
 export const WunderGraphContext = createContext<Config | undefined>(undefined);
 
 export interface Props {
@@ -36,7 +45,7 @@ export const WunderGraphProvider: FunctionComponent<Props> = ({ endpoint, extraH
     const [refetchMountedQueries, setRefetchMountedQueries] = useState(new Date());
     const queryCache: {[key:string]:Object} = {};
     const client = useMemo<Client>(() => {
-        const client = new Client({baseURL: endpoint, extraHeaders, customFetch });
+        const client = new Client({baseURL: endpoint, extraHeaders, customFetch, operationMetadata});
         client.setLogoutCallback(()=>{
             Object.keys(queryCache).forEach(key => {
                 delete queryCache[key];

--- a/packages/sdk/src/codegen/templates/typescript/react.ts
+++ b/packages/sdk/src/codegen/templates/typescript/react.ts
@@ -7,12 +7,14 @@ import { OperationType } from '@wundergraph/protobuf';
 import { template as providerTemplate } from './react.provider.template';
 import { template as reactNativeProviderTemplate } from './react.native.provider.template';
 import { template as hooksTemplate } from './react.hooks.template';
-import { hasInput, isNotInternal } from './helpers';
+import { hasInput, isNotInternal, queries as allQueries } from './helpers';
 
 export class TypescriptReactProvider implements Template {
 	generate(config: ResolvedWunderGraphConfig): Promise<TemplateOutputFile[]> {
 		const tmpl = Handlebars.compile(providerTemplate);
+		const allOperations = allQueries(config.application, false);
 		const content = tmpl({
+			allOperations: allOperations,
 			hasAuthProviders: config.authentication.cookieBased.length !== 0,
 		});
 		return Promise.resolve([
@@ -28,7 +30,9 @@ export class TypescriptReactProvider implements Template {
 export class TypescriptReactNativeProvider implements Template {
 	generate(config: ResolvedWunderGraphConfig): Promise<TemplateOutputFile[]> {
 		const tmpl = Handlebars.compile(reactNativeProviderTemplate);
+		const allOperations = allQueries(config.application, false);
 		const content = tmpl({
+			allOperations: allOperations,
 			hasAuthProviders: config.authentication.cookieBased.length !== 0,
 		});
 		return Promise.resolve([


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Adds operation metadata to react provider's client instantiation.

#### Checklist

- [x] run `make test`
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)

<!--
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->
