### PR TITLE
fix: use the version from package.json for the --version command

### DIFF
--- a/packages/create-wundergraph-app/README.md
+++ b/packages/create-wundergraph-app/README.md
@@ -32,9 +32,9 @@ npx create-wundergraph-app <project-name> -L <github-link>
 ## Local Usage
 
 ```shell
-node ./dist/index.js --help
-node ./dist/index.js --version
-node ./dist/index.js <project-name>
-node ./dist/index.js <project-name> -E <example-name>
-node ./dist/index.js <project-name> -L <github-link>
+node ./dist/src/index.js --help
+node ./dist/src/index.js --version
+node ./dist/src/index.js <project-name>
+node ./dist/src/index.js <project-name> -E <example-name>
+node ./dist/src/index.js <project-name> -L <github-link>
 ```

--- a/packages/create-wundergraph-app/package.json
+++ b/packages/create-wundergraph-app/package.json
@@ -3,15 +3,15 @@
   "version": "0.2.0",
   "license": "Apache-2.0",
   "description": "Create Wundergraph App CLI command",
-  "main": "dist/index.js",
-  "exports": "./dist/index.js",
+  "main": "dist/src/index.js",
+  "exports": "./dist/src/index.js",
   "scripts": {
-    "start": "pnpm run build && node ./dist/index.js",
+    "start": "pnpm run build && node ./dist/src/index.js",
     "build": "tsc",
     "test": "jest"
   },
   "bin": {
-    "create-wundergraph-app": "./dist/index.js"
+    "create-wundergraph-app": "./dist/src/index.js"
   },
   "repository": {
     "type": "git",

--- a/packages/create-wundergraph-app/src/index.ts
+++ b/packages/create-wundergraph-app/src/index.ts
@@ -3,11 +3,12 @@ import chalk from 'chalk';
 import { Command } from 'commander';
 import logSymbols from 'log-symbols';
 import { getRepository } from './helpers/getRepository';
+import packageJson from '../package.json';
 
 let projectName = '';
 
 const program = new Command('create-wundergraph-app')
-	.version('0.0.1')
+	.version(packageJson.version)
 	.arguments('<project-name>')
 	.usage(`${chalk.green('<project-name>')} [options]`)
 	.option(


### PR DESCRIPTION
#### Checklist

- [x] run `make test`
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)

<!--
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->
