### PR TITLE
fix: add missing dependency to our nextjs package

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -60,6 +60,7 @@
     "@wundergraph/swr": "workspace:*",
     "handlebars": "^4.7.7",
     "next": "^12.1.6",
+    "object-hash": "^2.2.0",
     "react-ssr-prepass": "^1.5.0"
   },
   "sideEffects": false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -194,6 +194,7 @@ importers:
       next: ^12.1.6
       nock: ^13.2.9
       node-fetch: 2.6.7
+      object-hash: ^2.2.0
       react: 18.2.0
       react-dom: ^18.1.0
       react-ssr-prepass: ^1.5.0
@@ -204,6 +205,7 @@ importers:
       '@wundergraph/swr': link:../swr
       handlebars: 4.7.7
       next: 12.3.2_biqbaboplfbrettd7655fr4n2y
+      object-hash: 2.2.0
       react-ssr-prepass: 1.5.0_react@18.2.0
     devDependencies:
       '@swc/core': 1.3.14


### PR DESCRIPTION
object-hash was accidentally removed at some point, causing import
errors

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->


<!--
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->
