### PR TITLE
chore: fix check for prettier formatted files in CI

### DIFF
--- a/.github/workflows/packages-ci.yaml
+++ b/.github/workflows/packages-ci.yaml
@@ -93,7 +93,7 @@ jobs:
           main-branch-name: ${{ steps.branch-name.outputs.current_branch }} # Get the last successful commit for the current branch.
 
       - name: Check for formatting errors
-        run: eval "pnpx prettier --check $(git diff --name-only --diff-filter=ACMRT -r ${{ steps.last_successful_commit_push.outputs.base }} | xargs)"
+        run: eval "pnpx prettier --check -u $(git diff --name-only --diff-filter=ACMRT -r ${{ steps.last_successful_commit_push.outputs.base }} | xargs)"
 
       - name: Check if git is not dirty after generating files
         run: git diff --no-ext-diff --exit-code

--- a/.prettierignore
+++ b/.prettierignore
@@ -22,6 +22,9 @@ logs
 
 CHANGELOG.md
 
+# Ignore html files
+*.html
+
 # Ignore go files
 *.go
 


### PR DESCRIPTION
Tell prettier to ignore unknown extensions, and also exclude .html
files since we do not run those by prettier

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

<!--
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->
