### PR TITLE
fix: remove colors from configurePublishWunderGraphAPI()

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -78,7 +78,6 @@
   "devDependencies": {
     "@types/axios": "^0.14.0",
     "@types/chai": "^4.2.22",
-    "@types/colors": "^1.2.1",
     "@types/cors": "^2.8.10",
     "@types/debug": "^4.1.7",
     "@types/jest": "^28.1.1",
@@ -93,8 +92,8 @@
     "nock": "^13.2.9",
     "node-fetch": "^2.6.7",
     "ts-jest": "^29.0.1",
-    "typescript": "^4.8.2",
-    "tsd": "^0.24.1"
+    "tsd": "^0.24.1",
+    "typescript": "^4.8.2"
   },
   "dependencies": {
     "@fastify/formbody": "^7.3.0",
@@ -106,7 +105,6 @@
     "axios": "^0.26.1",
     "axios-retry": "^3.3.1",
     "close-with-grace": "^1.1.0",
-    "colors": "^1.4.0",
     "execa": "5.1.1",
     "fastify": "^4.9.2",
     "fastify-plugin": "^4.3.0",

--- a/packages/sdk/src/configure/index.ts
+++ b/packages/sdk/src/configure/index.ts
@@ -49,7 +49,6 @@ import path from 'path';
 import { applyNamespaceToApi } from '../definition/namespacing';
 import _ from 'lodash';
 import { wunderctlExec } from '../wunderctlexec';
-import colors from 'colors';
 import { CustomizeMutation, CustomizeQuery, CustomizeSubscription, OperationsConfiguration } from './operations';
 import {
 	AuthenticationHookRequest,
@@ -1122,9 +1121,7 @@ export const configurePublishWunderGraphAPI = (configuration: PublishConfigurati
 	const outFile = path.join('generated', `${configuration.organization}.${configuration.name}.api.json`);
 	_configurePublishWunderGraphAPI(configuration, outFile)
 		.then(() => {
-			Logger.info(
-				colors.blue(`${configuration.organization}/${configuration.name} API configuration written to ${outFile}`)
-			);
+			Logger.info(`${configuration.organization}/${configuration.name} API configuration written to ${outFile}`);
 			if (process.env.WUNDERGRAPH_PUBLISH_API === 'true') {
 				try {
 					const result = wunderctlExec({
@@ -1132,14 +1129,14 @@ export const configurePublishWunderGraphAPI = (configuration: PublishConfigurati
 						timeout: 1000 * 5,
 					});
 					if (result?.failed) {
-						Logger.error(colors.red(`Failed to publish ${configuration.organization}/${configuration.name}`));
+						Logger.error(`Failed to publish ${configuration.organization}/${configuration.name}`);
 					}
 				} catch (e) {
-					Logger.error(colors.red(`Failed to publish ${configuration.organization}/${configuration.name}`));
+					Logger.error(`Failed to publish ${configuration.organization}/${configuration.name}`);
 				}
 			} else {
-				Logger.info(colors.blue(`You can now publish the API using the following command:`));
-				Logger.info(colors.green(`wunderctl publish ${configuration.organization}/${configuration.name}`));
+				Logger.info(`You can now publish the API using the following command:`);
+				Logger.info(`wunderctl publish ${configuration.organization}/${configuration.name}`);
 			}
 		})
 		.catch((err) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -287,7 +287,6 @@ importers:
       '@prisma/generator-helper': ^3.9.2
       '@types/axios': ^0.14.0
       '@types/chai': ^4.2.22
-      '@types/colors': ^1.2.1
       '@types/cors': ^2.8.10
       '@types/debug': ^4.1.7
       '@types/jest': ^28.1.1
@@ -304,7 +303,6 @@ importers:
       axios-retry: ^3.3.1
       chai: ^4.3.4
       close-with-grace: ^1.1.0
-      colors: ^1.4.0
       execa: 5.1.1
       fastify: ^4.9.2
       fastify-plugin: ^4.3.0
@@ -339,7 +337,6 @@ importers:
       axios: 0.26.1
       axios-retry: 3.3.1
       close-with-grace: 1.1.0
-      colors: 1.4.0
       execa: 5.1.1
       fastify: 4.9.2
       fastify-plugin: 4.3.0
@@ -361,7 +358,6 @@ importers:
     devDependencies:
       '@types/axios': 0.14.0
       '@types/chai': 4.3.3
-      '@types/colors': 1.2.1
       '@types/cors': 2.8.12
       '@types/debug': 4.1.7
       '@types/jest': 28.1.8
@@ -3659,13 +3655,6 @@ packages:
     resolution: {integrity: sha512-hC7OMnszpxhZPduX+m+nrx+uFoLkWOMiR4oa/AZF3MuSETYTZmFfJAHqZEM8MVlvfG7BEUcgvtwoCTxBp6hm3g==}
     dev: true
 
-  /@types/colors/1.2.1:
-    resolution: {integrity: sha512-7jNkpfN2lVO07nJ1RWzyMnNhH/I5N9iWuMPx9pedptxJ4MODf8rRV0lbJi6RakQ4sKQk231Fw4e2W9n3D7gZ3w==}
-    deprecated: This is a stub types definition. colors provides its own type definitions, so you don't need this installed.
-    dependencies:
-      colors: 1.4.0
-    dev: true
-
   /@types/cors/2.8.12:
     resolution: {integrity: sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==}
     dev: true
@@ -5183,6 +5172,7 @@ packages:
   /colors/1.4.0:
     resolution: {integrity: sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==}
     engines: {node: '>=0.1.90'}
+    dev: false
 
   /columnify/1.6.0:
     resolution: {integrity: sha512-lomjuFZKfM6MSAnV9aCZC9sc0qGbmZdfygNv+nCpqVkSKdCxCklLtd16O0EILGkImHw9ZpHkAnHaB+8Zxq5W6Q==}


### PR DESCRIPTION
Interferes with logging, printing color sequences to JSON logs. Also,
we now have colors via --pretty-logging

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

<!--
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->
