### PR TITLE
fix: react-query dependency in testsapps/nextjs

### DIFF
--- a/testapps/nextjs/package.json
+++ b/testapps/nextjs/package.json
@@ -29,7 +29,7 @@
     "@graphql-yoga/node": "^2.13.13",
     "@tanstack/react-query": "^4.16.1",
     "@wundergraph/nextjs": "workspace:*",
-    "@wundergraph/react-query": "workspace:^0.1.0",
+    "@wundergraph/react-query": "workspace:*",
     "@wundergraph/sdk": "workspace:*",
     "@wundergraph/swr": "workspace:*",
     "next": "^12.1.6",


### PR DESCRIPTION
We need to depend on the workspace, not on an specific version

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

<!--
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->
