### PR TITLE
fix(oas): use primitive schema references as the field schema

### DIFF
--- a/packages/sdk/src/v2openapi/__snapshots__/index.test.ts.snap
+++ b/packages/sdk/src/v2openapi/__snapshots__/index.test.ts.snap
@@ -21086,6 +21086,7 @@ type api_User {
   name: String
   country_code: String
   status_code: Int
+  uuid: String
 }
 
 type api_PropertiesResponse {

--- a/packages/sdk/src/v2openapi/testdata/users.json
+++ b/packages/sdk/src/v2openapi/testdata/users.json
@@ -111,6 +111,9 @@
           },
           "status_code": {
             "$ref": "#/components/schemas/StatusCode"
+          },
+          "uuid": {
+            "$ref": "#/components/schemas/UUID"
           }
         }
       },
@@ -136,6 +139,10 @@
         "enum": [0, 1, 2],
         "type": "integer",
         "format": "int32"
+      },
+      "UUID": {
+        "type": "string",
+        "format": "uuid"
       }
     }
   }


### PR DESCRIPTION
OAS introspection was failing when references weren't object/array/enum, which meant that primitive schemas (e.g. `{ "type": "string" }`) were being interpreted as nested definitions.  Instead we can detect the primitive case and replace the field's schema with the schema from the reference.

#### Checklist

- [x] run `make test`
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)
