### PR TITLE
chore: rename X-Cache header to X-Wg-Cache

### DIFF
--- a/pkg/apihandler/apihandler.go
+++ b/pkg/apihandler/apihandler.go
@@ -57,9 +57,10 @@ import (
 )
 
 const (
-	WG_PREFIX    = "wg_"
-	WG_LIVE      = WG_PREFIX + "live"
-	WG_VARIABLES = WG_PREFIX + "variables"
+	WG_PREFIX       = "wg_"
+	WG_LIVE         = WG_PREFIX + "live"
+	WG_VARIABLES    = WG_PREFIX + "variables"
+	WG_CACHE_HEADER = "X-Wg-Cache"
 )
 
 type Builder struct {
@@ -1111,7 +1112,7 @@ func (h *QueryHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		item, hit := h.cache.Get(ctx.Context, cacheKey)
 		if hit {
 
-			w.Header().Set("X-Cache", "HIT")
+			w.Header().Set(WG_CACHE_HEADER, "HIT")
 
 			_, _ = buf.Write(item.Data)
 
@@ -1145,7 +1146,7 @@ func (h *QueryHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			_, _ = buf.WriteTo(w)
 			return
 		}
-		w.Header().Set("X-Cache", "MISS")
+		w.Header().Set(WG_CACHE_HEADER, "MISS")
 	}
 
 	if h.hooksConfig.preResolve {

--- a/pkg/apihandler/apihandler_test.go
+++ b/pkg/apihandler/apihandler_test.go
@@ -203,7 +203,7 @@ func TestQueryHandler_Caching(t *testing.T) {
 	res.Headers().ValueEqual("Etag", []string{"W/\"15825766644480138524\""})
 	res.Headers().ValueEqual("Cache-Control", []string{"public, max-age=2, stale-while-revalidate=0"})
 	res.Headers().ValueEqual("Age", []string{"0"})
-	res.Headers().ValueEqual("X-Cache", []string{"MISS"})
+	res.Headers().ValueEqual(WG_CACHE_HEADER, []string{"MISS"})
 	res.Body().Equal(`{"data":{"me":{"name":"Jens"}}}`)
 
 	handler.cacheConfig.public = false
@@ -218,7 +218,7 @@ func TestQueryHandler_Caching(t *testing.T) {
 	res.Headers().ValueEqual("Etag", []string{"W/\"15825766644480138524\""})
 	res.Headers().ValueEqual("Cache-Control", []string{"private, max-age=2, stale-while-revalidate=0"})
 	res.Headers().ValueEqual("Age", []string{"1"})
-	res.Headers().ValueEqual("X-Cache", []string{"HIT"})
+	res.Headers().ValueEqual(WG_CACHE_HEADER, []string{"HIT"})
 	res.Body().Equal(`{"data":{"me":{"name":"Jens"}}}`)
 
 	assert.Equal(t, 1, resolver.invocations)
@@ -232,7 +232,7 @@ func TestQueryHandler_Caching(t *testing.T) {
 	res.Headers().ValueEqual("Etag", []string{"W/\"15825766644480138524\""})
 	res.Headers().ValueEqual("Cache-Control", []string{"private, max-age=2, stale-while-revalidate=0"})
 	res.Headers().ValueEqual("Age", []string{"1"})
-	res.Headers().ValueEqual("X-Cache", []string{"HIT"})
+	res.Headers().ValueEqual(WG_CACHE_HEADER, []string{"HIT"})
 	res.Body().Empty()
 
 	time.Sleep(time.Second * 2)
@@ -245,7 +245,7 @@ func TestQueryHandler_Caching(t *testing.T) {
 	res.Headers().ValueEqual("Etag", []string{"W/\"15825766644480138524\""})
 	res.Headers().ValueEqual("Cache-Control", []string{"private, max-age=2, stale-while-revalidate=0"})
 	res.Headers().ValueEqual("Age", []string{"0"})
-	res.Headers().ValueEqual("X-Cache", []string{"MISS"})
+	res.Headers().ValueEqual(WG_CACHE_HEADER, []string{"MISS"})
 	res.Body().Equal(`{"data":{"me":{"name":"Jens"}}}`)
 
 	assert.Equal(t, 2, resolver.invocations)
@@ -261,7 +261,7 @@ func TestQueryHandler_Caching(t *testing.T) {
 	res.Headers().ValueEqual("Etag", []string{"W/\"15825766644480138524\""})
 	res.Headers().ValueEqual("Cache-Control", []string{"private, max-age=2, stale-while-revalidate=0"})
 	res.Headers().ValueEqual("Age", []string{"1"})
-	res.Headers().ValueEqual("X-Cache", []string{"HIT"})
+	res.Headers().ValueEqual(WG_CACHE_HEADER, []string{"HIT"})
 	res.Body().Empty()
 
 	assert.Equal(t, 2, resolver.invocations)


### PR DESCRIPTION
refactor the cache key to a constant to avoid repeating it

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

<!--
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->
