### PR TITLE
chore: bump wunderctl dependency to 0.131

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -123,7 +123,7 @@
     "@prisma/generator-helper": "^3.9.2",
     "@web-std/fetch": "^4.1.0",
     "@wundergraph/protobuf": "workspace:^0.104.0",
-    "@wundergraph/wunderctl": "workspace:>=0.130.0",
+    "@wundergraph/wunderctl": "workspace:>=0.131.0",
     "axios": "^0.26.1",
     "axios-retry": "^3.3.1",
     "close-with-grace": "^1.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -306,7 +306,7 @@ importers:
       '@types/object-hash': ^1.3.4
       '@web-std/fetch': ^4.1.0
       '@wundergraph/protobuf': workspace:^0.104.0
-      '@wundergraph/wunderctl': workspace:>=0.130.0
+      '@wundergraph/wunderctl': workspace:>=0.131.0
       axios: ^0.26.1
       axios-retry: ^3.3.1
       chai: ^4.3.4
@@ -491,17 +491,6 @@ importers:
       jose: 4.11.2
       ts-jest: 29.0.5_p6ekqnroyms5nhqbfxosryz7rm
       ts-node: 10.9.1_awa2wsr5thmg3i7jqycphctjfq
-
-  testapps/cloud-starter:
-    specifiers:
-      '@types/node': ^14.14.37
-      '@wundergraph/sdk': ^0.130.2
-      typescript: ^4.8.2
-    dependencies:
-      '@wundergraph/sdk': 0.130.2
-    devDependencies:
-      '@types/node': 14.18.33
-      typescript: 4.9.4
 
   testapps/default:
     specifiers:
@@ -4520,67 +4509,6 @@ packages:
       web-streams-polyfill: 3.2.1
     transitivePeerDependencies:
       - encoding
-    dev: false
-
-  /@wundergraph/protobuf/0.100.0:
-    resolution: {integrity: sha512-nWGdAU8MqLo7A3uzk/yFZ2OxzccLiPzLuVCXGaotYs5jITJFjsXj0uF5fvBttIlIZNWYgZbFlOcbnrNq2XasuQ==}
-    dependencies:
-      long: 5.2.1
-      protobufjs: 6.11.3
-      ts-proto: 1.131.0
-    dev: false
-
-  /@wundergraph/sdk/0.130.2:
-    resolution: {integrity: sha512-J3sTcEoHumycWmIqgAXarFHkbvx2PAKHu8v5Z+SEo4QQzOGnBsbCF2tKHHQoeh0ZF7C4AONZgj45uHVWwZm0hA==}
-    hasBin: true
-    dependencies:
-      '@fastify/formbody': 7.3.0
-      '@graphql-tools/schema': 8.5.1_graphql@16.6.0
-      '@prisma/generator-helper': 3.15.2
-      '@web-std/fetch': 4.1.0
-      '@wundergraph/protobuf': 0.100.0
-      '@wundergraph/wunderctl': 0.130.0
-      axios: 0.26.1
-      axios-retry: 3.3.1
-      close-with-grace: 1.1.0
-      execa: 5.1.1
-      fastify: 4.10.2
-      fastify-plugin: 4.4.0
-      graphql: 16.6.0
-      graphql-helix: 1.13.0_graphql@16.6.0
-      handlebars: 4.7.7
-      js-yaml: 4.1.0
-      json-schema: 0.4.0
-      lodash: 4.17.21
-      long: 5.2.1
-      object-hash: 2.2.0
-      openapi-types: 10.0.0
-      pino: 8.8.0
-      pino-pretty: 9.1.1
-      postman-collection: 4.1.5
-      prettier: 2.7.1
-      protobufjs: 6.11.3
-      swagger2openapi: 7.0.8
-      terminate: 2.5.0
-      ts-retry-promise: 0.7.0
-    transitivePeerDependencies:
-      - debug
-      - encoding
-      - supports-color
-    dev: false
-
-  /@wundergraph/wunderctl/0.130.0:
-    resolution: {integrity: sha512-V0GZiowWz9taw3clBo7DtvvlnB+29VIFFk4qtbnR1sysJFIqmzEc1eYUWIYJTP/S8vRsLcFqxHymJexX6RvsSw==}
-    hasBin: true
-    requiresBuild: true
-    dependencies:
-      axios: 0.26.1_debug@4.3.4
-      debug: 4.3.4
-      execa: 5.1.1
-      rimraf: 3.0.2
-      tar: 6.1.12
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /@yarnpkg/lockfile/1.1.0:


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

<!--
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->
