### PR TITLE
feat(create-wundergraph-app): download latest tag instead of main

### DIFF
--- a/packages/create-wundergraph-app/src/helpers/download.ts
+++ b/packages/create-wundergraph-app/src/helpers/download.ts
@@ -41,7 +41,10 @@ export const downloadAndExtractRepo = async ({
 			file: tempFile,
 			cwd: root,
 			strip: filePath ? filePath.split('/').length + 1 : 1,
-			filter: (p) => p.startsWith(`${repoName}-${ref}${filePath ? `/${filePath}/` : ''}`),
+			filter: (p) => {
+				const rel = p.split('/').slice(1).join('/');
+				return rel.startsWith(`${filePath ? `${filePath}/` : ''}`);
+			},
 		});
 		await fsp.unlink(tempFile);
 		spinner.succeed(chalk.green('Successfully cloned the repository'));

--- a/packages/create-wundergraph-app/src/helpers/download.ts
+++ b/packages/create-wundergraph-app/src/helpers/download.ts
@@ -24,24 +24,24 @@ export const downloadTar = async (url: string) => {
 export const downloadAndExtractRepo = async ({
 	root,
 	repoName,
-	branch,
+	ref,
 	repoOwnerName,
 	filePath,
 }: {
 	root: string;
 	repoName: string;
-	branch: string;
+	ref: string;
 	repoOwnerName: string;
 	filePath?: string;
 }) => {
 	try {
 		const spinner = ora('Loading..').start();
-		const tempFile = await downloadTar(`https://codeload.github.com/${repoOwnerName}/${repoName}/tar.gz/${branch}`);
+		const tempFile = await downloadTar(`https://codeload.github.com/${repoOwnerName}/${repoName}/tar.gz/${ref}`);
 		await tar.x({
 			file: tempFile,
 			cwd: root,
 			strip: filePath ? filePath.split('/').length + 1 : 1,
-			filter: (p) => p.startsWith(`${repoName}-${branch}${filePath ? `/${filePath}/` : ''}`),
+			filter: (p) => p.startsWith(`${repoName}-${ref}${filePath ? `/${filePath}/` : ''}`),
 		});
 		await fsp.unlink(tempFile);
 		spinner.succeed(chalk.green('Successfully cloned the repository'));

--- a/packages/create-wundergraph-app/src/helpers/examples.ts
+++ b/packages/create-wundergraph-app/src/helpers/examples.ts
@@ -2,9 +2,9 @@ import chalk from 'chalk';
 import got from 'got';
 import inquirer from 'inquirer';
 
-export const getExamplesList = async () => {
+export const getExamplesList = async (ref: string) => {
 	const exampleDirectoriesResponse = await got
-		.get('https://api.github.com/repos/wundergraph/wundergraph/contents/examples')
+		.get(`https://api.github.com/repos/wundergraph/wundergraph/contents/examples?ref=${ref}`)
 		.catch((e) => {
 			throw e;
 		});
@@ -16,8 +16,8 @@ export const getExamplesList = async () => {
 	return examples;
 };
 
-export const checkIfValidExample = async (exampleName: string) => {
-	const examples = await getExamplesList();
+export const checkIfValidExample = async (exampleName: string, ref: string) => {
+	const examples = await getExamplesList(ref);
 
 	if (!examples.includes(exampleName)) {
 		console.error(chalk.red('The given example name doesnt exist in the Wundergraph repository'));

--- a/packages/create-wundergraph-app/src/helpers/getRepoTags.ts
+++ b/packages/create-wundergraph-app/src/helpers/getRepoTags.ts
@@ -1,0 +1,22 @@
+import got from 'got';
+
+import { getRepoInfo } from './getRepoInfo';
+
+export const getRepoTags = async (githubLink: string, prefix?: string) => {
+	const { repoName, repoOwnerName } = await getRepoInfo(githubLink);
+
+	const response = await got
+		.get(`https://api.github.com/repos/${repoOwnerName}/${repoName}/git/refs/tags`)
+		.catch((e) => {
+			throw e;
+		});
+	const data = JSON.parse(response.body);
+	const prefixLength = 'refs/tags/'.length;
+	let tags: string[] = data.map((item: { ref: string }) => {
+		return item.ref.substring(prefixLength);
+	});
+	if (prefix) {
+		tags = tags.filter((item) => item.startsWith(prefix));
+	}
+	return tags;
+};

--- a/packages/create-wundergraph-app/src/helpers/getRepository.ts
+++ b/packages/create-wundergraph-app/src/helpers/getRepository.ts
@@ -42,7 +42,7 @@ const resolveRepository = async ({ exampleName, githubLink }: { exampleName?: st
 			return {
 				repoOwnerName: 'wundergraph',
 				repoName: 'wundergraph',
-				ref: 'main',
+				ref: ref,
 				filePath: `examples/${selectedExampleName}`,
 			};
 		} else if (githubLink) {

--- a/packages/create-wundergraph-app/src/tests/index.test.ts
+++ b/packages/create-wundergraph-app/src/tests/index.test.ts
@@ -1,7 +1,9 @@
 import fs, { promises as fsp } from 'fs';
 import path from 'path';
-import { getRepository } from '../helpers/getRepository';
 import { tmpdir } from 'os';
+
+import { getRepository } from '../helpers/getRepository';
+import { getRepoTags } from '../helpers/getRepoTags';
 
 jest.setTimeout(20000);
 test('The command should clone the repository using example name and github link and return "success"', async () => {
@@ -47,4 +49,12 @@ test('The command should clone the repository using example name and github link
 		await fsp.access(path.join(tempDirectory, secondRepoName));
 		fs.rmSync(path.join(tempDirectory, secondRepoName), { recursive: true, force: true });
 	} catch (e) {}
+});
+
+test('should return the tags for wundergraph/wundergraph', async () => {
+	const prefix = '@wundergraph/sdk';
+	const tags = await getRepoTags('https://github.com/wundergraph/wundergraph', prefix);
+	expect(tags.length).toBeGreaterThan(0);
+	expect(tags[0].startsWith(prefix)).toBeTruthy();
+	expect(tags[tags.length - 1].startsWith(prefix)).toBeTruthy();
 });


### PR DESCRIPTION
Downloading from the main branch prevents us from making breaking
changes, since the examples would stop working until the next SDK with
the breaking changes is released.

When using the wundegraph repository as the example source, first
retrieve the tags and use the latest tag starting with @wundergraph/sdk

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

<!--
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->
