### PR TITLE
feat: disable response caching when returning HTTP errors

### DIFF
--- a/pkg/apihandler/apihandler.go
+++ b/pkg/apihandler/apihandler.go
@@ -192,6 +192,10 @@ func (r *Builder) BuildAndMountApiHandler(ctx context.Context, router *mux.Route
 		abstractlogger.Int("numOfOperations", len(api.Operations)),
 	)
 
+	// Default Cache-Control, handlers might override it
+	defaultCacheControl := cachecontrol.Disabled()
+	r.router.Use(defaultCacheControl.Middleware())
+
 	if len(api.Hosts) > 0 {
 		r.router.Use(func(handler http.Handler) http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/apihandler/apihandler.go
+++ b/pkg/apihandler/apihandler.go
@@ -193,7 +193,8 @@ func (r *Builder) BuildAndMountApiHandler(ctx context.Context, router *mux.Route
 	)
 
 	// Default Cache-Control, handlers might override it
-	defaultCacheControl := cachecontrol.Disabled()
+	var defaultCacheControl cachecontrol.Header
+	defaultCacheControl.DisableCache()
 	r.router.Use(defaultCacheControl.Middleware())
 
 	if len(api.Hosts) > 0 {
@@ -2260,7 +2261,9 @@ func hookBaseData(r *http.Request, buf []byte, variables []byte, response []byte
 }
 
 func setSubscriptionHeaders(w http.ResponseWriter) {
-	cachecontrol.Disabled().Set(w)
+	var cc cachecontrol.Header
+	cc.DisableCache()
+	cc.Set(w)
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Connection", "keep-alive")
 	// allow unbuffered responses, it's used when it's necessary just to pass response through

--- a/pkg/apihandler/internalapihandler.go
+++ b/pkg/apihandler/internalapihandler.go
@@ -23,6 +23,7 @@ import (
 	"github.com/wundergraph/graphql-go-tools/pkg/engine/resolve"
 
 	"github.com/wundergraph/wundergraph/pkg/engineconfigloader"
+	"github.com/wundergraph/wundergraph/pkg/httperror"
 	"github.com/wundergraph/wundergraph/pkg/pool"
 	"github.com/wundergraph/wundergraph/pkg/wgpb"
 )
@@ -196,7 +197,7 @@ func (h *InternalApiHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer pool.PutBytesBuffer(bodyBuf)
 	_, err := io.Copy(bodyBuf, r.Body)
 	if err != nil && !errors.Is(err, io.EOF) {
-		http.Error(w, "bad request", http.StatusBadRequest)
+		httperror.Error(w, "bad request", http.StatusBadRequest)
 		return
 	}
 
@@ -210,7 +211,7 @@ func (h *InternalApiHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			abstractlogger.Error(err),
 			abstractlogger.String("url", r.RequestURI),
 		)
-		http.Error(w, "bad request", http.StatusBadRequest)
+		httperror.Error(w, "bad request", http.StatusBadRequest)
 		return
 	}
 
@@ -247,7 +248,7 @@ func (h *InternalApiHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	resolveErr := h.resolver.ResolveGraphQLResponse(ctx, h.preparedPlan.Response, nil, buf)
 	if resolveErr != nil {
 		h.log.Error("InternalApiHandler.ResolveGraphQLResponse", abstractlogger.Error(resolveErr))
-		http.Error(w, "unable to resolve", http.StatusInternalServerError)
+		httperror.Err(w, err, "unable to resolve")
 		return
 	}
 

--- a/pkg/authentication/authentication.go
+++ b/pkg/authentication/authentication.go
@@ -742,7 +742,7 @@ func (u *CookieUserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.Header()["ETag"] = []string{user.ETag}
-	cachecontrol.EnableCache(w, false, 0, 60)
+	cachecontrol.EnableForAuthentication(w)
 
 	user.RemoveInternalFields()
 	if r.Header.Get("Accept") != "application/json" {

--- a/pkg/authentication/authentication.go
+++ b/pkg/authentication/authentication.go
@@ -742,8 +742,7 @@ func (u *CookieUserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.Header()["ETag"] = []string{user.ETag}
-	var h cachecontrol.Header
-	h.Private().MaxAge(0).StaleWhileRevalidate(60).Set(w)
+	cachecontrol.EnableCache(w, false, 0, 60)
 
 	user.RemoveInternalFields()
 	if r.Header.Get("Accept") != "application/json" {

--- a/pkg/authentication/authentication.go
+++ b/pkg/authentication/authentication.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/wundergraph/wundergraph/pkg/cachecontrol"
 	"github.com/wundergraph/wundergraph/pkg/hooks"
+	"github.com/wundergraph/wundergraph/pkg/httperror"
 	"github.com/wundergraph/wundergraph/pkg/loadvariable"
 	"github.com/wundergraph/wundergraph/pkg/wgpb"
 )
@@ -355,7 +356,7 @@ func ValidateRedirectURIQueryParameter(matchString, matchRegex []string) func(ha
 				handler.ServeHTTP(w, r)
 				return
 			}
-			http.Error(w, "invalid redirect uri", http.StatusBadRequest)
+			httperror.Error(w, "invalid redirect uri", http.StatusBadRequest)
 		})
 	}
 }
@@ -813,7 +814,7 @@ type CSRFErrorHandler struct {
 
 func (u *CSRFErrorHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	resetUserCookies(w, r, !u.InsecureCookies)
-	http.Error(w, "forbidden", http.StatusForbidden)
+	httperror.Error(w, "forbidden", http.StatusForbidden)
 }
 
 // sanitizeDomain cleans up the host so that it can work on localhost

--- a/pkg/authentication/authentication.go
+++ b/pkg/authentication/authentication.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gorilla/securecookie"
 	"github.com/jensneuse/abstractlogger"
 
+	"github.com/wundergraph/wundergraph/pkg/cachecontrol"
 	"github.com/wundergraph/wundergraph/pkg/hooks"
 	"github.com/wundergraph/wundergraph/pkg/loadvariable"
 	"github.com/wundergraph/wundergraph/pkg/wgpb"
@@ -740,7 +741,8 @@ func (u *CookieUserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.Header()["ETag"] = []string{user.ETag}
-	w.Header().Set("Cache-Control", "private, max-age=0, stale-while-revalidate=60")
+	var h cachecontrol.Header
+	h.Private().MaxAge(0).StaleWhileRevalidate(60).Set(w)
 
 	user.RemoveInternalFields()
 	if r.Header.Get("Accept") != "application/json" {

--- a/pkg/authentication/oidc.go
+++ b/pkg/authentication/oidc.go
@@ -14,6 +14,8 @@ import (
 	"github.com/gorilla/securecookie"
 	"github.com/jensneuse/abstractlogger"
 	"golang.org/x/oauth2"
+
+	"github.com/wundergraph/wundergraph/pkg/httperror"
 )
 
 type OpenIDConnectCookieHandler struct {
@@ -87,7 +89,7 @@ func (h *OpenIDConnectCookieHandler) Register(authorizeRouter, callbackRouter *m
 	authorizeRouter.Path(fmt.Sprintf("/%s", config.ProviderID)).Methods(http.MethodGet).HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
 		if provider == nil {
-			http.Error(w, "oidc provider configuration error", http.StatusMethodNotAllowed)
+			httperror.Error(w, "oidc provider configuration error", http.StatusMethodNotAllowed)
 			return
 		}
 
@@ -168,7 +170,7 @@ func (h *OpenIDConnectCookieHandler) Register(authorizeRouter, callbackRouter *m
 	callbackRouter.Path(fmt.Sprintf("/%s", config.ProviderID)).Methods(http.MethodGet).HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
 		if provider == nil {
-			http.Error(w, "oidc provider configuration error", http.StatusMethodNotAllowed)
+			httperror.Error(w, "oidc provider configuration error", http.StatusMethodNotAllowed)
 			return
 		}
 

--- a/pkg/cachecontrol/cachecontrol.go
+++ b/pkg/cachecontrol/cachecontrol.go
@@ -22,3 +22,10 @@ func EnableCache(w http.ResponseWriter, publicOrPrivate bool, maxAge int, staleW
 	header := fmt.Sprintf("%s, max-age=%d, stale-while-revalidate=%d", visibility, maxAge, staleWhileRevalidate)
 	w.Header().Set("Cache-Control", header)
 }
+
+// EnableForAuthentication sets Cache-Control headers in the response appropriate for
+// storing the response to an authentication request
+func EnableForAuthentication(w http.ResponseWriter) {
+	// Rationale: https://github.com/wundergraph/wundergraph/pull/310#discussion_r1013011396
+	EnableCache(w, false, 0, 60)
+}

--- a/pkg/cachecontrol/cachecontrol.go
+++ b/pkg/cachecontrol/cachecontrol.go
@@ -59,7 +59,9 @@ func (h *Header) Middleware() func(next http.Handler) http.Handler {
 	}
 }
 
-func (h *Header) Disabled() *Header {
+// DisableCache removes all previous values and populates the headers with
+// values to disable all HTTP caching.
+func (h *Header) DisableCache() *Header {
 	h.values = append([]string(nil), "no-cache", "no-store", "must-revalidate")
 	return h
 }
@@ -90,11 +92,4 @@ func (h *Header) MaxAge(seconds int) *Header {
 // StaleWhileRevalidate appends a stale-while-revalidate header
 func (h *Header) StaleWhileRevalidate(seconds int) *Header {
 	return h.intHeader("stale-while-revalidate", seconds)
-}
-
-// Disabled is a shorthand for creating an empty Header
-// and calling its Disabled method.
-func Disabled() *Header {
-	var h Header
-	return h.Disabled()
 }

--- a/pkg/cachecontrol/cachecontrol.go
+++ b/pkg/cachecontrol/cachecontrol.go
@@ -1,0 +1,100 @@
+// Package cachecontrol implements functions for managing Cache-Control directives
+package cachecontrol
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control for
+// information on the different cache values. Not all
+
+// Header represents a series of values for a Cache-Control header.
+// The zero value is a valid an empty Cache-Control header. To set the
+// header use String(), Set() or Middleware().
+type Header struct {
+	values []string
+}
+
+func (h *Header) append(value string) *Header {
+	h.values = append(h.values, value)
+	return h
+}
+
+func (h *Header) filterOut(value string) *Header {
+	// Iterate backwards to not require index adjustment on delete
+	for ii := len(h.values) - 1; ii >= 0; ii-- {
+		if h.values[ii] == value {
+			h.values = append(h.values[:ii], h.values[ii+1:]...)
+		}
+	}
+	return h
+}
+
+func (h *Header) intHeader(name string, value int) *Header {
+	return h.append(name + "=" + strconv.Itoa(value))
+}
+
+// String returns the formatted Cache-Control header
+func (h *Header) String() string {
+	return strings.Join(h.values, ", ")
+}
+
+// Set sets the Cache-Control header into the given http.ResponseWriter
+// using h.String().
+func (h *Header) Set(w http.ResponseWriter) {
+	w.Header().Set("Cache-Control", h.String())
+}
+
+// Middleware returns an http.Handler compatible middleware that sets the
+// given Header as the Cache-Control header in the ResponseWriter, then calls
+// its next http.Handler.
+func (h *Header) Middleware() func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			h.Set(w)
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func (h *Header) Disabled() *Header {
+	h.values = append([]string(nil), "no-cache", "no-store", "must-revalidate")
+	return h
+}
+
+func (h *Header) Public() *Header {
+	return h.filterOut("private").append("public")
+
+}
+
+func (h *Header) Private() *Header {
+	return h.filterOut("public").append("private")
+}
+
+// PublicOrPrivate is a shorthand for calling Public() iff
+// isPublic is true, and calling Private() otherwise
+func (h *Header) PublicOrPrivate(isPublic bool) *Header {
+	if isPublic {
+		return h.Public()
+	}
+	return h.Private()
+}
+
+// MaxAge appends a max-age header
+func (h *Header) MaxAge(seconds int) *Header {
+	return h.intHeader("max-age", seconds)
+}
+
+// StaleWhileRevalidate appends a stale-while-revalidate header
+func (h *Header) StaleWhileRevalidate(seconds int) *Header {
+	return h.intHeader("stale-while-revalidate", seconds)
+}
+
+// Disabled is a shorthand for creating an empty Header
+// and calling its Disabled method.
+func Disabled() *Header {
+	var h Header
+	return h.Disabled()
+}

--- a/pkg/cachecontrol/cachecontrol.go
+++ b/pkg/cachecontrol/cachecontrol.go
@@ -2,94 +2,23 @@
 package cachecontrol
 
 import (
+	"fmt"
 	"net/http"
-	"strconv"
-	"strings"
 )
 
-// See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control for
-// information on the different cache values. Not all
-
-// Header represents a series of values for a Cache-Control header.
-// The zero value is a valid an empty Cache-Control header. To set the
-// header use String(), Set() or Middleware().
-type Header struct {
-	values []string
+// DisableCache sets the Cache-Control header in the given http.ResponseWriter
+// to disable all HTTP caching.
+func DisableCache(w http.ResponseWriter) {
+	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
 }
 
-func (h *Header) append(value string) *Header {
-	h.values = append(h.values, value)
-	return h
-}
-
-func (h *Header) filterOut(value string) *Header {
-	// Iterate backwards to not require index adjustment on delete
-	for ii := len(h.values) - 1; ii >= 0; ii-- {
-		if h.values[ii] == value {
-			h.values = append(h.values[:ii], h.values[ii+1:]...)
-		}
+// DisableCache sets the Cache-Control header in the given http.ResponseWriter
+// to enable HTTP caching with the given visibility, max-age and stale-while-revalidate
+func EnableCache(w http.ResponseWriter, publicOrPrivate bool, maxAge int, staleWhileRevalidate int) {
+	visibility := "private"
+	if publicOrPrivate {
+		visibility = "public"
 	}
-	return h
-}
-
-func (h *Header) intHeader(name string, value int) *Header {
-	return h.append(name + "=" + strconv.Itoa(value))
-}
-
-// String returns the formatted Cache-Control header
-func (h *Header) String() string {
-	return strings.Join(h.values, ", ")
-}
-
-// Set sets the Cache-Control header into the given http.ResponseWriter
-// using h.String().
-func (h *Header) Set(w http.ResponseWriter) {
-	w.Header().Set("Cache-Control", h.String())
-}
-
-// Middleware returns an http.Handler compatible middleware that sets the
-// given Header as the Cache-Control header in the ResponseWriter, then calls
-// its next http.Handler.
-func (h *Header) Middleware() func(next http.Handler) http.Handler {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			h.Set(w)
-			next.ServeHTTP(w, r)
-		})
-	}
-}
-
-// DisableCache removes all previous values and populates the headers with
-// values to disable all HTTP caching.
-func (h *Header) DisableCache() *Header {
-	h.values = append([]string(nil), "no-cache", "no-store", "must-revalidate")
-	return h
-}
-
-func (h *Header) Public() *Header {
-	return h.filterOut("private").append("public")
-
-}
-
-func (h *Header) Private() *Header {
-	return h.filterOut("public").append("private")
-}
-
-// PublicOrPrivate is a shorthand for calling Public() iff
-// isPublic is true, and calling Private() otherwise
-func (h *Header) PublicOrPrivate(isPublic bool) *Header {
-	if isPublic {
-		return h.Public()
-	}
-	return h.Private()
-}
-
-// MaxAge appends a max-age header
-func (h *Header) MaxAge(seconds int) *Header {
-	return h.intHeader("max-age", seconds)
-}
-
-// StaleWhileRevalidate appends a stale-while-revalidate header
-func (h *Header) StaleWhileRevalidate(seconds int) *Header {
-	return h.intHeader("stale-while-revalidate", seconds)
+	header := fmt.Sprintf("%s, max-age=%d, stale-while-revalidate=%d", visibility, maxAge, staleWhileRevalidate)
+	w.Header().Set("Cache-Control", header)
 }

--- a/pkg/cachecontrol/cachecontrol_test.go
+++ b/pkg/cachecontrol/cachecontrol_test.go
@@ -1,0 +1,79 @@
+package cachecontrol
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func testHeader(t *testing.T, expected string, fn func(h *Header)) {
+	var h Header
+	fn(&h)
+	assert.Equal(t, expected, h.String(), "header should have correct value")
+}
+
+func TestValues(t *testing.T) {
+	t.Run("disabled", func(t *testing.T) {
+		testHeader(t, "no-cache, no-store, must-revalidate", func(h *Header) {
+			h.Disabled()
+		})
+	})
+	t.Run("private then public", func(t *testing.T) {
+		testHeader(t, "public", func(h *Header) {
+			h.Private().Public()
+		})
+	})
+
+	t.Run("public or private", func(t *testing.T) {
+		testHeader(t, "public", func(h *Header) {
+			h.PublicOrPrivate(true)
+		})
+
+		testHeader(t, "private", func(h *Header) {
+			h.PublicOrPrivate(false)
+		})
+	})
+
+	t.Run("int headers", func(t *testing.T) {
+		testHeader(t, "max-age=0, stale-while-revalidate=0", func(h *Header) {
+			h.MaxAge(0).StaleWhileRevalidate(0)
+		})
+	})
+
+	var disabled Header
+	disabled.Disabled()
+	assert.Equal(t, disabled.String(), Disabled().String(), ".Disabled() should return the same header as Header.Disabled()")
+}
+
+func TestSet(t *testing.T) {
+	rec := httptest.NewRecorder()
+	var h Header
+	h.Public().Set(rec)
+	resp := rec.Result()
+	defer resp.Body.Close()
+	assert.Equal(t, h.String(), resp.Header.Get("Cache-Control"), "Set() should set Cache-Control")
+}
+
+func TestMiddleware(t *testing.T) {
+	const (
+		helloWorld = "Hello World"
+	)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, helloWorld)
+	})
+	var h Header
+	h.Private()
+	ts := httptest.NewServer(h.Middleware()(handler))
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL)
+	assert.Nil(t, err, "reading URL should not return an error")
+	defer resp.Body.Close()
+	data, err := io.ReadAll(resp.Body)
+	assert.Nil(t, err, "reading body should not return an error")
+	assert.Equal(t, helloWorld, string(data), "returned data should match what handler wrote")
+	assert.Equal(t, h.String(), resp.Header.Get("Cache-Control"), "cache control should be the same as the Header")
+}

--- a/pkg/cachecontrol/cachecontrol_test.go
+++ b/pkg/cachecontrol/cachecontrol_test.go
@@ -18,7 +18,7 @@ func testHeader(t *testing.T, expected string, fn func(h *Header)) {
 func TestValues(t *testing.T) {
 	t.Run("disabled", func(t *testing.T) {
 		testHeader(t, "no-cache, no-store, must-revalidate", func(h *Header) {
-			h.Disabled()
+			h.DisableCache()
 		})
 	})
 	t.Run("private then public", func(t *testing.T) {
@@ -42,10 +42,6 @@ func TestValues(t *testing.T) {
 			h.MaxAge(0).StaleWhileRevalidate(0)
 		})
 	})
-
-	var disabled Header
-	disabled.Disabled()
-	assert.Equal(t, disabled.String(), Disabled().String(), ".Disabled() should return the same header as Header.Disabled()")
 }
 
 func TestSet(t *testing.T) {

--- a/pkg/httperror/httperror.go
+++ b/pkg/httperror/httperror.go
@@ -12,7 +12,8 @@ import (
 
 // Error is a wrapper over http.Error which also sets the appropriate response headers
 func Error(w http.ResponseWriter, error string, code int) {
-	cachecontrol.Disabled().Set(w)
+	var h cachecontrol.Header
+	h.DisableCache().Set(w)
 	http.Error(w, error, code)
 }
 

--- a/pkg/httperror/httperror.go
+++ b/pkg/httperror/httperror.go
@@ -12,8 +12,7 @@ import (
 
 // Error is a wrapper over http.Error which also sets the appropriate response headers
 func Error(w http.ResponseWriter, error string, code int) {
-	var h cachecontrol.Header
-	h.DisableCache().Set(w)
+	cachecontrol.DisableCache(w)
 	http.Error(w, error, code)
 }
 

--- a/pkg/httperror/httperror.go
+++ b/pkg/httperror/httperror.go
@@ -1,0 +1,30 @@
+// Package httperror implements functions for returning HTTP errors to clients
+package httperror
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"os"
+
+	"github.com/wundergraph/wundergraph/pkg/cachecontrol"
+)
+
+// Error is a wrapper over http.Error which also sets the appropriate response headers
+func Error(w http.ResponseWriter, error string, code int) {
+	cachecontrol.Disabled().Set(w)
+	http.Error(w, error, code)
+}
+
+// Err determines the appropiate HTTP status code depending on err and if message
+// is empty, replaces it with the default message for the HTTP code
+func Err(w http.ResponseWriter, err error, message string) {
+	code := http.StatusInternalServerError
+	if errors.Is(err, context.DeadlineExceeded) || os.IsTimeout(err) {
+		code = http.StatusGatewayTimeout
+	}
+	if message == "" {
+		message = http.StatusText(code)
+	}
+	Error(w, message, code)
+}

--- a/pkg/httperror/httperror_test.go
+++ b/pkg/httperror/httperror_test.go
@@ -23,6 +23,14 @@ func (tempError) Timeout() bool {
 	return true
 }
 
+func cacheControlDisabledHeader() string {
+	rec := httptest.NewRecorder()
+	cachecontrol.DisableCache(rec)
+	resp := rec.Result()
+	defer resp.Body.Close()
+	return resp.Header.Get("Cache-Control")
+}
+
 func TestError(t *testing.T) {
 	rec := httptest.NewRecorder()
 	Error(rec, "error", http.StatusNotFound)
@@ -30,7 +38,7 @@ func TestError(t *testing.T) {
 	defer resp.Body.Close()
 
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode, "HTTP response code should match Error()")
-	assert.Equal(t, cachecontrol.Disabled().String(), resp.Header.Get("Cache-Control"), "Cache-Control must disable cache")
+	assert.Equal(t, cacheControlDisabledHeader(), resp.Header.Get("Cache-Control"), "Cache-Control must disable cache")
 
 	data, err := io.ReadAll(resp.Body)
 	assert.Nil(t, err, "reading the body should not return an error")

--- a/pkg/httperror/httperror_test.go
+++ b/pkg/httperror/httperror_test.go
@@ -1,0 +1,63 @@
+package httperror
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wundergraph/wundergraph/pkg/cachecontrol"
+)
+
+type tempError struct{}
+
+func (tempError) Error() string {
+	return "error"
+}
+
+func (tempError) Timeout() bool {
+	return true
+}
+
+func TestError(t *testing.T) {
+	rec := httptest.NewRecorder()
+	Error(rec, "error", http.StatusNotFound)
+	resp := rec.Result()
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode, "HTTP response code should match Error()")
+	assert.Equal(t, cachecontrol.Disabled().String(), resp.Header.Get("Cache-Control"), "Cache-Control must disable cache")
+
+	data, err := io.ReadAll(resp.Body)
+	assert.Nil(t, err, "reading the body should not return an error")
+	assert.Equal(t, "error", strings.TrimSpace(string(data)), "body should be equal to Error() message")
+}
+
+func TestErr(t *testing.T) {
+	t.Run("non timeout error", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		Err(rec, os.ErrNotExist, "")
+		resp := rec.Result()
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode, "status code should be 500")
+		data, err := io.ReadAll(resp.Body)
+		assert.Nil(t, err, "reading the body should not return an error")
+		assert.Equal(t, http.StatusText(http.StatusInternalServerError), strings.TrimSpace(string(data)), "body should contain error message")
+	})
+
+	t.Run("timeout error", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		Err(rec, tempError{}, "")
+		resp := rec.Result()
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusGatewayTimeout, resp.StatusCode, "status code should be 503")
+		data, err := io.ReadAll(resp.Body)
+		assert.Nil(t, err, "reading the body should not return an error")
+		assert.Equal(t, http.StatusText(http.StatusGatewayTimeout), strings.TrimSpace(string(data)), "body should contain error message")
+	})
+}

--- a/pkg/httperror/httperror_test.go
+++ b/pkg/httperror/httperror_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"github.com/wundergraph/wundergraph/pkg/cachecontrol"
 )
 

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -22,6 +22,7 @@ import (
 	"github.com/wundergraph/wundergraph/pkg/apihandler"
 	"github.com/wundergraph/wundergraph/pkg/engineconfigloader"
 	"github.com/wundergraph/wundergraph/pkg/hooks"
+	"github.com/wundergraph/wundergraph/pkg/httperror"
 	"github.com/wundergraph/wundergraph/pkg/httpidletimeout"
 	"github.com/wundergraph/wundergraph/pkg/loadvariable"
 	"github.com/wundergraph/wundergraph/pkg/logging"
@@ -356,7 +357,7 @@ func (n *Node) startServer(nodeConfig WunderNodeConfig) error {
 		router.Use(func(handler http.Handler) http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if !limiter.Allow() {
-					http.Error(w, "too many requests", http.StatusTooManyRequests)
+					httperror.Error(w, "too many requests", http.StatusTooManyRequests)
 					return
 				}
 				handler.ServeHTTP(w, r)

--- a/pkg/s3uploadclient/s3uploadclient.go
+++ b/pkg/s3uploadclient/s3uploadclient.go
@@ -16,6 +16,8 @@ import (
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
 	"golang.org/x/net/context"
+
+	"github.com/wundergraph/wundergraph/pkg/httperror"
 )
 
 const MaxUploadSize = 20 * 1024 * 1024 // 20MB
@@ -134,7 +136,7 @@ func (s *S3UploadClient) UploadFile(w http.ResponseWriter, r *http.Request) {
 	var result []UploadedFile
 	reader, err := r.MultipartReader()
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		httperror.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
@@ -143,7 +145,7 @@ func (s *S3UploadClient) UploadFile(w http.ResponseWriter, r *http.Request) {
 		if err == io.EOF {
 			break
 		} else if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
+			httperror.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 		// handle only Files
@@ -152,7 +154,7 @@ func (s *S3UploadClient) UploadFile(w http.ResponseWriter, r *http.Request) {
 		}
 		info, err := s.handlePart(r.Context(), part)
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
+			httperror.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 		result = append(result, UploadedFile{info.Key})
@@ -160,7 +162,7 @@ func (s *S3UploadClient) UploadFile(w http.ResponseWriter, r *http.Request) {
 
 	files, err := json.Marshal(result)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		httperror.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 


### PR DESCRIPTION
- feat: add cachecontrol package
- refactor: use cachecontrol package to set headers
- feat: add httperror package
- feat: make all returned HTTP errors  use httperror package
- feat: add middleware to make all responses default to use no cache

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

<!--
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->
