### PR TITLE
feat: add support for videos in docs

### DIFF
--- a/docs-website/markdoc/tags.js
+++ b/docs-website/markdoc/tags.js
@@ -1,5 +1,6 @@
 import { Callout } from '@/components/Callout'
 import { QuickLink, QuickLinks } from '@/components/QuickLinks'
+import Video from '../src/components/Video'
 
 const tags = {
 	callout: {
@@ -13,6 +14,19 @@ const tags = {
 			},
 		},
 		render: Callout,
+	},
+	video: {
+		render: Video,
+		children: ['inline'],
+		attributes: {
+			src: { type: String, required: true },
+			className: { type: String },
+			autoPlay: { type: Boolean },
+			muted: { type: Boolean },
+			playsInline: { type: Boolean },
+			loop: { type: Boolean },
+			controls: { type: Boolean },
+		},
 	},
 	figure: {
 		selfClosing: true,

--- a/docs-website/src/components/Video.tsx
+++ b/docs-website/src/components/Video.tsx
@@ -1,0 +1,26 @@
+import clsx from 'clsx'
+import { HTMLProps } from 'react'
+
+const Video = ({
+	className,
+	src,
+	autoPlay,
+	muted,
+	playsInline,
+	loop,
+	controls = true,
+}: HTMLProps<HTMLVideoElement>) => {
+	return (
+		<video
+			src={src}
+			autoPlay={autoPlay}
+			muted={muted}
+			playsInline={playsInline}
+			loop={loop}
+			controls={controls}
+			className={clsx('rounded-md', className)}
+		/>
+	)
+}
+
+export default Video


### PR DESCRIPTION
Usage in markdown
`{% video src="/videos/bunny.mp4" /%}`