### PR TITLE
fix: avoid feeding paths into applicationHash calculation

### DIFF
--- a/packages/golang-client/src/index.ts
+++ b/packages/golang-client/src/index.ts
@@ -1,4 +1,4 @@
-import { BaseTypeScriptDataModel, Template, TemplateOutputFile } from '@wundergraph/sdk';
+import { BaseTypeScriptDataModel, CodeGenerationConfig, Template, TemplateOutputFile } from '@wundergraph/sdk';
 import { hasInput, visitJSONSchema } from '@wundergraph/sdk/internal';
 import { JSONSchema7 as JSONSchema, JSONSchema7 } from 'json-schema';
 import execa from 'execa';
@@ -7,7 +7,6 @@ import Handlebars from 'handlebars';
 import { clientTemplate } from './client-template';
 import { OperationType } from '@wundergraph/protobuf';
 import Logger from '@wundergraph/sdk/internal/logger';
-import { CodeGenerationConfig } from '@wundergraph/sdk/dist/configure';
 
 const logger = Logger.child({ plugin: 'golang-client' });
 

--- a/packages/nextjs/src/template.ts
+++ b/packages/nextjs/src/template.ts
@@ -1,20 +1,21 @@
 import { handlebarTemplate } from './handlebar.template';
 import Handlebars from 'handlebars';
 import {
+	BaseTypeScriptDataModel,
+	CodeGenerationConfig,
+	formatTypeScript,
+	GraphQLOperation,
 	Template,
 	TemplateOutputFile,
-	BaseTypeScriptDataModel,
-	formatTypeScript,
+	TypeScriptClient,
 	TypeScriptInputModels,
 	TypeScriptResponseDataModels,
 	TypeScriptResponseModels,
-	GraphQLOperation,
-	TypeScriptClient,
 } from '@wundergraph/sdk';
 import { modelImports } from '@wundergraph/sdk/internal';
 import hash from 'object-hash';
 import { OperationType } from '@wundergraph/protobuf';
