### PR TITLE
fix: paths and uri composition on Windows when using nested directories for operations

### DIFF
--- a/packages/sdk/src/codegen/templates/typescript/index.ts
+++ b/packages/sdk/src/codegen/templates/typescript/index.ts
@@ -7,6 +7,7 @@ import fs from 'fs';
 import path from 'path';
 import { visitJSONSchema } from '../../jsonschema';
 import { OperationExecutionEngine } from '@wundergraph/protobuf';
+import { GraphQLOperation } from '../../../graphql/operations';
 
 export const formatTypeScript = (input: string): string => {
 	return prettier.format(input, {
@@ -226,10 +227,10 @@ const typescriptFunctionsImports = (config: CodeGenerationConfig): string => {
 		return '';
 	}
 	const relBasePath = path.relative(config.outPath, config.wunderGraphDir);
+	// Be careful with translating filesystem paths to import paths on Windows
+	const relImport = (op: GraphQLOperation) => path.join(relBasePath, 'operations', op.PathName).replace(/\\/g, '/');
 	return (
-		ops
-			.map((op) => `import type function_${op.Name} from '${path.join(relBasePath, 'operations', op.PathName)}';\n`)
-			.join('') +
+		ops.map((op) => `import type function_${op.Name} from '${relImport(op)}';\n`).join('') +
 		'import type {ExtractInput,ExtractResponse} from "@wundergraph/sdk/operations";\n' +
 		'\n'
 	);

--- a/packages/sdk/src/server/plugins/functions.ts
+++ b/packages/sdk/src/server/plugins/functions.ts
@@ -15,7 +15,7 @@ const FastifyFunctionsPlugin: FastifyPluginAsync<FastifyFunctionsOptions> = asyn
 	for (const operation of config.operations) {
 		try {
 			const filePath = path.join(process.env.WG_DIR_ABS!, operation.module_path);
-			const routeUrl = '/functions/' + operation.api_mount_path;
+			const routeUrl = `/functions/${operation.api_mount_path}`;
 			let maybeImplementation: NodeJSOperation<any, any, any, any, any> | undefined;
 			try {
 				maybeImplementation = (await import(filePath)).default;

--- a/packages/sdk/src/server/plugins/functions.ts
+++ b/packages/sdk/src/server/plugins/functions.ts
@@ -15,7 +15,7 @@ const FastifyFunctionsPlugin: FastifyPluginAsync<FastifyFunctionsOptions> = asyn
 	for (const operation of config.operations) {
 		try {
 			const filePath = path.join(process.env.WG_DIR_ABS!, operation.module_path);
-			const routeUrl = path.join('/functions', operation.api_mount_path);
+			const routeUrl = '/functions/' + operation.api_mount_path;
 			let maybeImplementation: NodeJSOperation<any, any, any, any, any> | undefined;
 			try {
 				maybeImplementation = (await import(filePath)).default;


### PR DESCRIPTION
- Use filepath.Join() to manipulate file paths in the Go side
- In the typescript side, avoid path.join() to manipulate URL
- Fix file path to module import path conversion on Windows

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

<!--
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->
