### PR TITLE
fix: don't swallow errors in wunderctl loadoperations

### DIFF
--- a/cli/commands/loadoperations.go
+++ b/cli/commands/loadoperations.go
@@ -19,7 +19,7 @@ var loadoperationsCmd = &cobra.Command{
 		out := loader.Load(args[0], args[1], args[2])
 		// TODO: migrate to writing it to file because it can infer with logs
 		// or log and print to two different streams and respect that on the consumer side
-		fmt.Println(out)
+		fmt.Println(out.String())
 		return nil
 	},
 	Args: cobra.ExactArgs(3),


### PR DESCRIPTION
Always return the Output to the caller, then convert it to string
before printing. Return zero in all cases, since the TS side uses the
exit code to determine wether to parse the outout or print it as a raw
error.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->


<!--
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->
