### PR TITLE
fix: filter only folders while listing examples

### DIFF
--- a/packages/create-wundergraph-app/package.json
+++ b/packages/create-wundergraph-app/package.json
@@ -32,7 +32,7 @@
     "commander": "^9.4.1",
     "dotenv": "^16.0.3",
     "figlet": "^1.5.2",
-    "got": "^11.8.5",
+    "got": "^11.8.6",
     "gradient-string": "^2.0.2",
     "inquirer": "^8.0.0",
     "log-symbols": "^4.1.0",

--- a/packages/create-wundergraph-app/src/helpers/examples.ts
+++ b/packages/create-wundergraph-app/src/helpers/examples.ts
@@ -10,8 +10,8 @@ export const getExamplesList = async (ref: string) => {
 		});
 	const exampleDirectories = JSON.parse(exampleDirectoriesResponse.body);
 	const examples: string[] = [];
-	exampleDirectories.forEach((element: { name: string }) => {
-		examples.push(element.name);
+	exampleDirectories.forEach((element: { name: string; type: string }) => {
+		if (element.type === 'dir') examples.push(element.name);
 	});
 	return examples;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,7 +114,7 @@ importers:
       commander: ^9.4.1
       dotenv: ^16.0.3
       figlet: ^1.5.2
-      got: ^11.8.5
+      got: ^11.8.6
       gradient-string: ^2.0.2
       inquirer: ^8.0.0
       jest: ^29.3.1
@@ -129,7 +129,7 @@ importers:
       commander: 9.4.1
       dotenv: 16.0.3
       figlet: 1.5.2
-      got: 11.8.5
+      got: 11.8.6
       gradient-string: 2.0.2
       inquirer: 8.2.5
       log-symbols: 4.1.0
@@ -7411,8 +7411,8 @@ packages:
     dependencies:
       get-intrinsic: 1.1.3
 
-  /got/11.8.5:
-    resolution: {integrity: sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==}
+  /got/11.8.6:
+    resolution: {integrity: sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==}
     engines: {node: '>=10.19.0'}
     dependencies:
       '@sindresorhus/is': 4.6.0


### PR DESCRIPTION
#### Checklist

- [x] run `make test`
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)

<!--
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->
