### PR TITLE
feat: copy wunderctl bin to wundergraph home dir

### DIFF
--- a/packages/wunderctl/README.md
+++ b/packages/wunderctl/README.md
@@ -5,6 +5,8 @@
 This package is a wrapper for the wunderctl Go binary. It makes it super easy to run wundergraph commands from your terminal.
 This package is not required if you have already installed [`@wundergraph/sdk`](https://github.com/wundergraph/wundergraph/tree/main/packages/sdk). The SDK is shipped with the compatible wunderctl Go binary for development.
 
+> **Note:** This package uses postinstall script to download and install the wunderctl binary.
+
 ## Getting Started
 
 ```shell

--- a/packages/wunderctl/README.md
+++ b/packages/wunderctl/README.md
@@ -17,3 +17,7 @@ npx @wundergraph/wunderctl --help
 ```
 
 > **Warning**: Please use the Go [release](https://github.com/wundergraph/wundergraph/releases) binary to start the wundergraph server in production.
+
+## Misc
+
+You can pass `WG_COPY_BIN_PATH` to copy the installed binary to a specific path. This is useful if you want to use the binary in your CI/CD pipeline.

--- a/packages/wunderctl/src/installer.ts
+++ b/packages/wunderctl/src/installer.ts
@@ -20,7 +20,7 @@ export const installer = async (version: string, installDir: string, binaryName:
 		// That's a convenience, so we have a fixed path to current installed binary
 		if (process.env.WG_COPY_BIN_PATH) {
 			log(`copy binary to wundergraph home bin directory`);
-			CopyBinToWgDir(log, binaryPath, process.env.WG_COPY_BIN_PATH);
+			copyFileRecursive(log, binaryPath, process.env.WG_COPY_BIN_PATH);
 		}
 		return;
 	}
@@ -58,7 +58,7 @@ export const installer = async (version: string, installDir: string, binaryName:
 			// That's a convenience, so we have a fixed path to current installed binary
 			if (process.env.WG_COPY_BIN_PATH) {
 				log(`copy binary to wundergraph home bin directory`);
-				CopyBinToWgDir(log, binaryPath, process.env.WG_COPY_BIN_PATH);
+				copyFileRecursive(log, binaryPath, process.env.WG_COPY_BIN_PATH);
 			}
 		});
 		outStream.addListener('error', (err) => {
@@ -71,7 +71,7 @@ export const installer = async (version: string, installDir: string, binaryName:
 	}
 };
 
-function CopyBinToWgDir(log: debug.Debugger, filePath: string, targetPath: string) {
+function copyFileRecursive(log: debug.Debugger, filePath: string, targetPath: string) {
 	fs.mkdirSync(path.dirname(targetPath), { recursive: true });
 	fs.copyFileSync(filePath, targetPath);
 }

--- a/packages/wunderctl/src/installer.ts
+++ b/packages/wunderctl/src/installer.ts
@@ -6,7 +6,7 @@ import os from 'os';
 import rimraf from 'rimraf';
 import { logger } from './logger';
 import path from 'path';
-import debug from 'debug';
+import type debug from 'debug';
 
 export const installer = async (version: string, installDir: string, binaryName: string) => {
 	const log = logger.extend('install');
@@ -18,10 +18,9 @@ export const installer = async (version: string, installDir: string, binaryName:
 
 	if (locker.exists()) {
 		log(`Lock file already exists, skipping the download of the binary ${version}`);
-		// That's a convenience for the cloud, so we don't have to download the binary every time
-		// or have to find the binary in the docker container
+		// That's a convenience for the cloud, so we have a fixed path to current binary
 		if (process.env.WG_CLOUD === 'true') {
-			log(`copy binary to wundergraph home directory`);
+			log(`copy binary to wundergraph home bin directory`);
 			CopyBinToWgDir(log, binaryPath, binaryName);
 		}
 		return;
@@ -57,10 +56,9 @@ export const installer = async (version: string, installDir: string, binaryName:
 			log(`make binary executable`);
 			chmodX(binaryPath);
 
-			// That's a convenience for the cloud, so we don't have to download the binary every time
-			// or have to find the binary in the docker container
+			// That's a convenience for the cloud, so we have a fixed path to current binary
 			if (process.env.WG_CLOUD === 'true') {
-				log(`copy binary to wundergraph home directory`);
+				log(`copy binary to wundergraph home bin directory`);
 				CopyBinToWgDir(log, binaryPath, binaryName);
 			}
 		});

--- a/packages/wunderctl/src/installer.ts
+++ b/packages/wunderctl/src/installer.ts
@@ -18,8 +18,8 @@ export const installer = async (version: string, installDir: string, binaryName:
 
 	if (locker.exists()) {
 		log(`Lock file already exists, skipping the download of the binary ${version}`);
-		// That's a convenience for the cloud, so we have a fixed path to current binary
-		if (process.env.WG_CLOUD === 'true') {
+		// That's a convenience, so we have a fixed path to current installed binary
+		if (process.env.CI) {
 			log(`copy binary to wundergraph home bin directory`);
 			CopyBinToWgDir(log, binaryPath, binaryName);
 		}
@@ -56,8 +56,8 @@ export const installer = async (version: string, installDir: string, binaryName:
 			log(`make binary executable`);
 			chmodX(binaryPath);
 
-			// That's a convenience for the cloud, so we have a fixed path to current binary
-			if (process.env.WG_CLOUD === 'true') {
+			// That's a convenience, so we have a fixed path to current installed binary
+			if (process.env.CI) {
 				log(`copy binary to wundergraph home bin directory`);
 				CopyBinToWgDir(log, binaryPath, binaryName);
 			}

--- a/packages/wunderctl/src/installer.ts
+++ b/packages/wunderctl/src/installer.ts
@@ -19,7 +19,7 @@ export const installer = async (version: string, installDir: string, binaryName:
 		log(`Lock file already exists, skipping the download of the binary ${version}`);
 		// That's a convenience, so we have a fixed path to current installed binary
 		if (process.env.WG_COPY_BIN_PATH) {
-			log(`copy binary to wundergraph home bin directory`);
+			log(`copy binary to ${process.env.WG_COPY_BIN_PATH}`);
 			copyFileRecursive(log, binaryPath, process.env.WG_COPY_BIN_PATH);
 		}
 		return;
@@ -57,7 +57,7 @@ export const installer = async (version: string, installDir: string, binaryName:
 
 			// That's a convenience, so we have a fixed path to current installed binary
 			if (process.env.WG_COPY_BIN_PATH) {
-				log(`copy binary to wundergraph home bin directory`);
+				log(`copy binary to ${process.env.WG_COPY_BIN_PATH}`);
 				copyFileRecursive(log, binaryPath, process.env.WG_COPY_BIN_PATH);
 			}
 		});

--- a/packages/wunderctl/src/installer.ts
+++ b/packages/wunderctl/src/installer.ts
@@ -16,10 +16,10 @@ export const installer = async (version: string, installDir: string, binaryName:
 	const locker = LockFile(version, lockFile);
 
 	if (locker.exists()) {
-		log(`Lock file already exists, skipping the download of the binary ${version}`);
+		log(`Lock file already exists, skipping the download of the binary v${version}`);
 		// That's a convenience, so we have a fixed path to current installed binary
 		if (process.env.WG_COPY_BIN_PATH) {
-			log(`copy binary to ${process.env.WG_COPY_BIN_PATH}`);
+			log(`copy v${version} binary to ${process.env.WG_COPY_BIN_PATH}`);
 			copyFileRecursive(log, binaryPath, process.env.WG_COPY_BIN_PATH);
 		}
 		return;
@@ -57,7 +57,7 @@ export const installer = async (version: string, installDir: string, binaryName:
 
 			// That's a convenience, so we have a fixed path to current installed binary
 			if (process.env.WG_COPY_BIN_PATH) {
-				log(`copy binary to ${process.env.WG_COPY_BIN_PATH}`);
+				log(`copy v${version} binary to ${process.env.WG_COPY_BIN_PATH}`);
 				copyFileRecursive(log, binaryPath, process.env.WG_COPY_BIN_PATH);
 			}
 		});

--- a/packages/wunderctl/src/installer.ts
+++ b/packages/wunderctl/src/installer.ts
@@ -2,7 +2,6 @@ import axios from 'axios';
 import { x } from 'tar';
 import { downloadURL } from './binarypath';
 import * as fs from 'fs';
-import os from 'os';
 import rimraf from 'rimraf';
 import { logger } from './logger';
 import path from 'path';
@@ -19,9 +18,9 @@ export const installer = async (version: string, installDir: string, binaryName:
 	if (locker.exists()) {
 		log(`Lock file already exists, skipping the download of the binary ${version}`);
 		// That's a convenience, so we have a fixed path to current installed binary
-		if (process.env.CI) {
+		if (process.env.WG_COPY_BIN_PATH) {
 			log(`copy binary to wundergraph home bin directory`);
-			CopyBinToWgDir(log, binaryPath, binaryName);
+			CopyBinToWgDir(log, binaryPath, process.env.WG_COPY_BIN_PATH);
 		}
 		return;
 	}
@@ -57,9 +56,9 @@ export const installer = async (version: string, installDir: string, binaryName:
 			chmodX(binaryPath);
 
 			// That's a convenience, so we have a fixed path to current installed binary
-			if (process.env.CI) {
+			if (process.env.WG_COPY_BIN_PATH) {
 				log(`copy binary to wundergraph home bin directory`);
-				CopyBinToWgDir(log, binaryPath, binaryName);
+				CopyBinToWgDir(log, binaryPath, process.env.WG_COPY_BIN_PATH);
 			}
 		});
 		outStream.addListener('error', (err) => {
@@ -72,10 +71,9 @@ export const installer = async (version: string, installDir: string, binaryName:
 	}
 };
 
-function CopyBinToWgDir(log: debug.Debugger, filePath: string, relTargetPath: string) {
-	const binDir = path.join(os.homedir(), '.wundergraph', 'bin');
-	fs.mkdirSync(binDir, { recursive: true });
-	fs.copyFileSync(filePath, path.join(binDir, relTargetPath));
+function CopyBinToWgDir(log: debug.Debugger, filePath: string, targetPath: string) {
+	fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+	fs.copyFileSync(filePath, targetPath);
 }
 
 function LockFile(version: string, lockFile: string) {

--- a/packages/wunderctl/src/installer.ts
+++ b/packages/wunderctl/src/installer.ts
@@ -71,9 +71,9 @@ export const installer = async (version: string, installDir: string, binaryName:
 	}
 };
 
-function copyFileRecursive(log: debug.Debugger, filePath: string, targetPath: string) {
-	fs.mkdirSync(path.dirname(targetPath), { recursive: true });
-	fs.copyFileSync(filePath, targetPath);
+function copyFileRecursive(log: debug.Debugger, sourceFilePath: string, targetFilePath: string) {
+	fs.mkdirSync(path.dirname(targetFilePath), { recursive: true });
+	fs.copyFileSync(sourceFilePath, targetFilePath);
 }
 
 function LockFile(version: string, lockFile: string) {

--- a/packages/wunderctl/src/installer.ts
+++ b/packages/wunderctl/src/installer.ts
@@ -98,10 +98,7 @@ function LockFile(version: string, lockFile: string) {
 		exists: () => {
 			if (fs.existsSync(lockFile)) {
 				const data = fs.readFileSync(lockFile, 'utf-8');
-				if (data === version) {
-					return true;
-				}
-				return false;
+				return data === version;
 			}
 		},
 	};


### PR DESCRIPTION
The user can set ` WG_COPY_BIN_PATH=~/.wundergraph/bin/wunderctl` to install the current wunderctl binary to a custom location. This is a convenient way to use the binary directly e.g. in docker, instead spawning a child process with `npm exec`, which also slows down cold starts by hundreds of milliseconds. Intentionally, we don't make the binary available to the user by default to not collide with different versions.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `make test`
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)

<!--
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->
