### PR TITLE
feat: find WG context based on config file

### DIFF
--- a/cli/commands/root.go
+++ b/cli/commands/root.go
@@ -221,7 +221,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&rootFlags.Telemetry, "telemetry", !isTelemetryDisabled, "enables telemetry. Telemetry allows us to accurately gauge WunderGraph feature usage, pain points, and customization across all users.")
 	rootCmd.PersistentFlags().BoolVar(&rootFlags.TelemetryDebugMode, "telemetry-debug", isTelemetryDebugEnabled, "enables the debug mode for telemetry. Understand what telemetry is being sent to us.")
 	rootCmd.PersistentFlags().BoolVar(&rootFlags.PrettyLogs, "pretty-logging", false, "switches to human readable format")
-	rootCmd.PersistentFlags().StringVar(&_wunderGraphDirConfig, "wundergraph-dir", ".", "path to your .wundergraph directory")
+	rootCmd.PersistentFlags().StringVar(&_wunderGraphDirConfig, "wundergraph-dir", ".", "directory of your wundergraph.config.ts")
 	rootCmd.PersistentFlags().BoolVar(&disableCache, "no-cache", false, "disables local caches")
 	rootCmd.PersistentFlags().BoolVar(&clearCache, "clear-cache", false, "clears local caches during startup")
 }

--- a/cli/commands/root.go
+++ b/cli/commands/root.go
@@ -221,7 +221,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&rootFlags.Telemetry, "telemetry", !isTelemetryDisabled, "enables telemetry. Telemetry allows us to accurately gauge WunderGraph feature usage, pain points, and customization across all users.")
 	rootCmd.PersistentFlags().BoolVar(&rootFlags.TelemetryDebugMode, "telemetry-debug", isTelemetryDebugEnabled, "enables the debug mode for telemetry. Understand what telemetry is being sent to us.")
 	rootCmd.PersistentFlags().BoolVar(&rootFlags.PrettyLogs, "pretty-logging", false, "switches to human readable format")
-	rootCmd.PersistentFlags().StringVar(&_wunderGraphDirConfig, "wundergraph-dir", files.WunderGraphDirName, "path to your .wundergraph directory")
+	rootCmd.PersistentFlags().StringVar(&_wunderGraphDirConfig, "wundergraph-dir", ".", "path to your .wundergraph directory")
 	rootCmd.PersistentFlags().BoolVar(&disableCache, "no-cache", false, "disables local caches")
 	rootCmd.PersistentFlags().BoolVar(&clearCache, "clear-cache", false, "clears local caches during startup")
 }

--- a/pkg/files/files.go
+++ b/pkg/files/files.go
@@ -2,13 +2,14 @@ package files
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
 )
 
 const (
-	WunderGraphDirName = ".wundergraph"
+	WunderGraphConfigFilename = "wundergraph.config.ts"
 )
 
 func DirectoryExists(path string) bool {
@@ -26,39 +27,34 @@ func FileExists(filePath string) bool {
 	return true
 }
 
-func findWunderGraphDirInParent() (string, error) {
-	// Check if we already operate inside .wundergraph directory
-	wd, err := os.Getwd()
-	if err != nil {
-		return "", fmt.Errorf("could not get your current working directory")
-	}
-
-	parentWunderGraphDir := path.Join(wd, "..", WunderGraphDirName)
-	if DirectoryExists(parentWunderGraphDir) {
-		return parentWunderGraphDir, nil
-	}
-
-	return "", fmt.Errorf("could not find .wundergraph directory")
-}
-
-// FindWunderGraphDir returns the absolute path to the .wundergraph directory.
-// If the wundergraphDir can't be found we try to find it in the parent directory.
-// If no directory is found we return an error.
+// FindWunderGraphDir returns the absolute path to the directory of the wundergraph.config.ts file.
 func FindWunderGraphDir(wundergraphDir string) (string, error) {
 	absWgDir, err := filepath.Abs(wundergraphDir)
 	if err != nil {
-		return "", fmt.Errorf("unable to get absolute path from .wundergraph dir: %w", err)
+		return "", fmt.Errorf("unable to get absolute path of %s dir: %w", wundergraphDir, err)
 	}
 
-	if !DirectoryExists(absWgDir) {
-		dir, err := findWunderGraphDirInParent()
-		if err != nil {
-			return "", fmt.Errorf(`unable to find .wundergraph dir: %w`, err)
-		}
-		return dir, nil
+	wgDir := ""
+
+	err = filepath.WalkDir(absWgDir,
+		func(path string, info os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if info.IsDir() && info.Name() == "node_modules" {
+				return filepath.SkipDir
+			} else if !info.IsDir() && info.Name() == WunderGraphConfigFilename {
+				wgDir = filepath.Dir(path)
+				return io.EOF
+			}
+			return nil
+		})
+
+	if err != nil && err != io.EOF {
+		return "", fmt.Errorf(`unable to find %s in %s or children: %w`, WunderGraphConfigFilename, wundergraphDir, err)
 	}
 
-	return absWgDir, nil
+	return wgDir, nil
 }
 
 // CodeFilePath returns the absolute path to the file and returns an error if the file does not exist.

--- a/pkg/files/files.go
+++ b/pkg/files/files.go
@@ -41,9 +41,12 @@ func FindWunderGraphDir(wundergraphDir string) (string, error) {
 			if err != nil {
 				return err
 			}
+
 			if info.IsDir() && info.Name() == "node_modules" {
 				return filepath.SkipDir
-			} else if !info.IsDir() && info.Name() == WunderGraphConfigFilename {
+			}
+
+			if !info.IsDir() && info.Name() == WunderGraphConfigFilename {
 				wgDir = filepath.Dir(path)
 				return io.EOF
 			}


### PR DESCRIPTION
This simplifies the build pipeline, so we don't need to pass this path explicitly for different use cases.
For example, when we allow the user to run a custom build script.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `make test`
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)

<!--
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->
