### PR TITLE
fix: remove deprecated prefix from cookie path

### DIFF
--- a/pkg/authentication/oidc.go
+++ b/pkg/authentication/oidc.go
@@ -114,7 +114,7 @@ func (h *OpenIDConnectCookieHandler) Register(authorizeRouter, callbackRouter *m
 			return
 		}
 
-		cookiePath := fmt.Sprintf("/%s/auth/cookie/callback/%s", config.PathPrefix, config.ProviderID)
+		cookiePath := fmt.Sprintf("/auth/cookie/callback/%s", config.ProviderID)
 		cookieDomain := sanitizeDomain(r.Host)
 
 		c := &http.Cookie{


### PR DESCRIPTION
PR #335 breaks our auth flow with Auth0 - cookies are missing after logging in.

After digging around a bit, I think you guys simply forgot to remove the old prefix from the cookie path.