### PR TITLE
fix: dont enforce prettyLogging for all commands

### DIFF
--- a/cli/commands/loadoperations.go
+++ b/cli/commands/loadoperations.go
@@ -8,10 +8,12 @@ import (
 	"github.com/wundergraph/wundergraph/pkg/loadoperations"
 )
 
+const LoadOperationsCmdName = "loadoperations"
+
 var loadoperationsCmd = &cobra.Command{
-	Use:   "loadoperations",
-	Short: "loads the operations, internally used by the wundergraph SDK",
-	Long:  `loadoperations %operations path% %fragments path% %schema path%`,
+	Use:     LoadOperationsCmdName,
+	Short:   "Loads the operations, internally used by the WunderGraph SDK",
+	Example: fmt.Sprintf(`wunderctl %s $operationsRootPath $fragmentsRootPath $schemaFilePath`, LoadOperationsCmdName),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		loader := loadoperations.Loader{}
 		out := loader.Load(args[0], args[1], args[2])

--- a/cli/commands/loadoperations.go
+++ b/cli/commands/loadoperations.go
@@ -15,6 +15,8 @@ var loadoperationsCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		loader := loadoperations.Loader{}
 		out := loader.Load(args[0], args[1], args[2])
+		// TODO: migrate to writing it to file because it can infer with logs
+		// or log and print to two different streams and respect that on the consumer side
 		fmt.Println(out)
 		return nil
 	},

--- a/cli/commands/root.go
+++ b/cli/commands/root.go
@@ -70,12 +70,12 @@ You can opt out of this by setting the following environment variable: WUNDERGRA
 		switch cmd.Name() {
 		// skip any setup to avoid logging anything
 		// because the command output data on stdout
-		case "loadoperations":
+		case LoadOperationsCmdName:
 			return nil
 			// up command has a different default for global pretty logging
 			// we can't overwrite the default value in the init function because
 			// it would overwrite the default value for all other commands
-		case "up":
+		case UpCmdName:
 			rootFlags.PrettyLogs = upCmdPrettyLogging
 		}
 

--- a/cli/commands/root.go
+++ b/cli/commands/root.go
@@ -66,16 +66,20 @@ wunderctl is gathering anonymous usage data so that we can better understand how
 You can opt out of this by setting the following environment variable: WUNDERGRAPH_DISABLE_METRICS
 `,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+
 		switch cmd.Name() {
+		// skip any setup to avoid logging anything
+		// because the command output data on stdout
 		case "loadoperations":
-			// skip any setup for loadoperations to avoid logging anything
-			// as sdk uses stdout for the generated operations list
-			// TODO: migrate to writing it to a file
 			return nil
+			// up command has a different default for global pretty logging
+			// we can't overwrite the default value in the init function because
+			// it would overwrite the default value for all other commands
+		case "up":
+			rootFlags.PrettyLogs = upCmdPrettyLogging
 		}
 
 		logging.Init(rootFlags.PrettyLogs, rootFlags.DebugMode)
-
 		if rootFlags.DebugMode {
 			// override log level to debug
 			rootFlags.CliLogLevel = "debug"
@@ -175,7 +179,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&rootFlags.CliLogLevel, "cli-log-level", "l", "info", "sets the CLI log level")
 	rootCmd.PersistentFlags().StringVarP(&DotEnvFile, "env", "e", ".env", "allows you to set environment variables from an env file")
 	rootCmd.PersistentFlags().BoolVar(&rootFlags.DebugMode, "debug", false, "enables the debug mode so that all requests and responses will be logged")
-	rootCmd.PersistentFlags().BoolVar(&rootFlags.PrettyLogs, "pretty-logging", false, "switches the logging to human readable format")
+	rootCmd.PersistentFlags().BoolVar(&rootFlags.PrettyLogs, "pretty-logging", false, "switches to human readable format")
 	rootCmd.PersistentFlags().StringVar(&_wunderGraphDirConfig, "wundergraph-dir", files.WunderGraphDirName, "path to your .wundergraph directory")
 	rootCmd.PersistentFlags().BoolVar(&disableCache, "no-cache", false, "disables local caches")
 	rootCmd.PersistentFlags().BoolVar(&clearCache, "clear-cache", false, "clears local caches during startup")

--- a/cli/commands/up.go
+++ b/cli/commands/up.go
@@ -21,13 +21,14 @@ import (
 	"github.com/wundergraph/wundergraph/pkg/webhooks"
 )
 
+var upCmdPrettyLogging bool
+
 // upCmd represents the up command
 var upCmd = &cobra.Command{
 	Use:   "up",
-	Short: "Start the WunderGraph application in the current dir",
-	Long:  `Make sure wundergraph.config.json is present or set the flag accordingly`,
+	Short: "Starts WunderGraph in development mode",
+	Long:  "Start the WunderGraph application in development mode and watch for changes",
 	RunE: func(cmd *cobra.Command, args []string) error {
-
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -289,7 +290,7 @@ var upCmd = &cobra.Command{
 }
 
 func init() {
-	upCmd.PersistentFlags().BoolVar(&rootFlags.PrettyLogs, "pretty-logging", true, "switches the logging to human readable format")
+	upCmd.PersistentFlags().BoolVar(&upCmdPrettyLogging, "pretty-logging", true, "switches the logging to human readable format")
 
 	rootCmd.AddCommand(upCmd)
 }

--- a/cli/commands/up.go
+++ b/cli/commands/up.go
@@ -21,11 +21,13 @@ import (
 	"github.com/wundergraph/wundergraph/pkg/webhooks"
 )
 
+const UpCmdName = "up"
+
 var upCmdPrettyLogging bool
 
 // upCmd represents the up command
 var upCmd = &cobra.Command{
-	Use:   "up",
+	Use:   UpCmdName,
 	Short: "Starts WunderGraph in development mode",
 	Long:  "Start the WunderGraph application in development mode and watch for changes",
 	RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
https://linear.app/wundergraph/issue/ENG-641/dont-enforce-pretty-logging-for-all-wunderctl-commands

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `make test`
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)

<!--
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->
