### PR TITLE
fix: make baseURL optional

### DIFF
--- a/packages/sdk/src/codegen/templates/typescript/client.template.ts
+++ b/packages/sdk/src/codegen/templates/typescript/client.template.ts
@@ -102,7 +102,7 @@ export class WunderGraphClient extends Client {
 	}
 }
 
-export const createClient = (config?: Omit<ClientConfig, PrivateConfigProperties>) => {
+export const createClient = (config?: Partial<Omit<ClientConfig, PrivateConfigProperties>>) => {
 	return new WunderGraphClient({
 		...defaultClientConfig,
 		...config,


### PR DESCRIPTION
The problem was that config is optional, but baseURL was required when adding a config, while baseURL has a default value. So when you add a customFetch for usage in nodejs, you also had to add baseURL which is incorrect.