### PR TITLE
feat: when OIDC authentication is refused, redirect back with the error

### DIFF
--- a/pkg/authentication/oidc.go
+++ b/pkg/authentication/oidc.go
@@ -107,10 +107,6 @@ func (h *OpenIDConnectCookieHandler) Register(authorizeRouter, callbackRouter *m
 }
 
 func (h *OpenIDConnectCookieHandler) authorize(ctx context.Context, w http.ResponseWriter, r *http.Request, provider *oidc.Provider, config *OpenIDConnectConfig) {
-	if provider == nil {
-		http.Error(w, "oidc provider configuration error", http.StatusMethodNotAllowed)
-		return
-	}
 
 	redirectOnCompletionURI := r.URL.Query().Get("redirect_uri")
 
@@ -187,11 +183,6 @@ func (h *OpenIDConnectCookieHandler) authorize(ctx context.Context, w http.Respo
 }
 
 func (h *OpenIDConnectCookieHandler) authorizationCallback(ctx context.Context, w http.ResponseWriter, r *http.Request, provider *oidc.Provider, config *OpenIDConnectConfig, hooks *Hooks) {
-	if provider == nil {
-		http.Error(w, "oidc provider configuration error", http.StatusMethodNotAllowed)
-		return
-	}
-
 	state, err := r.Cookie("state")
 	if err != nil {
 		h.log.Error("OIDCCookieHandler state missing",

--- a/pkg/authentication/oidc.go
+++ b/pkg/authentication/oidc.go
@@ -128,6 +128,10 @@ func (h *OpenIDConnectCookieHandler) authorize(ctx context.Context, w http.Respo
 
 	state, err := generateState()
 	if err != nil {
+		h.log.Error("OIDCCookieHandler could not generate state",
+			zap.Error(err),
+		)
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 


### PR DESCRIPTION
Instead of returning a 400, if we have a redirect_uri go to it but pass
a parameter with the error message. This allows the frontend to react
accordingly.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

<!--
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->
