### PR TITLE
fix: pass GH token in HTTTP call from getExamplesList()

### DIFF
--- a/packages/create-wundergraph-app/src/helpers/examples.ts
+++ b/packages/create-wundergraph-app/src/helpers/examples.ts
@@ -2,9 +2,11 @@ import chalk from 'chalk';
 import got from 'got';
 import inquirer from 'inquirer';
 
+import { getGitHubRequestOptions } from './github';
+
 export const getExamplesList = async (ref: string) => {
 	const exampleDirectoriesResponse = await got
-		.get(`https://api.github.com/repos/wundergraph/wundergraph/contents/examples?ref=${ref}`)
+		.get(`https://api.github.com/repos/wundergraph/wundergraph/contents/examples?ref=${ref}`, getGitHubRequestOptions())
 		.catch((e: any) => {
 			throw e;
 		});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

<!--
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->
