### PR TITLE
feat: listen on both IPv4 and IPv6 by default

### DIFF
--- a/docs-website/src/pages/docs/architecture/wundergraph-conventions.md
+++ b/docs-website/src/pages/docs/architecture/wundergraph-conventions.md
@@ -94,10 +94,10 @@ By default, when no options are passed to `wundergraph.config.ts` or `wundergrap
 | `WG_LOG_LEVEL`       | The log level of the `WunderNode`/`WunderGraph Server`. | `info`                  |
 | `WG_NODE_URL`        | The internal URL of the `WunderNode`.                   | `http://localhost:9991` |
 | `WG_PUBLIC_NODE_URL` | The publicly available URL of the `WunderNode`.         | `http://localhost:9991` |
-| `WG_NODE_HOST`       | The host of the `WunderNode`.                           | `127.0.0.1`             |
+| `WG_NODE_HOST`       | The host of the `WunderNode`.                           | `localhost`             |
 | `WG_NODE_PORT`       | The port of the `WunderNode`.                           | `9991`                  |
 | `WG_SERVER_URL`      | The URL of the `WunderGraph Server`.                    | `http://localhost:9992` |
-| `WG_SERVER_HOST`     | The host of the `WunderGraph Server`.                   | `127.0.0.1`             |
+| `WG_SERVER_HOST`     | The host of the `WunderGraph Server`.                   | `localhost`             |
 | `WG_SERVER_PORT`     | The port of the `WunderGraph Server`.                   | `9992`                  |
 | `WG_IN_MEMORY_CACHE` | Size of the in-memory cache (number + suffix) or `off`. | `128MB`                 |
 

