### PR TITLE
fix: incorrectly derived filesystem paths on Windows

### DIFF
--- a/cli/commands/generate.go
+++ b/cli/commands/generate.go
@@ -3,7 +3,7 @@ package commands
 import (
 	"context"
 	"fmt"
-	"path"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
@@ -49,7 +49,7 @@ var generateCmd = &cobra.Command{
 
 		ctx := context.Background()
 
-		configOutFile := path.Join("generated", "bundle", "config.js")
+		configOutFile := filepath.Join("generated", "bundle", "config.js")
 
 		configRunner := scriptrunner.NewScriptRunner(&scriptrunner.Config{
 			Name:          "config-runner",
@@ -82,9 +82,9 @@ var generateCmd = &cobra.Command{
 		var onAfterBuild func() error
 
 		if codeServerFilePath != "" {
-			serverOutFile := path.Join(wunderGraphDir, "generated", "bundle", "server.js")
-			webhooksOutDir := path.Join("generated", "bundle", "webhooks")
-			webhooksDir := path.Join(wunderGraphDir, webhooks.WebhookDirectoryName)
+			serverOutFile := filepath.Join(wunderGraphDir, "generated", "bundle", "server.js")
+			webhooksOutDir := filepath.Join("generated", "bundle", "webhooks")
+			webhooksDir := filepath.Join(wunderGraphDir, webhooks.WebhookDirectoryName)
 
 			var webhooksBundler *bundler.Bundler
 

--- a/cli/commands/node.go
+++ b/cli/commands/node.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"path"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -107,7 +107,7 @@ func StartWunderGraphNode(n *node.Node, opts ...Option) error {
 		opts[i](&options)
 	}
 
-	configFile := path.Join(n.WundergraphDir, "generated", configJsonFilename)
+	configFile := filepath.Join(n.WundergraphDir, "generated", configJsonFilename)
 	if !files.FileExists(configFile) {
 		return fmt.Errorf("could not find configuration file: %s", configFile)
 	}

--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"path"
+	"path/filepath"
 	"syscall"
 
 	"github.com/spf13/cobra"
@@ -57,13 +57,13 @@ func startWunderGraphServer(ctx context.Context) error {
 		return err
 	}
 
-	configFile := path.Join(wunderGraphDir, "generated", configJsonFilename)
+	configFile := filepath.Join(wunderGraphDir, "generated", configJsonFilename)
 	if !files.FileExists(configFile) {
 		return fmt.Errorf("could not find configuration file: %s", configFile)
 	}
 
-	serverScriptFile := path.Join("generated", "bundle", "server.js")
-	serverExecutablePath := path.Join(wunderGraphDir, serverScriptFile)
+	serverScriptFile := filepath.Join("generated", "bundle", "server.js")
+	serverExecutablePath := filepath.Join(wunderGraphDir, serverScriptFile)
 	if !files.FileExists(serverExecutablePath) {
 		return fmt.Errorf(`hooks server executable "%s" not found`, serverExecutablePath)
 	}

--- a/cli/commands/up.go
+++ b/cli/commands/up.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"path"
+	"path/filepath"
 	"sync"
 	"syscall"
 
@@ -67,13 +67,13 @@ var upCmd = &cobra.Command{
 			zap.String("builtBy", BuildInfo.BuiltBy),
 		)
 
-		introspectionCacheDir := path.Join(wunderGraphDir, "cache", "introspection")
+		introspectionCacheDir := filepath.Join(wunderGraphDir, "cache", "introspection")
 
-		configJsonPath := path.Join(wunderGraphDir, "generated", configJsonFilename)
-		webhooksDir := path.Join(wunderGraphDir, webhooks.WebhookDirectoryName)
-		configOutFile := path.Join("generated", "bundle", "config.js")
-		serverOutFile := path.Join("generated", "bundle", "server.js")
-		webhooksOutDir := path.Join("generated", "bundle", "webhooks")
+		configJsonPath := filepath.Join(wunderGraphDir, "generated", configJsonFilename)
+		webhooksDir := filepath.Join(wunderGraphDir, webhooks.WebhookDirectoryName)
+		configOutFile := filepath.Join("generated", "bundle", "config.js")
+		serverOutFile := filepath.Join("generated", "bundle", "server.js")
+		webhooksOutDir := filepath.Join("generated", "bundle", "webhooks")
 
 		if port, err := helpers.ServerPortFromConfig(configJsonPath); err == nil {
 			helpers.KillExistingHooksProcess(port, log)
@@ -212,8 +212,8 @@ var upCmd = &cobra.Command{
 			OutFile:       configOutFile,
 			Logger:        log,
 			WatchPaths: []*watcher.WatchPath{
-				{Path: path.Join(wunderGraphDir, "operations"), Optional: true},
-				{Path: path.Join(wunderGraphDir, "fragments"), Optional: true},
+				{Path: filepath.Join(wunderGraphDir, "operations"), Optional: true},
+				{Path: filepath.Join(wunderGraphDir, "fragments"), Optional: true},
 				// all webhook filenames are stored in the config
 				// we are going to create HTTP routes on the node for all of them
 				{Path: webhooksDir, Optional: true},
@@ -261,7 +261,7 @@ var upCmd = &cobra.Command{
 
 		n := node.New(ctx, BuildInfo, wunderGraphDir, log)
 		go func() {
-			configFile := path.Join(wunderGraphDir, "generated", "wundergraph.config.json")
+			configFile := filepath.Join(wunderGraphDir, "generated", "wundergraph.config.json")
 			err := n.StartBlocking(
 				node.WithConfigFileChange(configFileChangeChan),
 				node.WithFileSystemConfig(configFile),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -35,7 +34,7 @@ func ConfigDir() string {
 
 // ConfigFilePath - returns the path to the config file
 func ConfigFilePath() string {
-	return path.Join(configDir, "config.json")
+	return filepath.Join(configDir, "config.json")
 }
 
 func initConfigDir() error {

--- a/pkg/datasources/database/engine.go
+++ b/pkg/datasources/database/engine.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -272,8 +271,8 @@ func (e *Engine) ensurePrisma() error {
 		return err
 	}
 
-	e.queryEnginePath = path.Join(prismaPath, binaries.EngineVersion, fmt.Sprintf("prisma-query-engine-%s", platform.BinaryPlatformName()))
-	e.introspectionEnginePath = path.Join(prismaPath, binaries.EngineVersion, fmt.Sprintf("prisma-introspection-engine-%s", platform.BinaryPlatformName()))
+	e.queryEnginePath = filepath.Join(prismaPath, binaries.EngineVersion, fmt.Sprintf("prisma-query-engine-%s", platform.BinaryPlatformName()))
+	e.introspectionEnginePath = filepath.Join(prismaPath, binaries.EngineVersion, fmt.Sprintf("prisma-introspection-engine-%s", platform.BinaryPlatformName()))
 
 	// Acquire a file lock before trying to download
 	lockPath := filepath.Join(prismaPath, ".lock")

--- a/pkg/files/files.go
+++ b/pkg/files/files.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 	"path/filepath"
 )
 
@@ -62,7 +61,7 @@ func FindWunderGraphDir(wundergraphDir string) (string, error) {
 
 // CodeFilePath returns the absolute path to the file and returns an error if the file does not exist.
 func CodeFilePath(wundergraphDir, filename string) (string, error) {
-	configEntryPoint := path.Join(wundergraphDir, filename)
+	configEntryPoint := filepath.Join(wundergraphDir, filename)
 
 	if FileExists(configEntryPoint) {
 		return configEntryPoint, nil

--- a/pkg/webhooks/webhooks.go
+++ b/pkg/webhooks/webhooks.go
@@ -2,14 +2,14 @@ package webhooks
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 )
 
 const WebhookDirectoryName = "webhooks"
 
 func GetWebhooks(wunderGraphDir string) ([]string, error) {
-	webhooksDirectoryAbs := path.Join(wunderGraphDir, WebhookDirectoryName)
+	webhooksDirectoryAbs := filepath.Join(wunderGraphDir, WebhookDirectoryName)
 	des, err := os.ReadDir(webhooksDirectoryAbs)
 	if err != nil {
 		return nil, err
@@ -19,7 +19,7 @@ func GetWebhooks(wunderGraphDir string) ([]string, error) {
 		if entry.IsDir() || strings.HasSuffix(entry.Name(), ".d.ts") || !strings.HasSuffix(entry.Name(), ".ts") {
 			continue
 		}
-		webhookFilePaths = append(webhookFilePaths, path.Join(WebhookDirectoryName, entry.Name()))
+		webhookFilePaths = append(webhookFilePaths, filepath.Join(WebhookDirectoryName, entry.Name()))
 	}
 	return webhookFilePaths, nil
 }


### PR DESCRIPTION
Use filepath.Join() instead of path.Join() to construct filesystem paths.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->


<!--
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->
