### PR TITLE
fix: Fix query string with similar variables

### DIFF
--- a/pkg/datasources/database/datasource.go
+++ b/pkg/datasources/database/datasource.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
 	"runtime"
-	"strings"
 	"sync"
 	"time"
 
@@ -173,7 +173,9 @@ func (p *Planner) ConfigureFetch() plan.FetchConfiguration {
 			Renderer: renderer,
 		}
 		replacement, _ := p.variables.AddVariable(variable)
-		input.Query = strings.Replace(input.Query, currentName, replacement, -1)
+		reg := regexp.MustCompile(`\` + currentName + `([^\w\d])`)
+		input.Query = reg.ReplaceAllString(input.Query, "$$" + replacement + "$$$1")
+		// input.Query = strings.Replace(input.Query, currentName, replacement, -1)
 	}
 
 	rawInput, err := json.Marshal(input)


### PR DESCRIPTION
Here is the following user case:

```
mutation CreateUser($provider: String!, $providerId: String!, $providerUserId: String!) {
  local_createOneUser(
    data: {provider: $provider, providerId: $providerId, providerUserId: $providerUserId}
  ) {
    avatar
    id
  }
}
```

This will be replaced as 
```
mutation{createOneAppUser(data: {nickname: $$0$$,avatar: $$1$$,provider: $$2$$,providerId: $$2$$Id,providerUserId: $$2$$UserId}){avatar id}}
```

because `providerId` and `providerUserId` was replaced by `$provider` in early position.

So my solution is replace variables by not ending with characters `[^\w\d]`

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `make test`
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)

<!--
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->
