### PR TITLE
fix: skip introspection cache when OpenAPI source is a file

### DIFF
--- a/packages/sdk/src/definition/index.ts
+++ b/packages/sdk/src/definition/index.ts
@@ -603,11 +603,16 @@ export const introspect = {
 			return new MongoDBApi(schema, dataSources, fields, types, interpolateVariableDefinitionAsJSON);
 		}),
 	federation: introspectFederation,
-	openApi: async (introspection: OpenAPIIntrospection): Promise<RESTApi> =>
-		introspectWithCache(introspection, async (introspection: OpenAPIIntrospection): Promise<RESTApi> => {
+	openApi: async (introspection: OpenAPIIntrospection): Promise<RESTApi> => {
+		const generator = async (introspection: OpenAPIIntrospection): Promise<RESTApi> => {
 			const spec = loadOpenApi(introspection);
 			return await openApiSpecificationToRESTApiObject(spec, introspection);
-		}),
+		};
+		if (introspection.source.kind === 'file') {
+			return generator(introspection);
+		}
+		return introspectWithCache(introspection, generator);
+	},
 };
 
 export const buildUpstreamAuthentication = (upstream: HTTPUpstream): UpstreamAuthentication | undefined => {

--- a/packages/sdk/src/definition/index.ts
+++ b/packages/sdk/src/definition/index.ts
@@ -608,6 +608,9 @@ export const introspect = {
 			const spec = loadOpenApi(introspection);
 			return await openApiSpecificationToRESTApiObject(spec, introspection);
 		};
+		// If the source is a file we have all data required to perform the instrospection
+		// locally, which is also fast. Skip the cache in this case, so changes to the file
+		// are picked up immediately without requiring a cache flush.
 		if (introspection.source.kind === 'file') {
 			return generator(introspection);
 		}


### PR DESCRIPTION
This prevents the cache from getting in the way when the underlying file
changes. Since all the data to generate the introspection is local, we
don't need the cache to able to introspect without hitting the network.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

<!--
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->
