### PR TITLE
fix: validate OpenID discovered configuration, warn when appropriate

### DIFF
--- a/pkg/apihandler/apihandler.go
+++ b/pkg/apihandler/apihandler.go
@@ -2036,6 +2036,9 @@ func (e openIDConnectConfigurationMissingFieldError) Error() string {
 
 func (c *OpenIDConnectConfiguration) Validate() error {
 	// See https://openid.net/specs/openid-connect-discovery-1_0.html
+	//
+	// Note that our implementation uses userinfo_endpoint and hence we
+	// make it required, but can work without jwks_uri so we make it optional
 	if c.Issuer == "" {
 		return openIDConnectConfigurationMissingFieldError("issuer")
 	}
@@ -2046,8 +2049,8 @@ func (c *OpenIDConnectConfiguration) Validate() error {
 		// TODO: This might be optional with Implicit Flow?
 		return openIDConnectConfigurationMissingFieldError("token_endpoint")
 	}
-	if c.JwksUri == "" {
-		return openIDConnectConfigurationMissingFieldError("jwks_uri")
+	if c.UserinfoEndpoint == "" {
+		return openIDConnectConfigurationMissingFieldError("userinfo_endpoint")
 	}
 	return nil
 }

--- a/pkg/apihandler/apihandler.go
+++ b/pkg/apihandler/apihandler.go
@@ -2011,7 +2011,7 @@ func (r *Builder) configureOpenIDConnectIssuerLogoutURLs() map[string]string {
 			continue
 		}
 		if config.EndSessionEndpoint == "" {
-			r.log.Warn("issuer doesn't support end_session_endpoint", zap.String("issuer", issuer))
+			r.log.Debug("issuer doesn't support end_session_endpoint", zap.String("issuer", issuer))
 		}
 		issuerLogoutURLs[issuer] = config.EndSessionEndpoint
 	}


### PR DESCRIPTION
end_session_endpoint is not a mandatory field, so it should print a
warning instead of an error. Also, add validation for the required
fields according to the spec.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

<!--
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->
