### PR TITLE
fix: use operationPath in client operation metadata

### DIFF
--- a/packages/sdk/src/client/client.ts
+++ b/packages/sdk/src/client/client.ts
@@ -237,12 +237,7 @@ export class Client {
 
 		const headers: Headers = {};
 
-		if (
-			this.options.operationMetadata &&
-			this.options.operationMetadata[options.operationName] &&
-			this.options.operationMetadata[options.operationName].requiresAuthentication &&
-			this.csrfEnabled
-		) {
+		if (this.isAuthenticatedOperation(options.operationName) && this.csrfEnabled) {
 			headers['X-CSRF-Token'] = await this.getCSRFToken();
 		}
 

--- a/packages/sdk/src/codegen/templates/typescript/client.template.ts
+++ b/packages/sdk/src/codegen/templates/typescript/client.template.ts
@@ -88,7 +88,7 @@ export const defaultClientConfig: ClientConfig = {
 
 export const operationMetadata: OperationMetadata = {
 {{#each allOperations}}
-    {{operationName}}: {
+    "{{operationPath}}": {
         requiresAuthentication: {{requiresAuthentication}}
 		}
     {{#unless @last}},{{/unless}}


### PR DESCRIPTION
fixes #581

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `make test`
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)

<!--
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->
