### PR TITLE
docs: fix typo in "WunderGraph explained in one sequence diagram"

### DIFF
--- a/docs-website/src/pages/docs/architecture/wundergraph-explained-in-one-sequence-diagram.md
+++ b/docs-website/src/pages/docs/architecture/wundergraph-explained-in-one-sequence-diagram.md
@@ -38,6 +38,7 @@ It takes away a lot of complexity,
 which is also quite handy to illustrate different capabilities of WunderGraph.
 
 ```graphql
+# operations/Weather.graphql
 query (
   $continent: String!
   # the @internal directive removes the $capital variable from the public API
@@ -78,8 +79,8 @@ query (
 ### Step-by-step explanation
 
 As WunderGraph uses a GraphQL to JSON RPC compiler,
-the client starts by requesting the Resource `/operations/Weather?continent=Europe`,
-so we're essentially asking to execute the `Weather` operation with the `continent` parameter set to `Europe`.
+the client starts by requesting the Resource `/operations/Weather?continent=EU`,
+so we're essentially asking to execute the `Weather` operation with the `continent` parameter set to `EU`.
 
 The server will then validate if the user is authenticated (if enabled) and will return 401 if not.
 If we've configured Role Based Access Control, the server will also validate if the user has the correct roles.


### PR DESCRIPTION
Parameter value should be "EU", not "Europe"

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

<!--
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->
