### PR TITLE
fix: replace graphql-weather-api.herokuapp.com with our own copy

### DIFF
--- a/docs-website/src/pages/docs/architecture/manage-api-dependencies-explicitly.md
+++ b/docs-website/src/pages/docs/architecture/manage-api-dependencies-explicitly.md
@@ -109,7 +109,7 @@ Here's an example. Let's add two API dependencies to our project:
 // wundergraph.config.ts
 const weather = introspect.graphql({
   apiNamespace: 'weather',
-  url: 'https://graphql-weather-api.herokuapp.com/',
+  url: 'https://weather-api.wundergraph.com/',
 })
 
 const countries = introspect.graphql({

--- a/docs-website/src/pages/docs/architecture/wundergraph-explained-in-one-sequence-diagram.md
+++ b/docs-website/src/pages/docs/architecture/wundergraph-explained-in-one-sequence-diagram.md
@@ -18,7 +18,7 @@ First, let's add two APIs to our application.
 // wundergraph.config.ts
 const weather = introspect.graphql({
   apiNamespace: 'weather',
-  url: 'https://graphql-weather-api.herokuapp.com/',
+  url: 'https://weather-api.wundergraph.com/',
 })
 
 const countries = introspect.graphql({

--- a/docs-website/src/pages/docs/directives-reference/export-directive.md
+++ b/docs-website/src/pages/docs/directives-reference/export-directive.md
@@ -23,7 +23,7 @@ To achieve this, we could use the following two APIs:
 // wundergraph.config.ts
 const weather = introspect.graphql({
   apiNamespace: 'weather',
-  url: 'https://graphql-weather-api.herokuapp.com/',
+  url: 'https://weather-api.wundergraph.com/',
 })
 
 const countries = introspect.graphql({

--- a/docs-website/src/pages/docs/examples/cross-api-joins.md
+++ b/docs-website/src/pages/docs/examples/cross-api-joins.md
@@ -17,7 +17,7 @@ import { configureWunderGraphApplication } from './index'
 
 const weather = introspect.graphql({
   apiNamespace: 'weather',
-  url: 'https://graphql-weather-api.herokuapp.com/',
+  url: 'https://weather-api.wundergraph.com/',
 })
 
 const countries = introspect.graphql({

--- a/docs-website/src/pages/docs/features/cross-api-joins-to-compose-apis.md
+++ b/docs-website/src/pages/docs/features/cross-api-joins-to-compose-apis.md
@@ -17,7 +17,7 @@ one to query the capitals and the other to query the weather data.
 // wundergraph.config.ts
 const weather = introspect.graphql({
   apiNamespace: 'weather',
-  url: 'https://graphql-weather-api.herokuapp.com/',
+  url: 'https://weather-api.wundergraph.com/',
 })
 
 const countries = introspect.graphql({

--- a/docs-website/src/pages/docs/use-cases/api-composition-and-integration.md
+++ b/docs-website/src/pages/docs/use-cases/api-composition-and-integration.md
@@ -85,7 +85,7 @@ First, let's define two API dependencies:
 // wundergraph.config.ts
 const weather = introspect.graphql({
   apiNamespace: 'weather',
-  url: 'https://graphql-weather-api.herokuapp.com/',
+  url: 'https://weather-api.wundergraph.com/',
 })
 
 const countries = introspect.graphql({

--- a/docs-website/src/pages/docs/use-cases/backend-for-frontend.md
+++ b/docs-website/src/pages/docs/use-cases/backend-for-frontend.md
@@ -52,7 +52,7 @@ Here's a quick example of an application defined using WunderGraph:
 // wundergraph.config.ts
 const weather = introspect.graphql({
   apiNamespace: 'weather',
-  url: 'https://graphql-weather-api.herokuapp.com/',
+  url: 'https://weather-api.wundergraph.com/',
 })
 
 const countries = introspect.graphql({

--- a/examples/cross-api-joins/.wundergraph/wundergraph.config.ts
+++ b/examples/cross-api-joins/.wundergraph/wundergraph.config.ts
@@ -11,7 +11,7 @@ import operations from './wundergraph.operations';
 
 const weather = introspect.graphql({
 	apiNamespace: 'weather',
-	url: 'https://graphql-weather-api.herokuapp.com/',
+	url: 'https://weather-api.wundergraph.com/',
 });
 
 const countries = introspect.graphql({

--- a/examples/publish-install-api/.wundergraph/wundergraph.config.ts
+++ b/examples/publish-install-api/.wundergraph/wundergraph.config.ts
@@ -13,7 +13,7 @@ const weatherApi = introspect.graphql({
 	// if the user of your API will use namespacing themselves, they'll have a double namespace, e.g.: weather_weather_api
 	// For that reason, only apply a namespace when you publish multiple APIs combined and a namespace is required to avoid collisions
 	// If this is the case, you should consider publishing both APIs separately under a different name
-	url: 'https://graphql-weather-api.herokuapp.com/',
+	url: 'https://weather-api.wundergraph.com/',
 	/*headers: builder => builder
         // add a static Header to all upstream Requests
         .addStaticHeader("AuthToken", "staticToken")

--- a/packages/sdk/src/definition/merge.test.ts
+++ b/packages/sdk/src/definition/merge.test.ts
@@ -415,7 +415,7 @@ test('Should collide because weather and countries API has an enum called Langua
 						UseSSE: false,
 					},
 					Fetch: {
-						url: mapInputVariable('https://graphql-weather-api.herokuapp.com'),
+						url: mapInputVariable('https://weather-api.wundergraph.com'),
 						baseUrl: mapInputVariable(''),
 						path: mapInputVariable(''),
 						method: HTTPMethod.POST,

--- a/testapps/default/.wundergraph/wundergraph.config.ts
+++ b/testapps/default/.wundergraph/wundergraph.config.ts
@@ -60,7 +60,7 @@ const countries = introspect.graphql({
 
 const weather = introspect.graphql({
 	apiNamespace: 'weather',
-	url: 'https://graphql-weather-api.herokuapp.com/',
+	url: 'https://weather-api.wundergraph.com/',
 	introspection: {
 		pollingIntervalSeconds: 5,
 	},

--- a/testapps/nextjs/.wundergraph/wundergraph.config.ts
+++ b/testapps/nextjs/.wundergraph/wundergraph.config.ts
@@ -13,7 +13,7 @@ import { NextJsTemplate } from '@wundergraph/nextjs/dist/template';
 
 const weather = introspect.graphql({
 	apiNamespace: 'weather',
-	url: 'https://graphql-weather-api.herokuapp.com/',
+	url: 'https://weather-api.wundergraph.com/',
 });
 
 /*const jsonPlaceholder = introspect.openApi({

--- a/testapps/vite/.wundergraph/wundergraph.config.ts
+++ b/testapps/vite/.wundergraph/wundergraph.config.ts
@@ -16,7 +16,7 @@ const spaceX = introspect.graphql({
 
 const weather = introspect.graphql({
 	apiNamespace: 'weather',
-	url: 'https://graphql-weather-api.herokuapp.com/',
+	url: 'https://weather-api.wundergraph.com/',
 });
 
 /*const jsonPlaceholder = introspect.openApi({


### PR DESCRIPTION
graphql-weather-api.herokuapp.com seems to have gone down permanently
after heroku removed their free tier

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

<!--
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->