--- a/docs-website/src/pages/docs/examples/graphql-sse-subscriptions.md
+++ b/docs-website/src/pages/docs/examples/graphql-sse-subscriptions.md
@@ -30,7 +30,7 @@ type Subscription {
 
 const greetings = introspect.graphql({
   apiNamespace: 'sse',
-  url: 'http://127.0.0.1:4000/graphql/stream',
+  url: 'http://localhost:4000/graphql/stream',
   loadSchemaFromString: schema,
   subscriptionsUseSSE: true,
 })

--- a/docs-website/src/pages/docs/examples/graphql-subscriptions-hooks.md
+++ b/docs-website/src/pages/docs/examples/graphql-subscriptions-hooks.md
@@ -17,7 +17,7 @@ const counter = introspect.graphql({
   id: 'counter',
   apiNamespace: 'ws',
   loadSchemaFromString: schema,
-  url: 'http://127.0.0.1:4000/graphql',
+  url: 'http://localhost:4000/graphql',
 })
 
 configureWunderGraphApplication({

--- a/docs-website/src/pages/docs/examples/graphql-yoga-subscriptions.md
+++ b/docs-website/src/pages/docs/examples/graphql-yoga-subscriptions.md
@@ -11,7 +11,7 @@ description:
 ```typescript
 const counter = introspect.graphql({
   apiNamespace: 'counter',
-  url: 'http://127.0.0.1:4000/graphql',
+  url: 'http://localhost:4000/graphql',
   subscriptionsUseSSE: true,
 })
 ```

--- a/docs-website/src/pages/docs/features/file-uploads-to-s3-compatible-file-storages.md
+++ b/docs-website/src/pages/docs/features/file-uploads-to-s3-compatible-file-storages.md
@@ -105,7 +105,7 @@ const UploadPage: NextPage = () => {
               <li>
                 <a
                   target="_blank"
-                  href={`http://127.0.0.1:9000/uploads/${file}`}
+                  href={`http://localhost:9000/uploads/${file}`}
                 >
                   {file}
                 </a>

--- a/docs-website/src/pages/docs/features/type-script-webhooks-to-integrate-third-party-applications.md
+++ b/docs-website/src/pages/docs/features/type-script-webhooks-to-integrate-third-party-applications.md
@@ -48,7 +48,7 @@ const webhook: Webhook<
 export default webhook
 ```
 
-After adding your first webhook, you can test it by calling `http://127.0.0.1:9991/webhooks/github`. It should return `{ hello: 'github' }`.
+After adding your first webhook, you can test it by calling `http://localhost:9991/webhooks/github`. It should return `{ hello: 'github' }`.
 
 ## Access the original client request
 

--- a/docs-website/src/pages/docs/wundergraph-config-ts-reference/configure-s3-file-upload-providers.md
+++ b/docs-website/src/pages/docs/wundergraph-config-ts-reference/configure-s3-file-upload-providers.md
@@ -14,7 +14,7 @@ configureWunderGraphApplication({
   s3UploadProvider: [
     {
       name: 'minio', // a unique name for the storage provider
-      endpoint: '127.0.0.1:9000', // the S3 endpoint
+      endpoint: 'localhost:9000', // the S3 endpoint
       accessKeyID: 'test', // access key to upload files to the S3 bucket
       secretAccessKey: '12345678', // access secret to upload files to the S3 bucket
       bucketLocation: 'eu-central-1', // the bucket location, some providers don't require it

--- a/docs-website/src/pages/docs/wundergraph-config-ts-reference/configure-wundernode-options.md
+++ b/docs-website/src/pages/docs/wundergraph-config-ts-reference/configure-wundernode-options.md
@@ -41,7 +41,7 @@ Each option when unset will get a value from the `Default Environment Variables`
 
 | Option          | Default Value           | Default Environment Variable |
 | --------------- | ----------------------- | ---------------------------- |
-| `listen.host`   | `127.0.0.1`             | `WG_NODE_HOST`               |
+| `listen.host`   | `localhost`             | `WG_NODE_HOST`               |
 | `listen.port`   | `9991`                  | `WG_NODE_PORT`               |
 | `nodeUrl`       | `http://localhost:9991` | `WG_NODE_URL`                |
 | `publicNodeUrl` | `http://localhost:9991` | `WG_PUBLIC_NODE_URL`         |
@@ -84,7 +84,7 @@ When using custom environment variables, you need to make sure that the environm
 configureWunderGraphApplication({
   options: {
     listen: {
-      host: '127.0.0.1',
+      host: 'localhost',
       port: '4444',
     },
     nodeUrl: 'http://my-internal-network-node:4444/',
@@ -104,7 +104,7 @@ import { EnvironmentVariable, LoggerLevel } from '@wundergraph/sdk'
 configureWunderGraphApplication({
   options: {
     listen: {
-      host: new EnvironmentVariable('NODE_HOST', '127.0.0.1'),
+      host: new EnvironmentVariable('NODE_HOST', 'localhost'),
       port: new EnvironmentVariable('NODE_PORT', '4444'),
     },
     nodeUrl: new EnvironmentVariable('NODE_URL', 'http://localhost:4444/'),
@@ -132,7 +132,7 @@ import { EnvironmentVariable, LoggerLevel, WgEnv } from '@wundergraph/sdk'
 configureWunderGraphApplication({
   options: {
     listen: {
-      host: new EnvironmentVariable(WgEnv.NodeHost, '127.0.0.1'),
+      host: new EnvironmentVariable(WgEnv.NodeHost, 'localhost'),
       port: new EnvironmentVariable(WgEnv.NodePort, '9991'),
     },
     nodeUrl: new EnvironmentVariable(WgEnv.NodeUrl, 'http://localhost:9991/'),
@@ -150,7 +150,7 @@ configureWunderGraphApplication({
 configureWunderGraphApplication({
   options: {
     listen: {
-      host: new EnvironmentVariable('WG_NODE_HOST', '127.0.0.1'),
+      host: new EnvironmentVariable('WG_NODE_HOST', 'localhost'),
       port: new EnvironmentVariable('WG_NODE_PORT', '9991'),
     },
     nodeUrl: new EnvironmentVariable('WG_NODE_URL', 'http://localhost:9991/'),

--- a/docs-website/src/pages/docs/wundergraph-server-ts-reference/configure-wundergraph-server-options.md
+++ b/docs-website/src/pages/docs/wundergraph-server-ts-reference/configure-wundergraph-server-options.md
@@ -33,7 +33,7 @@ Each option when unset will get a value from the `Default Environment Variables`
 
 | Option         | Default Value           | Default Environment Variable |
 | -------------- | ----------------------- | ---------------------------- |
-| `listen.host`  | `127.0.0.1`             | `WG_SERVER_HOST`             |
+| `listen.host`  | `localhost`             | `WG_SERVER_HOST`             |
 | `listen.port`  | `9992`                  | `WG_SERVER_PORT`             |
 | `serverUrl`    | `http://localhost:9992` | `WG_SERVER_URL`              |
 | `logger.level` | `info`                  | `WG_LOG_LEVEL`               |
@@ -66,7 +66,7 @@ When using custom environment variables, you need to make sure that the environm
 export default configureWunderGraphServer<HooksConfig, InternalClient, WebhooksConfig>(() => ({
   options: {
     listen: {
-      host: '127.0.0.1',
+      host: 'localhost',
       port: '5555',
     },
     serverUrl: 'http://localhost:5555/',
@@ -85,7 +85,7 @@ import { EnvironmentVariable, LoggerLevel } from '@wundergraph/sdk'
 export default configureWunderGraphServer<HooksConfig, InternalClient, WebhooksConfig>(() => ({
   options: {
     listen: {
-      host: new EnvironmentVariable('SERVER_HOST', '127.0.0.1'),
+      host: new EnvironmentVariable('SERVER_HOST', 'localhost'),
       port: new EnvironmentVariable('SERVER_PORT', '4444'),
     },
     serverUrl: new EnvironmentVariable('SERVER_URL', 'http://localhost:4444/'),
@@ -109,7 +109,7 @@ import { EnvironmentVariable, LoggerLevel, WgEnv } from '@wundergraph/sdk'
 export default configureWunderGraphServer<HooksConfig, InternalClient, WebhooksConfig>(() => ({
   options: {
     listen: {
-      host: new EnvironmentVariable(WgEnv.ServerHost, '127.0.0.1'),
+      host: new EnvironmentVariable(WgEnv.ServerHost, 'localhost'),
       port: new EnvironmentVariable(WgEnv.ServerPort, '9992'),
     },
     serverUrl: new EnvironmentVariable(
@@ -126,7 +126,7 @@ export default configureWunderGraphServer<HooksConfig, InternalClient, WebhooksC
 export default configureWunderGraphServer<HooksConfig, InternalClient, WebhooksConfig>(() => ({
   options: {
     listen: {
-      host: new EnvironmentVariable('WG_SERVER_HOST', '127.0.0.1'),
+      host: new EnvironmentVariable('WG_SERVER_HOST', 'localhost'),
       port: new EnvironmentVariable('WG_SERVER_PORT', '9992'),
     },
     serverUrl: new EnvironmentVariable(

--- a/docs/wunderctl.md
+++ b/docs/wunderctl.md
@@ -8,10 +8,10 @@
 | ---------------- | -------------------------------------------------- | ----------------------- |
 | `WG_LOG_LEVEL`   | The log level of the WundeNode/WunderGraph Server. | `info`                  |
 | `WG_NODE_URL`    | The URL of the WunderNode.                         | `http://localhost:9991` |
-| `WG_NODE_HOST`   | The host of the WunderNode.                        | `127.0.0.1`             |
+| `WG_NODE_HOST`   | The host of the WunderNode.                        | `localhost`             |
 | `WG_NODE_PORT`   | The port of the WunderNode.                        | `9991`                  |
 | `WG_SERVER_URL`  | The URL of the WunderGraph Server.                 | `http://localhost:9992` |
-| `WG_SERVER_HOST` | The host of the WunderGraph Server.                | `127.0.0.1`             |
+| `WG_SERVER_HOST` | The host of the WunderGraph Server.                | `localhost`             |
 | `WG_SERVER_PORT` | The port of the WunderGraph Server.                | `9992`                  |
 
 ### Environment variables required for the cloud run
@@ -27,7 +27,7 @@
 | Variable name   | Description                                        | Default value           |
 | --------------- | -------------------------------------------------- | ----------------------- |
 | `WG_LOG_LEVEL`  | The log level of the WundeNode/WunderGraph Server. | `info`                  |
-| `WG_NODE_HOST`  | The host of the WunderNode.                        | `127.0.0.1`             |
+| `WG_NODE_HOST`  | The host of the WunderNode.                        | `localhost`             |
 | `WG_NODE_PORT`  | The port of the WunderNode.                        | `9991`                  |
 | `WG_SERVER_URL` | The URL of the WunderGraph Server.                 | `http://localhost:9992` |
 
@@ -39,5 +39,5 @@
 | ---------------- | --------------------------------------------------- | ----------------------- |
 | `WG_LOG_LEVEL`   | The log level of the WunderNode/WunderGraph Server. | `info`                  |
 | `WG_NODE_URL`    | The URL of the WunderNode.                          | `http://localhost:9991` |
-| `WG_SERVER_HOST` | The host of the WunderGraph Server.                 | `127.0.0.1`             |
+| `WG_SERVER_HOST` | The host of the WunderGraph Server.                 | `localhost`             |
 | `WG_SERVER_PORT` | The port of the WunderGraph Server.                 | `9992`                  |

--- a/docs/wundernode.md
+++ b/docs/wundernode.md
@@ -2,7 +2,7 @@
 
 #### Server listen
 
-`wunderctl up` Starts the server with default host `127.0.0.1` and port `9991`.
+`wunderctl up` Starts the server with default host `localhost` and port `9991`.
 
 By default, the server will listen on the address(es) (IPv4 and IPv6) resolved by `localhost` when no specific address is provided.
 If listening on any available interface is desired, then specifying `WG_NODE_HOST=0.0.0.0` for the address will

--- a/examples/graphql-sse-subscriptions/.wundergraph/wundergraph.config.ts
+++ b/examples/graphql-sse-subscriptions/.wundergraph/wundergraph.config.ts
@@ -19,7 +19,7 @@ type Subscription {
 
 const greetings = introspect.graphql({
 	apiNamespace: 'sse',
-	url: 'http://127.0.0.1:4000/graphql/stream',
+	url: 'http://localhost:4000/graphql/stream',
 	loadSchemaFromString: schema,
 	subscriptionsUseSSE: true,
 });

--- a/examples/graphql-sse-subscriptions/README.md
+++ b/examples/graphql-sse-subscriptions/README.md
@@ -24,7 +24,7 @@ type Subscription {
 
 const greetings = introspect.graphql({
   apiNamespace: 'sse',
-  url: 'http://127.0.0.1:4000/graphql/stream',
+  url: 'http://localhost:4000/graphql/stream',
   loadSchemaFromString: schema,
   subscriptionsUseSSE: true,
 });

--- a/examples/graphql-sse-subscriptions/gql-sse/server.ts
+++ b/examples/graphql-sse-subscriptions/gql-sse/server.ts
@@ -52,5 +52,5 @@ fastify.all('/graphql/stream', (req, res) =>
 	)
 );
 
-fastify.listen(4000, '127.0.0.1');
+fastify.listen(4000, 'localhost');
 console.log('Listening to port 4000');

--- a/examples/graphql-subscriptions-hooks/.wundergraph/wundergraph.config.ts
+++ b/examples/graphql-subscriptions-hooks/.wundergraph/wundergraph.config.ts
@@ -21,7 +21,7 @@ const counter = introspect.graphql({
 	id: 'counter',
 	apiNamespace: 'ws',
 	loadSchemaFromString: schema,
-	url: 'http://127.0.0.1:4000/graphql',
+	url: 'http://localhost:4000/graphql',
 });
 
 // configureWunderGraph emits the configuration

--- a/examples/graphql-subscriptions-hooks/README.md
+++ b/examples/graphql-subscriptions-hooks/README.md
@@ -10,7 +10,7 @@ const counter = introspect.graphql({
   id: 'counter',
   apiNamespace: 'ws',
   loadSchemaFromString: schema,
-  url: 'http://127.0.0.1:4000/graphql',
+  url: 'http://localhost:4000/graphql',
 });
 
 configureWunderGraphApplication({

--- a/examples/graphql-subscriptions-hooks/graphql-ws/server.ts
+++ b/examples/graphql-subscriptions-hooks/graphql-ws/server.ts
@@ -55,7 +55,7 @@ fastify.register(async (fastify) => {
 	fastify.get('/graphql', { websocket: true }, makeHandler({ schema }));
 });
 
-fastify.listen(4000, '127.0.0.1', (err) => {
+fastify.listen(4000, 'localhost', (err) => {
 	if (err) {
 		fastify.log.error(err);
 		return process.exit(1);

--- a/examples/graphql-ws-subscriptions/.wundergraph/wundergraph.config.ts
+++ b/examples/graphql-ws-subscriptions/.wundergraph/wundergraph.config.ts
@@ -20,7 +20,7 @@ type Subscription {
 const greeter = introspect.graphql({
 	apiNamespace: 'ws',
 	loadSchemaFromString: schema,
-	url: 'http://127.0.0.1:4000/graphql',
+	url: 'http://localhost:4000/graphql',
 });
 
 // configureWunderGraph emits the configuration

--- a/examples/graphql-ws-subscriptions/graphql-ws/server.ts
+++ b/examples/graphql-ws-subscriptions/graphql-ws/server.ts
@@ -51,7 +51,7 @@ fastify.register(async (fastify) => {
 	fastify.get('/graphql', { websocket: true }, makeHandler({ schema }));
 });
 
-fastify.listen({ port: 4000, host: '127.0.0.1' }, (err) => {
+fastify.listen({ port: 4000, host: 'localhost' }, (err) => {
 	if (err) {
 		fastify.log.error(err);
 		return process.exit(1);

--- a/examples/graphql-yoga-sse-subscriptions/.wundergraph/wundergraph.config.ts
+++ b/examples/graphql-yoga-sse-subscriptions/.wundergraph/wundergraph.config.ts
@@ -4,7 +4,7 @@ import operations from './wundergraph.operations';
 
 const counter = introspect.graphql({
 	apiNamespace: 'counter',
-	url: 'http://127.0.0.1:4000/graphql',
+	url: 'http://localhost:4000/graphql',
 	subscriptionsUseSSE: true,
 });
 

--- a/examples/graphql-yoga-sse-subscriptions/README.md
+++ b/examples/graphql-yoga-sse-subscriptions/README.md
@@ -5,7 +5,7 @@
 ```typescript
 const counter = introspect.graphql({
   apiNamespace: 'counter',
-  url: 'http://127.0.0.1:4000/graphql',
+  url: 'http://localhost:4000/graphql',
   subscriptionsUseSSE: true,
 });
 ```

--- a/examples/graphql-yoga-sse-subscriptions/yoga/server.ts
+++ b/examples/graphql-yoga-sse-subscriptions/yoga/server.ts
@@ -29,7 +29,7 @@ const server = createServer({
 			},
 		},
 	},
-	hostname: '127.0.0.1',
+	hostname: 'localhost',
 	port: 4000,
 });
 

--- a/packages/sdk/src/codegen/index.test.ts
+++ b/packages/sdk/src/codegen/index.test.ts
@@ -43,14 +43,14 @@ export const RunTemplateTest = async (...templates: Template[]) => {
 				nodeOptions: {
 					nodeUrl: {
 						kind: ConfigurationVariableKind.STATIC_CONFIGURATION_VARIABLE,
-						staticVariableContent: 'http://127.0.0.1:9991',
+						staticVariableContent: 'http://localhost:9991',
 						environmentVariableName: '',
 						environmentVariableDefaultValue: '',
 						placeholderVariableName: '',
 					},
 					publicNodeUrl: {
 						kind: ConfigurationVariableKind.STATIC_CONFIGURATION_VARIABLE,
-						staticVariableContent: 'http://127.0.0.1:9991',
+						staticVariableContent: 'http://localhost:9991',
 						environmentVariableName: '',
 						environmentVariableDefaultValue: '',
 						placeholderVariableName: '',
@@ -58,7 +58,7 @@ export const RunTemplateTest = async (...templates: Template[]) => {
 					listen: {
 						host: {
 							kind: ConfigurationVariableKind.STATIC_CONFIGURATION_VARIABLE,
-							staticVariableContent: '127.0.0.1',
+							staticVariableContent: 'localhost',
 							environmentVariableName: '',
 							environmentVariableDefaultValue: '',
 							placeholderVariableName: '',
@@ -85,7 +85,7 @@ export const RunTemplateTest = async (...templates: Template[]) => {
 				serverOptions: {
 					serverUrl: {
 						kind: ConfigurationVariableKind.STATIC_CONFIGURATION_VARIABLE,
-						staticVariableContent: 'http://127.0.0.1:9992',
+						staticVariableContent: 'http://localhost:9992',
 						environmentVariableName: '',
 						environmentVariableDefaultValue: '',
 						placeholderVariableName: '',
@@ -93,7 +93,7 @@ export const RunTemplateTest = async (...templates: Template[]) => {
 					listen: {
 						host: {
 							kind: ConfigurationVariableKind.STATIC_CONFIGURATION_VARIABLE,
-							staticVariableContent: '127.0.0.1',
+							staticVariableContent: 'localhost',
 							environmentVariableName: '',
 							environmentVariableDefaultValue: '',
 							placeholderVariableName: '',

--- a/packages/sdk/src/configure/options.ts
+++ b/packages/sdk/src/configure/options.ts
@@ -16,7 +16,7 @@ export enum WgEnv {
 
 export type LoggerLevel = 'fatal' | 'panic' | 'warning' | 'error' | 'info' | 'debug';
 
-const defaultHost = '127.0.0.1';
+const defaultHost = 'localhost';
 const defaultNodePort = '9991';
 const defaultServerPort = '9992';
 

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -274,7 +274,7 @@ func (n *Node) newListeners(configuration *apihandler.Listener) ([]net.Listener,
 	var listeners []net.Listener
 	var localhostIPs []net.IP
 
-	// If listening to 'localhost', listen to both 127.0.0.1 or ::1 if they are available.
+	// If listening to 'localhost', listen to both localhost or ::1 if they are available.
 	if host == "localhost" {
 		localhostIPs, _ = net.LookupIP(host)
 	}
@@ -283,6 +283,10 @@ func (n *Node) newListeners(configuration *apihandler.Listener) ([]net.Listener,
 		nip := ip.String()
 		// isIPv6
 		if strings.Contains(nip, ":") {
+			// Filter out link-local addresses
+			if strings.HasPrefix(nip, "fe80:") {
+				continue
+			}
 			listener, err := cfg.Listen(context.Background(), "tcp6", fmt.Sprintf("[%s]:%d", nip, port))
 			// in some cases e.g when ipv6 is not enabled in docker, listen will error
 			// in that case we ignore this error and try to listen to next ip

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -127,7 +127,7 @@ func TestNode(t *testing.T) {
 			},
 			Options: &apihandler.Options{
 				Listener: &apihandler.Listener{
-					Host: "127.0.0.1",
+					Host: "localhost",
 					Port: uint16(port),
 				},
 				Logging: apihandler.Logging{Level: zap.ErrorLevel},
@@ -276,7 +276,7 @@ func TestInMemoryCache(t *testing.T) {
 			},
 			Options: &apihandler.Options{
 				Listener: &apihandler.Listener{
-					Host: "127.0.0.1",
+					Host: "localhost",
 					Port: uint16(port),
 				},
 				Logging: apihandler.Logging{Level: zap.ErrorLevel},
@@ -383,7 +383,7 @@ func TestWebHooks(t *testing.T) {
 			Options: &apihandler.Options{
 				ServerUrl: testServer.URL,
 				Listener: &apihandler.Listener{
-					Host: "127.0.0.1",
+					Host: "localhost",
 					Port: uint16(port),
 				},
 				Logging: apihandler.Logging{Level: zap.ErrorLevel},
@@ -479,7 +479,7 @@ func BenchmarkNode(t *testing.B) {
 			},
 			Options: &apihandler.Options{
 				Listener: &apihandler.Listener{
-					Host: "127.0.0.1",
+					Host: "localhost",
 					Port: uint16(port),
 				},
 				Logging: apihandler.Logging{Level: zap.ErrorLevel},

--- a/pkg/s3uploadclient/helpers_test.go
+++ b/pkg/s3uploadclient/helpers_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func initClient() *s3uploadclient.S3UploadClient {
-	client, err := s3uploadclient.NewS3UploadClient("127.0.0.1:9000", s3uploadclient.Options{
+	client, err := s3uploadclient.NewS3UploadClient("localhost:9000", s3uploadclient.Options{
 		BucketName:      "uploads",
 		BucketLocation:  "eu-central-1",
 		AccessKeyID:     "test",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -469,6 +469,21 @@ importers:
       postgraphile: 4.12.11
       typescript: 4.8.4
 
+  testapps/issue-278:
+    specifiers:
+      '@types/node': ^14.14.37
+      '@wundergraph/nextjs': workspace:*
+      '@wundergraph/sdk': workspace:*
+      graphql: ^16.3.0
+      typescript: ^4.8.2
+    dependencies:
+      '@wundergraph/nextjs': link:../../packages/nextjs
+      '@wundergraph/sdk': link:../../packages/sdk
+      graphql: 16.6.0
+    devDependencies:
+      '@types/node': 14.18.33
+      typescript: 4.8.4
+
   testapps/mtls:
     specifiers:
       '@types/node': ^14.14.37

--- a/scripts/minio-setup.sh
+++ b/scripts/minio-setup.sh
@@ -15,7 +15,7 @@ if ! [[ -x scripts/mc ]]; then
 fi
 
 chmod +x ./scripts/mc
-./scripts/mc alias set minio http://127.0.0.1:9000 minio minio123
+./scripts/mc alias set minio http://localhost:9000 minio minio123
 ./scripts/mc admin user add minio test 12345678
 ./scripts/mc admin policy set minio readwrite user=test
 ./scripts/mc admin user info minio test

--- a/testapps/nextjs/.wundergraph/wundergraph.config.ts
+++ b/testapps/nextjs/.wundergraph/wundergraph.config.ts
@@ -134,7 +134,7 @@ configureWunderGraphApplication({
 	s3UploadProvider: [
 		{
 			name: 'minio',
-			endpoint: '127.0.0.1:9000',
+			endpoint: 'localhost:9000',
 			accessKeyID: 'test',
 			secretAccessKey: '12345678',
 			bucketLocation: 'eu-central-1',

--- a/testapps/nextjs/minio/setup.sh
+++ b/testapps/nextjs/minio/setup.sh
@@ -6,7 +6,7 @@ docker-compose up -d
 sleep 3
 
 function setupMinio () {
-    docker-compose exec minio1 mc alias set myminio/ http://127.0.0.1:9000 minio minio123
+    docker-compose exec minio1 mc alias set myminio/ http://localhost:9000 minio minio123
     docker-compose exec minio1 mc admin user add myminio test 12345678
     docker-compose exec minio1 mc admin policy set myminio readwrite user=test
     docker-compose exec minio1 mc admin user info myminio test

--- a/testapps/nextjs/pages/react-query/upload.tsx
+++ b/testapps/nextjs/pages/react-query/upload.tsx
@@ -41,7 +41,7 @@ const UploadPage: NextPage = () => {
 				<ul>
 					{data.map((file) => (
 						<li key={file}>
-							<a target="_blank" href={`http://127.0.0.1:9000/uploads/${file}`}>
+							<a target="_blank" href={`http://localhost:9000/uploads/${file}`}>
 								{file}
 							</a>
 						</li>

--- a/testapps/nextjs/pages/upload.tsx
+++ b/testapps/nextjs/pages/upload.tsx
@@ -41,7 +41,7 @@ const UploadPage: NextPage = () => {
 				<ul>
 					{data.map((file) => (
 						<li key={file}>
-							<a target="_blank" href={`http://127.0.0.1:9000/uploads/${file}`}>
+							<a target="_blank" href={`http://localhost:9000/uploads/${file}`}>
 								{file}
 							</a>
 						</li>

--- a/testapps/vite/.wundergraph/wundergraph.config.ts
+++ b/testapps/vite/.wundergraph/wundergraph.config.ts
@@ -111,7 +111,7 @@ configureWunderGraphApplication({
 	s3UploadProvider: [
 		{
 			name: 'minio',
-			endpoint: '127.0.0.1:9000',
+			endpoint: 'localhost:9000',
 			accessKeyID: 'test',
 			secretAccessKey: '12345678',
 			bucketLocation: 'eu-central-1',
@@ -130,7 +130,7 @@ configureWunderGraphApplication({
 	],
 	cors: {
 		...cors.allowAll,
-		allowedOrigins: ['http://localhost:5173', 'http://127.0.0.1:5173'],
+		allowedOrigins: ['http://localhost:5173', 'http://localhost:5173'],
 	},
 	authentication: {
 		cookieBased: {


### PR DESCRIPTION
Node 18 gives ipv6 localhost resolution priority over ipv4, so connecting
to localhost won't work properly in a lot of system. To fix that,
listen on localhost instead of 127.0.0.1.

Fixes #414
Closes ENG-908
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

<!--
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->
