### PR TITLE
fix: return a 400 bad request when POST'ed JSON is invalid

### DIFF
--- a/pkg/apihandler/apihandler.go
+++ b/pkg/apihandler/apihandler.go
@@ -1070,14 +1070,19 @@ func (h *QueryHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx.Variables = parseQueryVariables(r, h.queryParamsAllowList)
 	ctx.Variables = h.stringInterpolator.Interpolate(ctx.Variables)
 
-	valid := h.variablesValidator.Validate(ctx, ctx.Variables, inputvariables.NewValidationWriter(w))
+	valid, err := h.variablesValidator.Validate(ctx, ctx.Variables, inputvariables.NewValidationWriter(w))
+	if err != nil {
+		requestLogger.Error("failed to validate variables", zap.Error(err))
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
 	if !valid {
 		return
 	}
 
 	compactBuf := pool.GetBytesBuffer()
 	defer pool.PutBytesBuffer(compactBuf)
-	err := json.Compact(compactBuf, ctx.Variables)
+	err = json.Compact(compactBuf, ctx.Variables)
 	if err != nil {
 		requestLogger.Error("Could not compact variables in query handler", zap.Bool("isLive", isLive), zap.Error(err))
 		w.WriteHeader(http.StatusBadRequest)
@@ -1505,14 +1510,19 @@ func (h *MutationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		ctx.Variables = []byte("{}")
 	}
 	ctx.Variables = h.stringInterpolator.Interpolate(ctx.Variables)
-	valid := h.variablesValidator.Validate(ctx, ctx.Variables, inputvariables.NewValidationWriter(w))
+	valid, err := h.variablesValidator.Validate(ctx, ctx.Variables, inputvariables.NewValidationWriter(w))
+	if err != nil {
+		requestLogger.Error("failed to validate variables", zap.Error(err))
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
 	if !valid {
 		return
 	}
 
 	compactBuf := pool.GetBytesBuffer()
 	defer pool.PutBytesBuffer(compactBuf)
-	err := json.Compact(compactBuf, ctx.Variables)
+	err = json.Compact(compactBuf, ctx.Variables)
 	if err != nil {
 		requestLogger.Error("failed to compact variables", zap.Error(err))
 		w.WriteHeader(http.StatusBadRequest)
@@ -1654,14 +1664,19 @@ func (h *SubscriptionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 
 	ctx.Variables = parseQueryVariables(r, h.queryParamsAllowList)
 	ctx.Variables = h.stringInterpolator.Interpolate(ctx.Variables)
-	valid := h.variablesValidator.Validate(ctx, ctx.Variables, inputvariables.NewValidationWriter(w))
+	valid, err := h.variablesValidator.Validate(ctx, ctx.Variables, inputvariables.NewValidationWriter(w))
+	if err != nil {
+		requestLogger.Error("failed to validate variables", zap.Error(err))
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
 	if !valid {
 		return
 	}
 
 	compactBuf := pool.GetBytesBuffer()
 	defer pool.PutBytesBuffer(compactBuf)
-	err := json.Compact(compactBuf, ctx.Variables)
+	err = json.Compact(compactBuf, ctx.Variables)
 	if err != nil {
 		requestLogger.Error("Could not compact variables", zap.Error(err))
 		w.WriteHeader(http.StatusBadRequest)

--- a/pkg/inputvariables/validator.go
+++ b/pkg/inputvariables/validator.go
@@ -26,28 +26,53 @@ func NewValidator(schema string, disableVerboseErrors bool) (*Validator, error) 
 	return &validator, nil
 }
 
+type jsonError struct {
+	Message string `json:"message"`
+}
+
+func (e *jsonError) Error() string {
+	return e.Message
+}
+
 type ValidationError struct {
 	Message string
 	Input   json.RawMessage
-	Errors  []jsonschema.KeyError
+	Errors  []error
 }
 
-func (v *Validator) Validate(ctx context.Context, variables []byte, errOut io.Writer) (valid bool) {
+func (v *Validator) Validate(ctx context.Context, variables []byte, errOut io.Writer) (valid bool, err error) {
 	errs, err := v.schema.ValidateBytes(ctx, variables)
 	if err == nil && len(errs) == 0 {
-		return true
+		return true, nil
 	}
 	if v.disableVerboseErrors {
-		_, _ = io.WriteString(errOut, "Bad Request: Invalid input")
+		if _, err := io.WriteString(errOut, "Bad Request: Invalid input"); err != nil {
+			return false, err
+		}
 	} else {
+		var input []byte
+		var validationErrors []error
+		if err != nil {
+			// if err is non nil, JSON might be invalid and we cannot
+			// send it back to the client as json.RawMessage because it
+			// will fail to serialize
+			validationErrors = append(validationErrors, &jsonError{Message: err.Error()})
+		} else {
+			input = variables
+			for _, err := range errs {
+				validationErrors = append(validationErrors, err)
+			}
+		}
 		validationError := ValidationError{
 			Message: "Bad Request: Invalid input",
-			Input:   variables,
-			Errors:  errs,
+			Input:   input,
+			Errors:  validationErrors,
 		}
-		_ = json.NewEncoder(errOut).Encode(validationError)
+		if err := json.NewEncoder(errOut).Encode(validationError); err != nil {
+			return false, err
+		}
 	}
-	return false
+	return false, nil
 }
 
 func NewValidationWriter(w http.ResponseWriter) *ValidationWriter {

--- a/pkg/inputvariables/validator_test.go
+++ b/pkg/inputvariables/validator_test.go
@@ -19,28 +19,34 @@ func TestValidator_Validate(t *testing.T) {
 	validator, err := NewValidator(validEmptySchema, true)
 	assert.NoError(t, err)
 
-	actual := validator.Validate(context.Background(), []byte(`{}`), io.Discard)
+	actual, err := validator.Validate(context.Background(), []byte(`{}`), io.Discard)
+	assert.Nil(t, err)
 	assert.Equal(t, true, actual)
 
-	actual = validator.Validate(context.Background(), []byte(``), io.Discard)
+	actual, err = validator.Validate(context.Background(), []byte(``), io.Discard)
+	assert.Nil(t, err)
 	assert.Equal(t, false, actual)
 
-	actual = validator.Validate(context.Background(), []byte(`{"foo":"bar"}`), io.Discard)
+	actual, err = validator.Validate(context.Background(), []byte(`{"foo":"bar"}`), io.Discard)
+	assert.Nil(t, err)
 	assert.Equal(t, false, actual)
 
 	validator, err = NewValidator(validSchema, true)
 	assert.NoError(t, err)
 
 	out := &bytes.Buffer{}
-	actual = validator.Validate(context.Background(), []byte(`{"id":"bar"}`), out)
+	actual, err = validator.Validate(context.Background(), []byte(`{"id":"bar"}`), out)
+	assert.Nil(t, err)
 	assert.Equal(t, true, actual)
 	assert.Equal(t, "", out.String())
 
-	actual = validator.Validate(context.Background(), []byte(`{"id":true}`), out)
+	actual, err = validator.Validate(context.Background(), []byte(`{"id":true}`), out)
+	assert.Nil(t, err)
 	assert.Equal(t, false, actual)
 	assert.Equal(t, "Bad Request: Invalid input", out.String())
 
-	actual = validator.Validate(context.Background(), []byte(`{"id":"bar","foo":"bar"}`), io.Discard)
+	actual, err = validator.Validate(context.Background(), []byte(`{"id":"bar","foo":"bar"}`), io.Discard)
+	assert.Nil(t, err)
 	assert.Equal(t, false, actual)
 
 	validator, err = NewValidator(brokenSchema, true)
@@ -50,13 +56,15 @@ func TestValidator_Validate(t *testing.T) {
 	assert.NoError(t, err)
 
 	out.Reset()
-	actual = validator.Validate(context.Background(), []byte(`{"id":true}`), out)
+	actual, err = validator.Validate(context.Background(), []byte(`{"id":true}`), out)
+	assert.Nil(t, err)
 	assert.Equal(t, false, actual)
 	assert.Equal(t, `{"Message":"Bad Request: Invalid input","Input":{"id":true},"Errors":[{"propertyPath":"/id","invalidValue":true,"message":"type should be string, got boolean"}]}
 `, out.String())
 
 	out.Reset()
-	actual = validator.Validate(context.Background(), []byte(`{}`), out)
+	actual, err = validator.Validate(context.Background(), []byte(`{}`), out)
+	assert.Nil(t, err)
 	assert.Equal(t, false, actual)
 	assert.Equal(t, `{"Message":"Bad Request: Invalid input","Input":{},"Errors":[{"propertyPath":"/","invalidValue":{},"message":"\"id\" value is required"}]}
 `, out.String())


### PR DESCRIPTION
Response was failing to serialize because we were trying to include the
JSON back as a json.RawMessage, which failed to serialize. To avoid silently
ignoring another problem here in the future, make sure any errors writing
the error to the output are propagated to the caller.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

<!--
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->
