### PR TITLE
feat: ensure wunderctl always call the same copy when calling itself

### DIFF
--- a/cli/commands/generate.go
+++ b/cli/commands/generate.go
@@ -62,6 +62,7 @@ var generateCmd = &cobra.Command{
 				fmt.Sprintf("WG_ENABLE_INTROSPECTION_CACHE=%t", !disableCache),
 				fmt.Sprintf("WG_ENABLE_INTROSPECTION_OFFLINE=%t", offline),
 				fmt.Sprintf("WG_DIR_ABS=%s", wunderGraphDir),
+				fmt.Sprintf("%s=%s", wunderctlBinaryPathEnvKey, wunderctlBinaryPath),
 			),
 		})
 		defer func() {

--- a/cli/commands/generate.go
+++ b/cli/commands/generate.go
@@ -62,7 +62,7 @@ var generateCmd = &cobra.Command{
 				fmt.Sprintf("WG_ENABLE_INTROSPECTION_CACHE=%t", !disableCache),
 				fmt.Sprintf("WG_ENABLE_INTROSPECTION_OFFLINE=%t", offline),
 				fmt.Sprintf("WG_DIR_ABS=%s", wunderGraphDir),
-				fmt.Sprintf("%s=%s", wunderctlBinaryPathEnvKey, wunderctlBinaryPath),
+				fmt.Sprintf("%s=%s", wunderctlBinaryPathEnvKey, wunderctlBinaryPath()),
 			),
 		})
 		defer func() {

--- a/cli/commands/root.go
+++ b/cli/commands/root.go
@@ -45,6 +45,7 @@ var (
 	_wunderGraphDirConfig string
 	disableCache          bool
 	clearCache            bool
+	wunderctlBinaryPath   string
 
 	rootFlags helpers.RootFlags
 
@@ -175,14 +176,15 @@ func Execute(buildInfo node.BuildInfo, githubAuthDemo node.GitHubAuthDemo) {
 func setupWunderctlBinaryPath() {
 	// Variable might be set, maybe by us or maybe by the
 	// user, but we never override it
-	_, isSet := os.LookupEnv(wunderctlBinaryPathEnvKey)
+	value, isSet := os.LookupEnv(wunderctlBinaryPathEnvKey)
 	if !isSet {
 		// Variable is not set, find out our path and set it
 		exe, err := os.Executable()
 		if err == nil {
-			os.Setenv(wunderctlBinaryPathEnvKey, exe)
+			value = exe
 		}
 	}
+	wunderctlBinaryPath = value
 }
 
 func init() {

--- a/cli/commands/root.go
+++ b/cli/commands/root.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/fatih/color"
@@ -174,17 +173,15 @@ func Execute(buildInfo node.BuildInfo, githubAuthDemo node.GitHubAuthDemo) {
 }
 
 func setupWunderctlBinaryPath() {
-	for _, v := range os.Environ() {
-		if strings.HasPrefix(v, wunderctlBinaryPathEnvKey+"=") {
-			// Variable is set, maybe by us or maybe by the
-			// user, but we never override it
-			return
+	// Variable might be set, maybe by us or maybe by the
+	// user, but we never override it
+	_, isSet := os.LookupEnv(wunderctlBinaryPathEnvKey)
+	if !isSet {
+		// Variable is not set, find out our path and set it
+		exe, err := os.Executable()
+		if err == nil {
+			os.Setenv(wunderctlBinaryPathEnvKey, exe)
 		}
-	}
-	// Variable is not set, find out our path and set it
-	exe, err := os.Executable()
-	if err == nil {
-		os.Setenv(wunderctlBinaryPathEnvKey, exe)
 	}
 }
 

--- a/cli/commands/up.go
+++ b/cli/commands/up.go
@@ -85,6 +85,7 @@ var upCmd = &cobra.Command{
 			ScriptEnv: append(helpers.CliEnv(rootFlags),
 				fmt.Sprintf("WG_ENABLE_INTROSPECTION_CACHE=%t", !disableCache),
 				fmt.Sprintf("WG_DIR_ABS=%s", wunderGraphDir),
+				fmt.Sprintf("%s=%s", wunderctlBinaryPathEnvKey, wunderctlBinaryPath),
 			),
 		})
 
@@ -100,6 +101,7 @@ var upCmd = &cobra.Command{
 				"WG_DATA_SOURCE_POLLING_MODE=true",
 				fmt.Sprintf("WG_ENABLE_INTROSPECTION_CACHE=%t", !disableCache),
 				fmt.Sprintf("WG_DIR_ABS=%s", wunderGraphDir),
+				fmt.Sprintf("%s=%s", wunderctlBinaryPathEnvKey, wunderctlBinaryPath),
 			),
 		})
 

--- a/cli/commands/up.go
+++ b/cli/commands/up.go
@@ -85,7 +85,7 @@ var upCmd = &cobra.Command{
 			ScriptEnv: append(helpers.CliEnv(rootFlags),
 				fmt.Sprintf("WG_ENABLE_INTROSPECTION_CACHE=%t", !disableCache),
 				fmt.Sprintf("WG_DIR_ABS=%s", wunderGraphDir),
-				fmt.Sprintf("%s=%s", wunderctlBinaryPathEnvKey, wunderctlBinaryPath),
+				fmt.Sprintf("%s=%s", wunderctlBinaryPathEnvKey, wunderctlBinaryPath()),
 			),
 		})
 
@@ -101,7 +101,7 @@ var upCmd = &cobra.Command{
 				"WG_DATA_SOURCE_POLLING_MODE=true",
 				fmt.Sprintf("WG_ENABLE_INTROSPECTION_CACHE=%t", !disableCache),
 				fmt.Sprintf("WG_DIR_ABS=%s", wunderGraphDir),
-				fmt.Sprintf("%s=%s", wunderctlBinaryPathEnvKey, wunderctlBinaryPath),
+				fmt.Sprintf("%s=%s", wunderctlBinaryPathEnvKey, wunderctlBinaryPath()),
 			),
 		})
 

--- a/packages/wunderctl/src/binarypath.ts
+++ b/packages/wunderctl/src/binarypath.ts
@@ -52,5 +52,8 @@ export const wunderctlName = (): string => {
 export const binaryDir = path.join(__dirname, '..', 'download');
 
 export const wunderctlBinaryPath = (): string => {
+	if (process.env.WUNDERCTL_BINARY_PATH) {
+		return process.env.WUNDERCTL_BINARY_PATH;
+	}
 	return path.join(binaryDir, wunderctlName());
 };


### PR DESCRIPTION
Introduce a WUNDERCTL_BINARY_PATH environment variable. This can
be set either by the user or either by wunderctl itself. On startup,
wunderctl checks if the variable is unset and if it is, then it
sets it to its own path. The TS side now checks for this new variable
and when it's non-empty, it overrides the path to the wunderctl binary.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

<!--
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->