-import { CodeGenerationConfig } from '@wundergraph/sdk/dist/configure';
+import {} from '@wundergraph/sdk/dist/configure';
 
 export class NextJsTemplate implements Template {
 	generate(generationConfig: CodeGenerationConfig): Promise<TemplateOutputFile[]> {

--- a/packages/nextjs/src/template.ts
+++ b/packages/nextjs/src/template.ts
@@ -8,16 +8,17 @@ import {
 	TypeScriptInputModels,
 	TypeScriptResponseDataModels,
 	TypeScriptResponseModels,
-	ResolvedWunderGraphConfig,
 	GraphQLOperation,
 	TypeScriptClient,
 } from '@wundergraph/sdk';
 import { modelImports } from '@wundergraph/sdk/internal';
 import hash from 'object-hash';
 import { OperationType } from '@wundergraph/protobuf';
+import { CodeGenerationConfig } from '@wundergraph/sdk/dist/configure';
 
 export class NextJsTemplate implements Template {
-	generate(config: ResolvedWunderGraphConfig): Promise<TemplateOutputFile[]> {
+	generate(generationConfig: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
+		const config = generationConfig.config;
 		const tmpl = Handlebars.compile(handlebarTemplate);
 		const content = tmpl({
 			baseURL: config.deployment.environment.baseUrl,

--- a/packages/sdk/src/codegen/index.test.ts
+++ b/packages/sdk/src/codegen/index.test.ts
@@ -1,12 +1,12 @@
 import { CodeGenOutWriter, collectAllTemplates, GenerateCode, Template, TemplateOutputFile } from './index';
 import { Api } from '../definition';
-import { ResolvedWunderGraphConfig } from '../configure';
+import { CodeGenerationConfig, ResolvedWunderGraphConfig } from '../configure';
 import { ConfigurationVariableKind, OperationExecutionEngine, OperationType } from '@wundergraph/protobuf';
 import { mapInputVariable } from '../configure/variables';
 
 class FakeTemplate implements Template {
-	generate(config: ResolvedWunderGraphConfig): Promise<TemplateOutputFile[]> {
-		const content = config.application.Operations.map((op) => op.Name).join('+');
+	generate(generationConfig: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
+		const content = generationConfig.config.application.Operations.map((op) => op.Name).join('+');
 		return Promise.resolve([
 			{
 				path: 'testFile.txt',
@@ -490,7 +490,7 @@ export const RunTemplateTest = async (...templates: Template[]) => {
 
 test('should collect all template dependencies recursively and dedupe based on the template name', () => {
 	class Template1 implements Template {
-		generate(config: ResolvedWunderGraphConfig): Promise<TemplateOutputFile[]> {
+		generate(generationConfig: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
 			return Promise.resolve([
 				{
 					path: 'template1.txt',
@@ -505,7 +505,7 @@ test('should collect all template dependencies recursively and dedupe based on t
 	}
 
 	class Template2 implements Template {
-		generate(config: ResolvedWunderGraphConfig): Promise<TemplateOutputFile[]> {
+		generate(generationConfig: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
 			return Promise.resolve([
 				{
 					path: 'template2.txt',
@@ -521,7 +521,7 @@ test('should collect all template dependencies recursively and dedupe based on t
 	}
 
 	class Template3 implements Template {
-		generate(config: ResolvedWunderGraphConfig): Promise<TemplateOutputFile[]> {
+		generate(generationConfig: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
 			return Promise.resolve([
 				{
 					path: 'template3.txt',
@@ -542,7 +542,7 @@ test('should collect all template dependencies recursively and dedupe based on t
 
 test('should collect templates up to maxTemplateDepth', () => {
 	class Template1 implements Template {
-		generate(config: ResolvedWunderGraphConfig): Promise<TemplateOutputFile[]> {
+		generate(generationConfig: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
 			return Promise.resolve([
 				{
 					path: 'template1.txt',
@@ -557,7 +557,7 @@ test('should collect templates up to maxTemplateDepth', () => {
 	}
 
 	class Template2 implements Template {
-		generate(config: ResolvedWunderGraphConfig): Promise<TemplateOutputFile[]> {
+		generate(generationConfig: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
 			return Promise.resolve([
 				{
 					path: 'template2.txt',
@@ -573,7 +573,7 @@ test('should collect templates up to maxTemplateDepth', () => {
 	}
 
 	class Template3 implements Template {
-		generate(config: ResolvedWunderGraphConfig): Promise<TemplateOutputFile[]> {
+		generate(generationConfig: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
 			return Promise.resolve([
 				{
 					path: 'template3.txt',

--- a/packages/sdk/src/codegen/index.test.ts
+++ b/packages/sdk/src/codegen/index.test.ts
@@ -1,6 +1,6 @@
 import { CodeGenOutWriter, collectAllTemplates, GenerateCode, Template, TemplateOutputFile } from './index';
 import { Api } from '../definition';
-import { CodeGenerationConfig, ResolvedWunderGraphConfig } from '../configure';
+import { CodeGenerationConfig } from '../configure';
 import { ConfigurationVariableKind, OperationExecutionEngine, OperationType } from '@wundergraph/protobuf';
 import { mapInputVariable } from '../configure/variables';
 

--- a/packages/sdk/src/codegen/index.ts
+++ b/packages/sdk/src/codegen/index.ts
@@ -66,7 +66,7 @@ export const GenerateCode = async (config: CodeGenConfig, customOutWriter?: Code
 	config.templates = Array.from(collectAllTemplates(config.templates));
 
 	const generateConfig: CodeGenerationConfig = {
-		...config.wunderGraphConfig,
+		config: config.wunderGraphConfig,
 		outPath: config.basePath,
 		wunderGraphDir: process.env.WG_DIR_ABS!,
 	};

--- a/packages/sdk/src/codegen/templates/markdown/authentication.ts
+++ b/packages/sdk/src/codegen/templates/markdown/authentication.ts
@@ -1,13 +1,13 @@
 import { Template, TemplateOutputFile } from '../../index';
-import { ResolvedWunderGraphConfig } from '../../../configure';
+import { CodeGenerationConfig } from '../../../configure';
 import { template } from './configure_auth_providers.template';
 import Handlebars from 'handlebars';
 import { AuthProviderKind } from '@wundergraph/protobuf';
 
 export class AuthenticationProviderConfiguration implements Template {
-	generate(config: ResolvedWunderGraphConfig): Promise<TemplateOutputFile[]> {
+	generate(generationConfig: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
 		const model: AuthenticationProviderModel = {
-			providers: config.authentication.cookieBased
+			providers: generationConfig.config.authentication.cookieBased
 				.filter((p) => p.id !== 'demo')
 				.map((p) => {
 					let providerKind: string = 'not defined';

--- a/packages/sdk/src/codegen/templates/typescript/client.ts
+++ b/packages/sdk/src/codegen/templates/typescript/client.ts
@@ -15,7 +15,8 @@ import templates from '../index';
 
 export class TypeScriptClient implements Template {
 	constructor(reactNative: boolean = false) {}
-	async generate(config: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
+	async generate(generationConfig: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
+		const config = generationConfig.config;
 		const tmpl = Handlebars.compile(handlebarTemplate);
 		const allOperations = allQueries(config.application, false);
 		const _liveQueries = liveQueries(config.application, false);

--- a/packages/sdk/src/codegen/templates/typescript/forms.ts
+++ b/packages/sdk/src/codegen/templates/typescript/forms.ts
@@ -7,7 +7,8 @@ import { template } from './forms.tsx.template';
 import { hasInput, isNotInternal } from './helpers';
 
 export class Forms implements Template {
-	generate(config: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
+	generate(generationConfig: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
+		const config = generationConfig.config;
 		const liveQueries: Operation[] = config.application.Operations.filter(hasInput)
 			.filter(isNotInternal)
 			.filter((op) => op.OperationType === OperationType.QUERY && op.LiveQuery?.enable === true)

--- a/packages/sdk/src/codegen/templates/typescript/hooks.ts
+++ b/packages/sdk/src/codegen/templates/typescript/hooks.ts
@@ -8,8 +8,8 @@ import { template } from './hooks.template';
 import templates from '../index';
 
 export class WunderGraphHooksPlugin implements Template {
-	generate(config: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
-		const application = filterNodeJSOperations(config.application);
+	generate(generationConfig: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
+		const application = filterNodeJSOperations(generationConfig.config.application);
 		const tmpl = Handlebars.compile(template);
 		const _queries = operations(application, OperationType.QUERY, false);
 		const _internalQueries = operations(application, OperationType.QUERY, true);
@@ -37,7 +37,7 @@ export class WunderGraphHooksPlugin implements Template {
 			hasInternalMutations: _internalMutations.length !== 0,
 			hasUploadProviders: _uploadProviders.length !== 0,
 			uploadProviders: _uploadProviders,
-			roleDefinitions: config.authentication.roles.map((role) => '"' + role + '"').join(' | '),
+			roleDefinitions: generationConfig.config.authentication.roles.map((role) => '"' + role + '"').join(' | '),
 		});
 		return Promise.resolve([
 			{

--- a/packages/sdk/src/codegen/templates/typescript/index.ts
+++ b/packages/sdk/src/codegen/templates/typescript/index.ts
@@ -19,8 +19,8 @@ export const formatTypeScript = (input: string): string => {
 };
 
 export class TypeScriptInputModels implements Template {
-	async generate(config: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
-		const content = config.application.Operations.filter(hasInput)
+	async generate(generationConfig: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
+		const content = generationConfig.config.application.Operations.filter(hasInput)
 			.map((op) =>
 				JSONSchemaToTypescriptInterface(
 					op.VariablesSchema,
@@ -50,8 +50,8 @@ export class TypeScriptInputModels implements Template {
 }
 
 export class TypeScriptInternalInputModels implements Template {
-	async generate(config: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
-		const content = config.application.Operations.filter(hasInternalInput)
+	async generate(generationConfig: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
+		const content = generationConfig.config.application.Operations.filter(hasInternalInput)
 			.map((op) => JSONSchemaToTypescriptInterface(op.InternalVariablesSchema, 'Internal' + op.Name + 'Input', false))
 			.join('\n\n');
 		return Promise.resolve([
@@ -69,8 +69,8 @@ export class TypeScriptInternalInputModels implements Template {
 }
 
 export class TypeScriptInjectedInputModels implements Template {
-	async generate(config: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
-		const content = config.application.Operations.filter(hasInjectedInput)
+	async generate(generationConfig: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
+		const content = generationConfig.config.application.Operations.filter(hasInjectedInput)
 			.map((op) => JSONSchemaToTypescriptInterface(op.InjectedVariablesSchema, 'Injected' + op.Name + 'Input', false))
 			.join('\n\n');
 
@@ -89,8 +89,8 @@ export class TypeScriptInjectedInputModels implements Template {
 }
 
 export class TypeScriptResponseModels implements Template {
-	generate(config: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
-		const content = config.application.Operations.map((op) => {
+	generate(generationConfig: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
+		const content = generationConfig.config.application.Operations.map((op) => {
 			const dataName = '#/definitions/' + op.Name + 'ResponseData';
 			const responseSchema = JSON.parse(JSON.stringify(op.ResponseSchema)) as JSONSchema7;
 			if (responseSchema.properties) {
@@ -115,8 +115,8 @@ export class TypeScriptResponseModels implements Template {
 }
 
 export class TypeScriptResponseDataModels implements Template {
-	generate(config: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
-		const content = config.application.Operations.filter(
+	generate(generationConfig: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
+		const content = generationConfig.config.application.Operations.filter(
 			(op) => op.ResponseSchema.properties !== undefined && op.ResponseSchema.properties['data'] !== undefined
 		)
 			.map((op) =>
@@ -150,10 +150,10 @@ export class TypeScriptResponseDataModels implements Template {
 export class BaseTypeScriptDataModel implements Template {
 	precedence = 10;
 
-	generate(config: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
+	generate(generationConfig: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
 		const definitions: Map<string, JSONSchema7> = new Map();
 
-		config.application.Operations.forEach((op) => {
+		generationConfig.config.application.Operations.forEach((op) => {
 			if (op.VariablesSchema.definitions)
 				Object.keys(op.VariablesSchema.definitions).forEach((definitionName) => {
 					if (definitions.has(definitionName)) {
@@ -193,7 +193,7 @@ export class BaseTypeScriptDataModel implements Template {
 			.map(([definitionName, definition]) => JSONSchemaToTypescriptInterface(definition, definitionName, false))
 			.join('\n\n');
 
-		const functionImports = typescriptFunctionsImports(config);
+		const functionImports = typescriptFunctionsImports(generationConfig);
 
 		const content = functionImports + models;
 
@@ -219,14 +219,14 @@ export interface GraphQLError {
 }
 `;
 
-const typescriptFunctionsImports = (config: CodeGenerationConfig): string => {
-	const ops = config.application.Operations.filter(
+const typescriptFunctionsImports = (generationConfig: CodeGenerationConfig): string => {
+	const ops = generationConfig.config.application.Operations.filter(
 		(op) => op.ExecutionEngine === OperationExecutionEngine.ENGINE_NODEJS
 	);
 	if (ops.length === 0) {
 		return '';
 	}
-	const relBasePath = path.relative(config.outPath, config.wunderGraphDir);
+	const relBasePath = path.relative(generationConfig.outPath, generationConfig.wunderGraphDir);
 	// Be careful with translating filesystem paths to import paths on Windows
 	const relImport = (op: GraphQLOperation) => path.join(relBasePath, 'operations', op.PathName).replace(/\\/g, '/');
 	return (

--- a/packages/sdk/src/codegen/templates/typescript/internal.client.ts
+++ b/packages/sdk/src/codegen/templates/typescript/internal.client.ts
@@ -8,7 +8,8 @@ import { template } from './internal.client.template';
 import templates from '../index';
 
 export class WunderGraphInternalApiClient implements Template {
-	generate(config: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
+	generate(generationConfig: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
+		const config = generationConfig.config;
 		const tmpl = Handlebars.compile(template);
 		const _queries = operations(config.application, OperationType.QUERY, false);
 		const _internalQueries = operations(config.application, OperationType.QUERY, true);

--- a/packages/sdk/src/codegen/templates/typescript/internal.operations.client.ts
+++ b/packages/sdk/src/codegen/templates/typescript/internal.operations.client.ts
@@ -8,7 +8,8 @@ import { template } from './internal.operations.client.template';
 import templates from '../index';
 
 export class WunderGraphInternalOperationsApiClient implements Template {
-	generate(config: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
+	generate(generationConfig: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
+		const config = generationConfig.config;
 		const tmpl = Handlebars.compile(template);
 		const _queries = operations(config.application, OperationType.QUERY, false);
 		const _internalQueries = operations(config.application, OperationType.QUERY, true);

--- a/packages/sdk/src/codegen/templates/typescript/jsonschema.ts
+++ b/packages/sdk/src/codegen/templates/typescript/jsonschema.ts
@@ -5,9 +5,9 @@ import Handlebars from 'handlebars';
 import { template } from './jsonschema.template';
 
 export class JsonSchema implements Template {
-	generate(config: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
+	generate(generationConfig: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
 		const model: Model = {
-			operations: config.application.Operations.map((op) => ({
+			operations: generationConfig.config.application.Operations.map((op) => ({
 				name: op.Name,
 				inputSchema: JSON.stringify(op.VariablesSchema),
 				outputSchema: JSON.stringify(op.ResponseSchema),

--- a/packages/sdk/src/codegen/templates/typescript/linkbuilder.ts
+++ b/packages/sdk/src/codegen/templates/typescript/linkbuilder.ts
@@ -7,9 +7,9 @@ import { formatTypeScript } from './index';
 import { template } from './linkbuilder.template';
 
 export class TypeScriptLinkBuilder implements Template {
-	generate(config: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
+	generate(generationConfig: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
 		const tmpl = Handlebars.compile(template);
-		const schema = buildSchema(config.application.EngineConfiguration.Schema);
+		const schema = buildSchema(generationConfig.config.application.EngineConfiguration.Schema);
 		const fields = queryTypeFields(schema);
 		const types = typesInfo(schema);
 		const model: Model = {

--- a/packages/sdk/src/codegen/templates/typescript/operations.ts
+++ b/packages/sdk/src/codegen/templates/typescript/operations.ts
@@ -6,9 +6,9 @@ import Handlebars from 'handlebars';
 import { template } from './operations.template';
 
 export class Operations implements Template {
-	generate(config: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
+	generate(generationConfig: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
 		const model: OperationsModel = {
-			operations: config.application.Operations.map((op) => ({
+			operations: generationConfig.config.application.Operations.map((op) => ({
 				name: op.Name,
 				isMutation: op.OperationType === OperationType.MUTATION,
 				isQuery: op.OperationType === OperationType.QUERY,

--- a/packages/sdk/src/codegen/templates/typescript/react.ts
+++ b/packages/sdk/src/codegen/templates/typescript/react.ts
@@ -10,12 +10,12 @@ import { template as hooksTemplate } from './react.hooks.template';
 import { hasInput, isNotInternal, queries as allQueries } from './helpers';
 
 export class TypescriptReactProvider implements Template {
-	generate(config: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
+	generate(generationConfig: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
 		const tmpl = Handlebars.compile(providerTemplate);
-		const allOperations = allQueries(config.application, false);
+		const allOperations = allQueries(generationConfig.config.application, false);
 		const content = tmpl({
 			allOperations: allOperations,
-			hasAuthProviders: config.authentication.cookieBased.length !== 0,
+			hasAuthProviders: generationConfig.config.authentication.cookieBased.length !== 0,
 		});
 		return Promise.resolve([
 			{
@@ -28,12 +28,12 @@ export class TypescriptReactProvider implements Template {
 }
 
 export class TypescriptReactNativeProvider implements Template {
-	generate(config: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
+	generate(generationConfig: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
 		const tmpl = Handlebars.compile(reactNativeProviderTemplate);
-		const allOperations = allQueries(config.application, false);
+		const allOperations = allQueries(generationConfig.config.application, false);
 		const content = tmpl({
 			allOperations: allOperations,
-			hasAuthProviders: config.authentication.cookieBased.length !== 0,
+			hasAuthProviders: generationConfig.config.authentication.cookieBased.length !== 0,
 		});
 		return Promise.resolve([
 			{
@@ -52,7 +52,8 @@ export class TypescriptReactHooks implements Template {
 
 	private readonly reactNative: boolean;
 
-	generate(config: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
+	generate(generationConfig: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
+		const config = generationConfig.config;
 		const tmpl = Handlebars.compile(hooksTemplate);
 		const _imports = imports(config.application);
 		_imports.push(...queryResponseImports(config.application));

--- a/packages/sdk/src/codegen/templates/typescript/server.ts
+++ b/packages/sdk/src/codegen/templates/typescript/server.ts
@@ -8,10 +8,10 @@ import { WunderGraphInternalApiClient } from './internal.client';
 import { WunderGraphInternalOperationsApiClient } from './internal.operations.client';
 
 export class WunderGraphServer implements Template {
-	generate(config: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
+	generate(generationConfig: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
 		const tmpl = Handlebars.compile(template);
 		const content = tmpl({
-			roleDefinitions: config.authentication.roles.map((role) => '"' + role + '"').join(' | '),
+			roleDefinitions: generationConfig.config.authentication.roles.map((role) => '"' + role + '"').join(' | '),
 		});
 		return Promise.resolve([
 			{

--- a/packages/sdk/src/codegen/templates/typescript/testing.ts
+++ b/packages/sdk/src/codegen/templates/typescript/testing.ts
@@ -1,13 +1,13 @@
 import { handlebarTemplate } from './testing.template';
 import Handlebars from 'handlebars';
 import { Template, TemplateOutputFile } from '../../index';
-import { ResolvedWunderGraphConfig } from '../../../configure';
+import { CodeGenerationConfig } from '../../../configure';
 import { formatTypeScript } from '.';
 import templates from '../index';
 
 export class TypeScriptTesting implements Template {
 	constructor() {}
-	generate(_: ResolvedWunderGraphConfig): Promise<TemplateOutputFile[]> {
+	generate(_: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
 		const tmpl = Handlebars.compile(handlebarTemplate);
 		const content = tmpl({});
 		return Promise.resolve([

--- a/packages/sdk/src/codegen/templates/typescript/web.client.ts
+++ b/packages/sdk/src/codegen/templates/typescript/web.client.ts
@@ -14,7 +14,8 @@ export class TypeScriptLegacyWebClient implements Template {
 
 	private readonly reactNative: boolean;
 
-	generate(config: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
+	generate(generationConfig: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
+		const config = generationConfig.config;
 		const tmpl = Handlebars.compile(template);
 		const _queries = operations(config.application, OperationType.QUERY, false);
 		const _liveQueries = liveQueries(config.application, false);

--- a/packages/sdk/src/codegen/templates/typescript/webhooks.ts
+++ b/packages/sdk/src/codegen/templates/typescript/webhooks.ts
@@ -5,10 +5,10 @@ import { formatTypeScript } from './index';
 import { template } from './webhooks.template';
 
 export class WunderGraphWebhooksPlugin implements Template {
-	generate(config: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
+	generate(generationConfig: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
 		const tmpl = Handlebars.compile(template);
 		const content = tmpl({
-			webhooks: config.webhooks,
+			webhooks: generationConfig.config.webhooks,
 		});
 		return Promise.resolve([
 			{

--- a/packages/sdk/src/configure/index.ts
+++ b/packages/sdk/src/configure/index.ts
@@ -259,7 +259,8 @@ export interface ResolvedWunderGraphConfig {
 	serverOptions?: ResolvedServerOptions;
 }
 
-export interface CodeGenerationConfig extends ResolvedWunderGraphConfig {
+export interface CodeGenerationConfig {
+	config: ResolvedWunderGraphConfig;
 	outPath: string;
 	wunderGraphDir: string;
 }

--- a/packages/sdk/src/configure/index.ts
+++ b/packages/sdk/src/configure/index.ts
@@ -228,6 +228,8 @@ interface ResolvedS3UploadConfiguration extends Omit<S3UploadConfiguration, 'upl
 }
 
 export interface ResolvedWunderGraphConfig {
+	// XXX: ResolvedWunderGraphConfig is hashed by several templates.
+	// DO NOT INCLUDE UNSTABLE DATA (paths, times, etc...) in it.
 	application: ResolvedApplication;
 	deployment: ResolvedDeployment;
 	sdkVersion: string;
@@ -260,6 +262,9 @@ export interface ResolvedWunderGraphConfig {
 }
 
 export interface CodeGenerationConfig {
+	// Keep ResolvedWunderGraphConfig in a separate field, so it can be
+	// hashed without using any unstable data as the hash input (e.g.
+	// paths like outPath or wunderGraphDir).
 	config: ResolvedWunderGraphConfig;
 	outPath: string;
 	wunderGraphDir: string;

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,4 +1,4 @@
-export type { ResolvedWunderGraphConfig } from './configure';
+export type { CodeGenerationConfig, ResolvedWunderGraphConfig } from './configure';
 export type {
 	BaseOperationConfiguration,
 	QueryConfiguration,


### PR DESCRIPTION
Store ResolveApplicationConfig in a field in CodeGenerationConfig
rather than extending it. This allows us to safely hash ResolveApplicationConfig
without including the paths in CodeGenerationConfig.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

<!--
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->
