### PR TITLE
feat: improve backoff settings for cold starts

### DIFF
--- a/pkg/telemetry/client.go
+++ b/pkg/telemetry/client.go
@@ -79,7 +79,7 @@ func NewClient(address string, clientInfo MetricClientInfo, opts ...ClientOption
 	if c.httpClient == nil {
 		retryClient := retryablehttp.NewClient()
 		retryClient.HTTPClient.Timeout = c.timeout
-		retryClient.RetryMax = 1
+		retryClient.RetryMax = 3
 		retryClient.Logger = nil
 		c.httpClient = retryClient.StandardClient()
 	}


### PR DESCRIPTION
After some testing, this is the sweet spot to archive better cold starts. Tested in FRA, fastest numbers after five trials:

Before: ~1.4s
After: ~1.08s

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `make test`
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)

<!--
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->
