### PR TITLE
alberto/eng 1081 hooks are not called when using internal

### DIFF
--- a/packages/sdk/src/client/client.ts
+++ b/packages/sdk/src/client/client.ts
@@ -149,14 +149,14 @@ export class Client {
 
 			switch (response.status) {
 				case 401:
-					return new AuthorizationError(json.errors[0]?.message, response.status);
+					return new AuthorizationError(json.errors[0]?.message.trim(), response.status);
 				case 400:
 					return new InputValidationError(json, response.status);
 				default:
-					return new ResponseError(json.errors[0]?.message || json.message, response.status);
+					return new ResponseError((json.errors[0]?.message || json.message).trim(), response.status);
 			}
 		} catch {
-			return new ResponseError(text.length ? text : 'Response is not OK', response.status);
+			return new ResponseError(text.length ? text.trim() : 'Response is not OK', response.status);
 		}
 	}
 

--- a/pkg/apihandler/apihandler.go
+++ b/pkg/apihandler/apihandler.go
@@ -2240,7 +2240,7 @@ func (h *FunctionsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	buf := pool.GetBytesBuffer()
 	defer pool.PutBytesBuffer(buf)
 
-	input := hookBaseData(r, buf.Bytes(), ctx.Variables, nil)
+	input := hooks.EncodeData(hooksAuthenticator, r, buf.Bytes(), ctx.Variables, nil)
 
 	switch {
 	case isLive:
@@ -2405,23 +2405,6 @@ func getOperationMetaData(r *http.Request) *OperationMetaData {
 		return nil
 	}
 	return maybeMetaData.(*OperationMetaData)
-}
-
-func hookBaseData(r *http.Request, buf []byte, variables []byte, response []byte) []byte {
-	buf = buf[:0]
-	buf = append(buf, []byte(`{"__wg":{}}`)...)
-	if user := authentication.UserFromContext(r.Context()); user != nil {
-		if userJson, err := json.Marshal(user); err == nil {
-			buf, _ = jsonparser.Set(buf, userJson, "__wg", "user")
-		}
-	}
-	if len(variables) > 2 {
-		buf, _ = jsonparser.Set(buf, variables, "input")
-	}
-	if len(response) != 0 {
-		buf, _ = jsonparser.Set(buf, response, "response")
-	}
-	return buf
 }
 
 func setSubscriptionHeaders(w http.ResponseWriter) {

--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -425,3 +425,21 @@ func (c *Client) DoHealthCheckRequest(ctx context.Context) (status bool) {
 
 	return true
 }
+
+func EncodeData(authenticator Authenticator, r *http.Request, buf []byte, variables []byte, response []byte) []byte {
+	// TODO: This doesn't really reuse the bytes.Buffer storage, refactor it after adding more tests
+	buf = buf[:0]
+	buf = append(buf, []byte(`{"__wg":{}}`)...)
+	if user := authenticator(r.Context()); user != nil {
+		if userJson, err := json.Marshal(user); err == nil {
+			buf, _ = jsonparser.Set(buf, userJson, "__wg", "user")
+		}
+	}
+	if len(variables) > 2 {
+		buf, _ = jsonparser.Set(buf, variables, "input")
+	}
+	if len(response) != 0 {
+		buf, _ = jsonparser.Set(buf, response, "response")
+	}
+	return buf
+}

--- a/pkg/hooks/pipeline.go
+++ b/pkg/hooks/pipeline.go
@@ -1,0 +1,227 @@
+package hooks
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/buger/jsonparser"
+	"github.com/wundergraph/graphql-go-tools/pkg/engine/resolve"
+	"github.com/wundergraph/graphql-go-tools/pkg/lexer/literal"
+	"github.com/wundergraph/wundergraph/pkg/pool"
+	"github.com/wundergraph/wundergraph/pkg/wgpb"
+	"go.uber.org/zap"
+)
+
+type Authenticator func(ctx context.Context) (user interface{})
+
+type ResolveConfiguration struct {
+	// Pre indicates wheter the PreResolve hook should be run
+	Pre bool
+	// MutatingPre indicates wheter the MutatingPreResolve hook should be run
+	MutatingPre bool
+	// Custom indicates wheter the CustomResolve hook should be run
+	Custom bool
+	// Mock indicates wether the MockResolve hook should be run
+	Mock bool
+}
+
+type PostResolveConfiguration struct {
+	// Post indicates wether the PostResolve hook should be run
+	Post bool
+	// MutatingPost indicates wether the MutatingPostResolve hook should be run
+	MutatingPost bool
+}
+
+type Response struct {
+	Done     bool
+	Resolved bool
+	Data     []byte
+}
+
+type Pipeline struct {
+	client            *Client
+	logger            *zap.Logger
+	operation         *wgpb.Operation
+	authenticator     Authenticator
+	ResolveConfig     ResolveConfiguration
+	PostResolveConfig PostResolveConfiguration
+}
+
+func NewPipeline(client *Client, authenticator Authenticator, operation *wgpb.Operation, logger *zap.Logger) *Pipeline {
+	hooksConfig := operation.GetHooksConfiguration()
+
+	return &Pipeline{
+		client:        client,
+		logger:        logger,
+		operation:     operation,
+		authenticator: authenticator,
+		ResolveConfig: ResolveConfiguration{
+			Pre:         hooksConfig.GetPreResolve(),
+			MutatingPre: hooksConfig.GetMutatingPreResolve(),
+			Custom:      hooksConfig.GetCustomResolve(),
+			// TODO: Mock hook seems to support some extra configuration
+			Mock: hooksConfig.GetMockResolve().GetEnable(),
+		},
+		PostResolveConfig: PostResolveConfiguration{
+			Post:         hooksConfig.GetPostResolve(),
+			MutatingPost: hooksConfig.GetMutatingPostResolve(),
+		},
+	}
+}
+
+func (p *Pipeline) updateContextHeaders(ctx *resolve.Context, headers map[string]string) {
+	// TODO!
+}
+
+func (p *Pipeline) handleHookResponse(ctx *resolve.Context, w http.ResponseWriter, hook MiddlewareHook, resp *MiddlewareHookResponse) (done bool) {
+	if resp == nil {
+		p.logger.Error(fmt.Sprintf("hook %s failed", hook),
+			zap.String("operationName", p.operation.Name),
+			zap.String("operationType", p.operation.OperationType.String()),
+		)
+		if w != nil {
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		}
+		return true
+	}
+	p.updateContextHeaders(ctx, resp.SetClientRequestHeaders)
+	return false
+}
+
+func (p *Pipeline) PreResolve(ctx *resolve.Context, w http.ResponseWriter, r *http.Request) (*Response, error) {
+
+	// XXX: Errors returned by Client.DoOperationRequest() already contain the hook name, do not reannotate them!
+	hookBuf := pool.GetBytesBuffer()
+	defer pool.PutBytesBuffer(hookBuf)
+
+	var resp *MiddlewareHookResponse
+	var err error
+	if p.ResolveConfig.Pre {
+		hookData := hookBaseData(p.authenticator, r, hookBuf.Bytes(), ctx.Variables, nil)
+		resp, err = p.client.DoOperationRequest(ctx.Context, p.operation.Name, PreResolve, hookData)
+		if err != nil {
+			return nil, err
+		}
+		if done := p.handleHookResponse(ctx, w, PreResolve, resp); done {
+			return &Response{
+				Done: true,
+			}, nil
+		}
+	}
+
+	if p.ResolveConfig.MutatingPre {
+		hookData := hookBaseData(p.authenticator, r, hookBuf.Bytes(), ctx.Variables, nil)
+		resp, err = p.client.DoOperationRequest(ctx.Context, p.operation.Name, MutatingPreResolve, hookData)
+		if err != nil {
+			return nil, err
+		}
+		if done := p.handleHookResponse(ctx, w, MutatingPreResolve, resp); done {
+			return &Response{
+				Done: true,
+			}, nil
+		}
+		// Update data with what the hook returned
+		// XXX: mutatingPreResolve returns the data in resp.Input
+		ctx.Variables = resp.Input
+	}
+
+	if p.ResolveConfig.Mock {
+		hookData := hookBaseData(p.authenticator, r, hookBuf.Bytes(), ctx.Variables, nil)
+		resp, err := p.client.DoOperationRequest(ctx.Context, p.operation.Name, MockResolve, hookData)
+		if err != nil {
+			return nil, err
+		}
+		if done := p.handleHookResponse(ctx, w, MutatingPreResolve, resp); done {
+			return &Response{
+				Done: true,
+			}, nil
+		}
+		// MockResolve returned data is used unconditionally
+		return &Response{
+			Resolved: true,
+			Data:     resp.Response,
+		}, nil
+	}
+
+	if p.ResolveConfig.Custom {
+		hookData := hookBaseData(p.authenticator, r, hookBuf.Bytes(), ctx.Variables, nil)
+		resp, err = p.client.DoOperationRequest(ctx.Context, p.operation.Name, CustomResolve, hookData)
+		if err != nil {
+			return nil, err
+		}
+		if done := p.handleHookResponse(ctx, w, CustomResolve, resp); done {
+			return &Response{
+				Done: true,
+			}, nil
+		}
+		// the customResolve hook can indicate to "skip" by responding with "null"
+		// so, we only write the response if it's not null
+		// XXX: customResolve returns the data in resp.Response
+		if !bytes.Equal(resp.Response, literal.NULL) {
+			return &Response{
+				Resolved: true,
+				Data:     resp.Response,
+			}, nil
+		}
+	}
+
+	return &Response{Data: ctx.Variables}, nil
+}
+
+func (p *Pipeline) PostResolve(ctx *resolve.Context, w http.ResponseWriter, r *http.Request, responseData []byte) (*Response, error) {
+
+	// XXX: Errors returned by Client.DoOperationRequest() already contain the hook name, do not reannotate them!
+	hookBuf := pool.GetBytesBuffer()
+	defer pool.PutBytesBuffer(hookBuf)
+
+	if p.PostResolveConfig.Post {
+		postResolveData := hookBaseData(p.authenticator, r, hookBuf.Bytes(), ctx.Variables, responseData)
+		resp, err := p.client.DoOperationRequest(ctx.Context, p.operation.Name, PostResolve, postResolveData)
+		if err != nil {
+			return nil, err
+		}
+		if done := p.handleHookResponse(ctx, w, CustomResolve, resp); done {
+			return &Response{
+				Done: true,
+			}, nil
+		}
+	}
+
+	if p.PostResolveConfig.MutatingPost {
+		mutatingPostData := hookBaseData(p.authenticator, r, hookBuf.Bytes(), ctx.Variables, responseData)
+		resp, err := p.client.DoOperationRequest(ctx.Context, p.operation.Name, MutatingPostResolve, mutatingPostData)
+		if err != nil {
+			return nil, err
+		}
+		if done := p.handleHookResponse(ctx, w, CustomResolve, resp); done {
+			return &Response{
+				Done: true,
+			}, nil
+		}
+		responseData = resp.Response
+	}
+
+	return &Response{
+		Data: responseData,
+	}, nil
+}
+
+func hookBaseData(authenticator Authenticator, r *http.Request, buf []byte, variables []byte, response []byte) []byte {
+	buf = buf[:0]
+	buf = append(buf, []byte(`{"__wg":{}}`)...)
+	if user := authenticator(r.Context()); user != nil {
+		if userJson, err := json.Marshal(user); err == nil {
+			buf, _ = jsonparser.Set(buf, userJson, "__wg", "user")
+		}
+	}
+	if len(variables) > 2 {
+		buf, _ = jsonparser.Set(buf, variables, "input")
+	}
+	if len(response) != 0 {
+		buf, _ = jsonparser.Set(buf, response, "response")
+	}
+	return buf
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -519,6 +519,25 @@ importers:
       jest: 29.4.2_@types+node@14.18.33
       ts-jest: 29.0.5_47mstovy2thvxzoe7ouhdvjexm
 
+  testapps/hooks:
+    specifiers:
+      '@jest/globals': ^29.3.1
+      '@types/node': ^14.14.37
+      '@wundergraph/sdk': workspace:*
+      graphql: ^16.3.0
+      jest: ^29.4.2
+      ts-jest: ^29.0.5
+      typescript: ^4.8.2
+    dependencies:
+      '@types/node': 14.18.33
+      '@wundergraph/sdk': link:../../packages/sdk
+      graphql: 16.6.0
+      typescript: 4.9.4
+    devDependencies:
+      '@jest/globals': 29.4.2
+      jest: 29.4.2_@types+node@14.18.33
+      ts-jest: 29.0.5_47mstovy2thvxzoe7ouhdvjexm
+
   testapps/mtls:
     specifiers:
       '@types/node': ^14.14.37
@@ -1763,11 +1782,11 @@ packages:
     resolution: {integrity: sha512-MF8Adcw+WPLZGBiNxn76DOuczG3BhODTcMlDCA4+cFi41OkaY/lyI0XUUhi73F88Y+7IHoGmD80pN5CtxQUdSw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/types': 29.3.1
+      '@jest/types': 29.4.2
       '@types/node': 18.11.18
       chalk: 4.1.2
-      jest-message-util: 29.3.1
-      jest-util: 29.3.1
+      jest-message-util: 29.4.2
+      jest-util: 29.4.2
       slash: 3.0.0
     dev: true
 
@@ -1775,11 +1794,11 @@ packages:
     resolution: {integrity: sha512-IRE6GD47KwcqA09RIWrabKdHPiKDGgtAL31xDxbi/RjQMsr+lY+ppxmHwY0dUEV3qvvxZzoe5Hl0RXZJOjQNUg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/types': 29.3.1
+      '@jest/types': 29.4.2
       '@types/node': 18.11.18
       chalk: 4.1.2
       jest-message-util: 29.3.1
-      jest-util: 29.3.1
+      jest-util: 29.4.2
       slash: 3.0.0
     dev: true
 
@@ -1808,7 +1827,7 @@ packages:
       '@jest/reporters': 29.2.2
       '@jest/test-result': 29.2.1
       '@jest/transform': 29.2.2
-      '@jest/types': 29.3.1
+      '@jest/types': 29.4.2
       '@types/node': 18.11.18
       ansi-escapes: 4.3.2
       chalk: 4.1.2
@@ -1825,7 +1844,7 @@ packages:
       jest-runner: 29.2.2
       jest-runtime: 29.2.2
       jest-snapshot: 29.2.2
-      jest-util: 29.3.1
+      jest-util: 29.4.2
       jest-validate: 29.2.2
       jest-watcher: 29.2.2
       micromatch: 4.0.5
@@ -1850,7 +1869,7 @@ packages:
       '@jest/reporters': 29.3.1
       '@jest/test-result': 29.3.1
       '@jest/transform': 29.3.1
-      '@jest/types': 29.3.1
+      '@jest/types': 29.4.2
       '@types/node': 18.11.18
       ansi-escapes: 4.3.2
       chalk: 4.1.2
@@ -1867,7 +1886,7 @@ packages:
       jest-runner: 29.3.1
       jest-runtime: 29.3.1
       jest-snapshot: 29.3.1
-      jest-util: 29.3.1
+      jest-util: 29.4.2
       jest-validate: 29.3.1
       jest-watcher: 29.3.1
       micromatch: 4.0.5
@@ -1892,7 +1911,7 @@ packages:
       '@jest/reporters': 29.3.1
       '@jest/test-result': 29.3.1
       '@jest/transform': 29.3.1
-      '@jest/types': 29.3.1
+      '@jest/types': 29.4.2
       '@types/node': 18.11.18
       ansi-escapes: 4.3.2
       chalk: 4.1.2
@@ -1909,7 +1928,7 @@ packages:
       jest-runner: 29.3.1
       jest-runtime: 29.3.1
       jest-snapshot: 29.3.1
-      jest-util: 29.3.1
+      jest-util: 29.4.2
       jest-validate: 29.3.1
       jest-watcher: 29.3.1
       micromatch: 4.0.5
@@ -1963,6 +1982,48 @@ packages:
       - ts-node
     dev: true
 
+  /@jest/core/29.4.2_ts-node@10.9.1:
+    resolution: {integrity: sha512-KGuoQah0P3vGNlaS/l9/wQENZGNKGoWb+OPxh3gz+YzG7/XExvYu34MzikRndQCdM2S0tzExN4+FL37i6gZmCQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/console': 29.4.2
+      '@jest/reporters': 29.4.2
+      '@jest/test-result': 29.4.2
+      '@jest/transform': 29.4.2
+      '@jest/types': 29.4.2
+      '@types/node': 18.11.18
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.5.0
+      exit: 0.1.2
+      graceful-fs: 4.2.10
+      jest-changed-files: 29.4.2
+      jest-config: 29.4.2_zfha7dvnw4nti6zkbsmhmn6xo4
+      jest-haste-map: 29.4.2
+      jest-message-util: 29.4.2
+      jest-regex-util: 29.4.2
+      jest-resolve: 29.4.2
+      jest-resolve-dependencies: 29.4.2
+      jest-runner: 29.4.2
+      jest-runtime: 29.4.2
+      jest-snapshot: 29.4.2
+      jest-util: 29.4.2
+      jest-validate: 29.4.2
+      jest-watcher: 29.4.2
+      micromatch: 4.0.5
+      pretty-format: 29.4.2
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - supports-color
+      - ts-node
+    dev: true
+
   /@jest/create-cache-key-function/27.5.1:
     resolution: {integrity: sha512-dmH1yW+makpTSURTy8VzdUwFnfQh1G8R+DxO2Ho2FFmBbKFEVm+3jWdvFhE2VqB/LATCTokkP0dotjyQyw5/AQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -1974,10 +2035,10 @@ packages:
     resolution: {integrity: sha512-pMmvfOPmoa1c1QpfFW0nXYtNLpofqo4BrCIk6f2kW4JFeNlHV2t3vd+3iDLf31e2ot2Mec0uqZfmI+U0K2CFag==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/fake-timers': 29.3.1
-      '@jest/types': 29.3.1
+      '@jest/fake-timers': 29.4.2
+      '@jest/types': 29.4.2
       '@types/node': 18.11.18
-      jest-mock: 29.3.1
+      jest-mock: 29.4.2
     dev: true
 
   /@jest/environment/29.4.2:
@@ -2046,7 +2107,7 @@ packages:
       '@sinonjs/fake-timers': 9.1.2
       '@types/node': 18.11.18
       jest-message-util: 29.3.1
-      jest-mock: 29.3.1
+      jest-mock: 29.4.2
       jest-util: 29.4.2
     dev: true
 
@@ -2099,7 +2160,7 @@ packages:
       '@jest/console': 29.3.1
       '@jest/test-result': 29.3.1
       '@jest/transform': 29.3.1
-      '@jest/types': 29.3.1
+      '@jest/types': 29.4.2
       '@jridgewell/trace-mapping': 0.3.17
       '@types/node': 18.11.18
       chalk: 4.1.2
@@ -2112,8 +2173,8 @@ packages:
       istanbul-lib-report: 3.0.0
       istanbul-lib-source-maps: 4.0.1
       istanbul-reports: 3.1.5
-      jest-message-util: 29.3.1
-      jest-util: 29.3.1
+      jest-message-util: 29.4.2
+      jest-util: 29.4.2
       jest-worker: 29.3.1
       slash: 3.0.0
       string-length: 4.0.2
@@ -2136,7 +2197,7 @@ packages:
       '@jest/console': 29.3.1
       '@jest/test-result': 29.3.1
       '@jest/transform': 29.3.1
-      '@jest/types': 29.3.1
+      '@jest/types': 29.4.2
       '@jridgewell/trace-mapping': 0.3.17
       '@types/node': 18.11.18
       chalk: 4.1.2
@@ -2150,7 +2211,7 @@ packages:
       istanbul-lib-source-maps: 4.0.1
       istanbul-reports: 3.1.5
       jest-message-util: 29.3.1
-      jest-util: 29.3.1
+      jest-util: 29.4.2
       jest-worker: 29.3.1
       slash: 3.0.0
       string-length: 4.0.2
@@ -2241,7 +2302,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/console': 29.3.1
-      '@jest/types': 29.3.1
+      '@jest/types': 29.4.2
       '@types/istanbul-lib-coverage': 2.0.4
       collect-v8-coverage: 1.0.1
     dev: true
@@ -2251,7 +2312,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/console': 29.3.1
-      '@jest/types': 29.3.1
+      '@jest/types': 29.4.2
       '@types/istanbul-lib-coverage': 2.0.4
       collect-v8-coverage: 1.0.1
     dev: true
@@ -2270,7 +2331,7 @@ packages:
     resolution: {integrity: sha512-IqYvLbieTv20ArgKoAMyhLHNrVHJfzO6ARZAbQRlY4UGWfdDnLlZEF0BvKOMd77uIiIjSZRwq3Jb3Fa3I8+2UA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/test-result': 29.3.1
+      '@jest/test-result': 29.4.2
       graceful-fs: 4.2.10
       jest-haste-map: 29.3.1
       slash: 3.0.0
@@ -2291,7 +2352,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@babel/core': 7.19.6
-      '@jest/types': 29.3.1
+      '@jest/types': 29.4.2
       '@jridgewell/trace-mapping': 0.3.17
       babel-plugin-istanbul: 6.1.1
       chalk: 4.1.2
@@ -2300,7 +2361,7 @@ packages:
       graceful-fs: 4.2.10
       jest-haste-map: 29.3.1
       jest-regex-util: 29.2.0
-      jest-util: 29.3.1
+      jest-util: 29.4.2
       micromatch: 4.0.5
       pirates: 4.0.5
       slash: 3.0.0
@@ -7250,7 +7311,7 @@ packages:
       jest-get-type: 29.2.0
       jest-matcher-utils: 29.2.2
       jest-message-util: 29.2.1
-      jest-util: 29.3.1
+      jest-util: 29.4.2
     dev: true
 
   /expect/29.3.1:
@@ -7260,8 +7321,8 @@ packages:
       '@jest/expect-utils': 29.3.1
       jest-get-type: 29.2.0
       jest-matcher-utils: 29.3.1
-      jest-message-util: 29.3.1
-      jest-util: 29.3.1
+      jest-message-util: 29.4.2
+      jest-util: 29.4.2
     dev: true
 
   /expect/29.4.2:
@@ -8902,10 +8963,10 @@ packages:
     resolution: {integrity: sha512-wpr26sEvwb3qQQbdlmei+gzp6yoSSoSL6GsLPxnuayZSMrSd5Ka7IjAvatpIernBvT2+Ic6RLTg+jSebScmasg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/environment': 29.3.1
-      '@jest/expect': 29.3.1
-      '@jest/test-result': 29.3.1
-      '@jest/types': 29.3.1
+      '@jest/environment': 29.4.2
+      '@jest/expect': 29.4.2
+      '@jest/test-result': 29.4.2
+      '@jest/types': 29.4.2
       '@types/node': 18.11.18
       chalk: 4.1.2
       co: 4.6.0
@@ -8913,10 +8974,10 @@ packages:
       is-generator-fn: 2.1.0
       jest-each: 29.3.1
       jest-matcher-utils: 29.3.1
-      jest-message-util: 29.3.1
+      jest-message-util: 29.4.2
       jest-runtime: 29.3.1
-      jest-snapshot: 29.3.1
-      jest-util: 29.3.1
+      jest-snapshot: 29.4.2
+      jest-util: 29.4.2
       p-limit: 3.1.0
       pretty-format: 29.3.1
       slash: 3.0.0
@@ -8962,15 +9023,15 @@ packages:
       node-notifier:
         optional: true
     dependencies:
-      '@jest/core': 29.3.1
+      '@jest/core': 29.4.2
       '@jest/test-result': 29.2.1
-      '@jest/types': 29.3.1
+      '@jest/types': 29.4.2
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.10
       import-local: 3.1.0
       jest-config: 29.2.2
-      jest-util: 29.3.1
+      jest-util: 29.4.2
       jest-validate: 29.2.2
       prompts: 2.4.2
       yargs: 17.6.2
@@ -8990,15 +9051,15 @@ packages:
       node-notifier:
         optional: true
     dependencies:
-      '@jest/core': 29.3.1
+      '@jest/core': 29.4.2
       '@jest/test-result': 29.2.1
-      '@jest/types': 29.3.1
+      '@jest/types': 29.4.2
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.10
       import-local: 3.1.0
       jest-config: 29.2.2_@types+node@14.18.33
-      jest-util: 29.3.1
+      jest-util: 29.4.2
       jest-validate: 29.2.2
       prompts: 2.4.2
       yargs: 17.6.2
@@ -9018,15 +9079,15 @@ packages:
       node-notifier:
         optional: true
     dependencies:
-      '@jest/core': 29.3.1
+      '@jest/core': 29.4.2
       '@jest/test-result': 29.3.1
-      '@jest/types': 29.3.1
+      '@jest/types': 29.4.2
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.10
       import-local: 3.1.0
       jest-config: 29.3.1
-      jest-util: 29.3.1
+      jest-util: 29.4.2
       jest-validate: 29.3.1
       prompts: 2.4.2
       yargs: 17.6.2
@@ -9046,15 +9107,15 @@ packages:
       node-notifier:
         optional: true
     dependencies:
-      '@jest/core': 29.3.1
+      '@jest/core': 29.4.2
       '@jest/test-result': 29.3.1
-      '@jest/types': 29.3.1
+      '@jest/types': 29.4.2
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.10
       import-local: 3.1.0
       jest-config: 29.3.1_@types+node@17.0.45
-      jest-util: 29.3.1
+      jest-util: 29.4.2
       jest-validate: 29.3.1
       prompts: 2.4.2
       yargs: 17.6.2
@@ -9074,15 +9135,15 @@ packages:
       node-notifier:
         optional: true
     dependencies:
-      '@jest/core': 29.3.1
+      '@jest/core': 29.4.2
       '@jest/test-result': 29.3.1
-      '@jest/types': 29.3.1
+      '@jest/types': 29.4.2
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.10
       import-local: 3.1.0
       jest-config: 29.3.1_@types+node@18.11.9
-      jest-util: 29.3.1
+      jest-util: 29.4.2
       jest-validate: 29.3.1
       prompts: 2.4.2
       yargs: 17.6.2
@@ -9102,15 +9163,15 @@ packages:
       node-notifier:
         optional: true
     dependencies:
-      '@jest/core': 29.3.1_ts-node@10.9.1
+      '@jest/core': 29.4.2_ts-node@10.9.1
       '@jest/test-result': 29.3.1
-      '@jest/types': 29.3.1
+      '@jest/types': 29.4.2
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.10
       import-local: 3.1.0
       jest-config: 29.3.1_zfha7dvnw4nti6zkbsmhmn6xo4
-      jest-util: 29.3.1
+      jest-util: 29.4.2
       jest-validate: 29.3.1
       prompts: 2.4.2
       yargs: 17.6.2
@@ -9162,7 +9223,7 @@ packages:
     dependencies:
       '@babel/core': 7.19.6
       '@jest/test-sequencer': 29.3.1
-      '@jest/types': 29.3.1
+      '@jest/types': 29.4.2
       babel-jest: 29.3.1_@babel+core@7.19.6
       chalk: 4.1.2
       ci-info: 3.5.0
@@ -9175,7 +9236,7 @@ packages:
       jest-regex-util: 29.2.0
       jest-resolve: 29.3.1
       jest-runner: 29.3.1
-      jest-util: 29.3.1
+      jest-util: 29.4.2
       jest-validate: 29.3.1
       micromatch: 4.0.5
       parse-json: 5.2.0
@@ -9200,7 +9261,7 @@ packages:
     dependencies:
       '@babel/core': 7.19.6
       '@jest/test-sequencer': 29.3.1
-      '@jest/types': 29.3.1
+      '@jest/types': 29.4.2
       '@types/node': 14.18.33
       babel-jest: 29.3.1_@babel+core@7.19.6
       chalk: 4.1.2
@@ -9214,7 +9275,7 @@ packages:
       jest-regex-util: 29.2.0
       jest-resolve: 29.3.1
       jest-runner: 29.3.1
-      jest-util: 29.3.1
+      jest-util: 29.4.2
       jest-validate: 29.3.1
       micromatch: 4.0.5
       parse-json: 5.2.0
@@ -9239,7 +9300,7 @@ packages:
     dependencies:
       '@babel/core': 7.19.6
       '@jest/test-sequencer': 29.3.1
-      '@jest/types': 29.3.1
+      '@jest/types': 29.4.2
       '@types/node': 18.11.18
       babel-jest: 29.3.1_@babel+core@7.19.6
       chalk: 4.1.2
@@ -9253,7 +9314,7 @@ packages:
       jest-regex-util: 29.2.0
       jest-resolve: 29.3.1
       jest-runner: 29.3.1
-      jest-util: 29.3.1
+      jest-util: 29.4.2
       jest-validate: 29.3.1
       micromatch: 4.0.5
       parse-json: 5.2.0
@@ -9278,7 +9339,7 @@ packages:
     dependencies:
       '@babel/core': 7.19.6
       '@jest/test-sequencer': 29.3.1
-      '@jest/types': 29.3.1
+      '@jest/types': 29.4.2
       babel-jest: 29.3.1_@babel+core@7.19.6
       chalk: 4.1.2
       ci-info: 3.5.0
@@ -9291,7 +9352,7 @@ packages:
       jest-regex-util: 29.2.0
       jest-resolve: 29.3.1
       jest-runner: 29.3.1
-      jest-util: 29.3.1
+      jest-util: 29.4.2
       jest-validate: 29.3.1
       micromatch: 4.0.5
       parse-json: 5.2.0
@@ -9316,7 +9377,7 @@ packages:
     dependencies:
       '@babel/core': 7.19.6
       '@jest/test-sequencer': 29.3.1
-      '@jest/types': 29.3.1
+      '@jest/types': 29.4.2
       '@types/node': 17.0.45
       babel-jest: 29.3.1_@babel+core@7.19.6
       chalk: 4.1.2
@@ -9330,7 +9391,7 @@ packages:
       jest-regex-util: 29.2.0
       jest-resolve: 29.3.1
       jest-runner: 29.3.1
-      jest-util: 29.3.1
+      jest-util: 29.4.2
       jest-validate: 29.3.1
       micromatch: 4.0.5
       parse-json: 5.2.0
@@ -9355,7 +9416,7 @@ packages:
     dependencies:
       '@babel/core': 7.19.6
       '@jest/test-sequencer': 29.3.1
-      '@jest/types': 29.3.1
+      '@jest/types': 29.4.2
       '@types/node': 18.11.18
       babel-jest: 29.3.1_@babel+core@7.19.6
       chalk: 4.1.2
@@ -9369,7 +9430,7 @@ packages:
       jest-regex-util: 29.2.0
       jest-resolve: 29.3.1
       jest-runner: 29.3.1
-      jest-util: 29.3.1
+      jest-util: 29.4.2
       jest-validate: 29.3.1
       micromatch: 4.0.5
       parse-json: 5.2.0
@@ -9394,7 +9455,7 @@ packages:
     dependencies:
       '@babel/core': 7.19.6
       '@jest/test-sequencer': 29.3.1
-      '@jest/types': 29.3.1
+      '@jest/types': 29.4.2
       '@types/node': 18.11.9
       babel-jest: 29.3.1_@babel+core@7.19.6
       chalk: 4.1.2
@@ -9408,7 +9469,7 @@ packages:
       jest-regex-util: 29.2.0
       jest-resolve: 29.3.1
       jest-runner: 29.3.1
-      jest-util: 29.3.1
+      jest-util: 29.4.2
       jest-validate: 29.3.1
       micromatch: 4.0.5
       parse-json: 5.2.0
@@ -9433,7 +9494,7 @@ packages:
     dependencies:
       '@babel/core': 7.19.6
       '@jest/test-sequencer': 29.3.1
-      '@jest/types': 29.3.1
+      '@jest/types': 29.4.2
       '@types/node': 18.11.18
       babel-jest: 29.3.1_@babel+core@7.19.6
       chalk: 4.1.2
@@ -9447,7 +9508,7 @@ packages:
       jest-regex-util: 29.2.0
       jest-resolve: 29.3.1
       jest-runner: 29.3.1
-      jest-util: 29.3.1
+      jest-util: 29.4.2
       jest-validate: 29.3.1
       micromatch: 4.0.5
       parse-json: 5.2.0
@@ -9537,6 +9598,46 @@ packages:
       - supports-color
     dev: true
 
+  /jest-config/29.4.2_zfha7dvnw4nti6zkbsmhmn6xo4:
+    resolution: {integrity: sha512-919CtnXic52YM0zW4C1QxjG6aNueX1kBGthuMtvFtRTAxhKfJmiXC9qwHmi6o2josjbDz8QlWyY55F1SIVmCWA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      '@types/node': '*'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      ts-node:
+        optional: true
+    dependencies:
+      '@babel/core': 7.19.6
+      '@jest/test-sequencer': 29.4.2
+      '@jest/types': 29.4.2
+      '@types/node': 18.11.18
+      babel-jest: 29.4.2_@babel+core@7.19.6
+      chalk: 4.1.2
+      ci-info: 3.5.0
+      deepmerge: 4.2.2
+      glob: 7.2.3
+      graceful-fs: 4.2.10
+      jest-circus: 29.4.2
+      jest-environment-node: 29.4.2
+      jest-get-type: 29.4.2
+      jest-regex-util: 29.4.2
+      jest-resolve: 29.4.2
+      jest-runner: 29.4.2
+      jest-util: 29.4.2
+      jest-validate: 29.4.2
+      micromatch: 4.0.5
+      parse-json: 5.2.0
+      pretty-format: 29.4.2
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+      ts-node: 10.9.1_awa2wsr5thmg3i7jqycphctjfq
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /jest-diff/28.1.3:
     resolution: {integrity: sha512-8RqP1B/OXzjjTWkqMX67iqgwBVJRgCyKD3L9nq+6ZqJMdvjE8RgHktqZ6jNrkdMT+dJuYNI3rhQpxaz7drJHfw==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
@@ -9585,10 +9686,10 @@ packages:
     resolution: {integrity: sha512-qrZH7PmFB9rEzCSl00BWjZYuS1BSOH8lLuC0azQE9lQrAx3PWGKHTDudQiOSwIy5dGAJh7KA0ScYlCP7JxvFYA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/types': 29.3.1
+      '@jest/types': 29.4.2
       chalk: 4.1.2
       jest-get-type: 29.2.0
-      jest-util: 29.3.1
+      jest-util: 29.4.2
       pretty-format: 29.3.1
     dev: true
 
@@ -9630,12 +9731,12 @@ packages:
     resolution: {integrity: sha512-xm2THL18Xf5sIHoU7OThBPtuH6Lerd+Y1NLYiZJlkE3hbE+7N7r8uvHIl/FkZ5ymKXJe/11SQuf3fv4v6rUMag==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/environment': 29.3.1
-      '@jest/fake-timers': 29.3.1
-      '@jest/types': 29.3.1
+      '@jest/environment': 29.4.2
+      '@jest/fake-timers': 29.4.2
+      '@jest/types': 29.4.2
       '@types/node': 18.11.18
-      jest-mock: 29.3.1
-      jest-util: 29.3.1
+      jest-mock: 29.4.2
+      jest-util: 29.4.2
     dev: true
 
   /jest-environment-node/29.4.2:
@@ -9669,14 +9770,14 @@ packages:
     resolution: {integrity: sha512-wF460rAFmYc6ARcCFNw4MbGYQjYkvjovb9GBT+W10Um8q5nHq98jD6fHZMDMO3tA56S8XnmNkM8GcA8diSZfnA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/types': 29.3.1
+      '@jest/types': 29.4.2
       '@types/graceful-fs': 4.1.5
       '@types/node': 18.11.18
       anymatch: 3.1.2
       fb-watchman: 2.0.2
       graceful-fs: 4.2.10
       jest-regex-util: 29.2.0
-      jest-util: 29.3.1
+      jest-util: 29.4.2
       jest-worker: 29.3.1
       micromatch: 4.0.5
       walker: 1.0.8
@@ -9798,7 +9899,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@babel/code-frame': 7.18.6
-      '@jest/types': 29.3.1
+      '@jest/types': 29.4.2
       '@types/stack-utils': 2.0.1
       chalk: 4.1.2
       graceful-fs: 4.2.10
@@ -9842,9 +9943,9 @@ packages:
     resolution: {integrity: sha512-H8/qFDtDVMFvFP4X8NuOT3XRDzOUTz+FeACjufHzsOIBAxivLqkB1PoLCaJx9iPPQ8dZThHPp/G3WRWyMgA3JA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/types': 29.3.1
+      '@jest/types': 29.4.2
       '@types/node': 18.11.18
-      jest-util: 29.3.1
+      jest-util: 29.4.2
     dev: true
 
   /jest-mock/29.4.2:
@@ -9907,7 +10008,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       jest-regex-util: 29.2.0
-      jest-snapshot: 29.3.1
+      jest-snapshot: 29.4.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -9917,7 +10018,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       jest-regex-util: 29.2.0
-      jest-snapshot: 29.3.1
+      jest-snapshot: 29.4.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -9940,7 +10041,7 @@ packages:
       graceful-fs: 4.2.10
       jest-haste-map: 29.3.1
       jest-pnp-resolver: 1.2.2_jest-resolve@29.2.2
-      jest-util: 29.3.1
+      jest-util: 29.4.2
       jest-validate: 29.3.1
       resolve: 1.22.1
       resolve.exports: 1.1.0
@@ -9955,7 +10056,7 @@ packages:
       graceful-fs: 4.2.10
       jest-haste-map: 29.3.1
       jest-pnp-resolver: 1.2.2_jest-resolve@29.3.1
-      jest-util: 29.3.1
+      jest-util: 29.4.2
       jest-validate: 29.3.1
       resolve: 1.22.1
       resolve.exports: 1.1.0
@@ -9982,10 +10083,10 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/console': 29.3.1
-      '@jest/environment': 29.3.1
+      '@jest/environment': 29.4.2
       '@jest/test-result': 29.3.1
       '@jest/transform': 29.3.1
-      '@jest/types': 29.3.1
+      '@jest/types': 29.4.2
       '@types/node': 18.11.18
       chalk: 4.1.2
       emittery: 0.13.1
@@ -9994,10 +10095,10 @@ packages:
       jest-environment-node: 29.3.1
       jest-haste-map: 29.3.1
       jest-leak-detector: 29.3.1
-      jest-message-util: 29.3.1
+      jest-message-util: 29.4.2
       jest-resolve: 29.3.1
       jest-runtime: 29.3.1
-      jest-util: 29.3.1
+      jest-util: 29.4.2
       jest-watcher: 29.3.1
       jest-worker: 29.3.1
       p-limit: 3.1.0
@@ -10011,10 +10112,10 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/console': 29.3.1
-      '@jest/environment': 29.3.1
+      '@jest/environment': 29.4.2
       '@jest/test-result': 29.3.1
       '@jest/transform': 29.3.1
-      '@jest/types': 29.3.1
+      '@jest/types': 29.4.2
       '@types/node': 18.11.18
       chalk: 4.1.2
       emittery: 0.13.1
@@ -10026,7 +10127,7 @@ packages:
       jest-message-util: 29.3.1
       jest-resolve: 29.3.1
       jest-runtime: 29.3.1
-      jest-util: 29.3.1
+      jest-util: 29.4.2
       jest-watcher: 29.3.1
       jest-worker: 29.3.1
       p-limit: 3.1.0
@@ -10068,13 +10169,13 @@ packages:
     resolution: {integrity: sha512-TpR1V6zRdLynckKDIQaY41od4o0xWL+KOPUCZvJK2bu5P1UXhjobt5nJ2ICNeIxgyj9NGkO0aWgDqYPVhDNKjA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/environment': 29.3.1
-      '@jest/fake-timers': 29.3.1
-      '@jest/globals': 29.3.1
+      '@jest/environment': 29.4.2
+      '@jest/fake-timers': 29.4.2
+      '@jest/globals': 29.4.2
       '@jest/source-map': 29.2.0
       '@jest/test-result': 29.3.1
       '@jest/transform': 29.3.1
-      '@jest/types': 29.3.1
+      '@jest/types': 29.4.2
       '@types/node': 18.11.18
       chalk: 4.1.2
       cjs-module-lexer: 1.2.2
@@ -10082,12 +10183,12 @@ packages:
       glob: 7.2.3
       graceful-fs: 4.2.10
       jest-haste-map: 29.3.1
-      jest-message-util: 29.3.1
-      jest-mock: 29.3.1
+      jest-message-util: 29.4.2
+      jest-mock: 29.4.2
       jest-regex-util: 29.2.0
       jest-resolve: 29.3.1
-      jest-snapshot: 29.3.1
-      jest-util: 29.3.1
+      jest-snapshot: 29.4.2
+      jest-util: 29.4.2
       slash: 3.0.0
       strip-bom: 4.0.0
     transitivePeerDependencies:
@@ -10098,13 +10199,13 @@ packages:
     resolution: {integrity: sha512-jLzkIxIqXwBEOZx7wx9OO9sxoZmgT2NhmQKzHQm1xwR1kNW/dn0OjxR424VwHHf1SPN6Qwlb5pp1oGCeFTQ62A==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/environment': 29.3.1
-      '@jest/fake-timers': 29.3.1
-      '@jest/globals': 29.3.1
+      '@jest/environment': 29.4.2
+      '@jest/fake-timers': 29.4.2
+      '@jest/globals': 29.4.2
       '@jest/source-map': 29.2.0
       '@jest/test-result': 29.3.1
       '@jest/transform': 29.3.1
-      '@jest/types': 29.3.1
+      '@jest/types': 29.4.2
       '@types/node': 18.11.18
       chalk: 4.1.2
       cjs-module-lexer: 1.2.2
@@ -10113,11 +10214,11 @@ packages:
       graceful-fs: 4.2.10
       jest-haste-map: 29.3.1
       jest-message-util: 29.3.1
-      jest-mock: 29.3.1
+      jest-mock: 29.4.2
       jest-regex-util: 29.2.0
       jest-resolve: 29.3.1
-      jest-snapshot: 29.3.1
-      jest-util: 29.3.1
+      jest-snapshot: 29.4.2
+      jest-util: 29.4.2
       slash: 3.0.0
       strip-bom: 4.0.0
     transitivePeerDependencies:
@@ -10167,19 +10268,19 @@ packages:
       '@babel/types': 7.20.7
       '@jest/expect-utils': 29.3.1
       '@jest/transform': 29.3.1
-      '@jest/types': 29.3.1
+      '@jest/types': 29.4.2
       '@types/babel__traverse': 7.18.2
       '@types/prettier': 2.7.1
       babel-preset-current-node-syntax: 1.0.1_@babel+core@7.19.6
       chalk: 4.1.2
-      expect: 29.3.1
+      expect: 29.4.2
       graceful-fs: 4.2.10
       jest-diff: 29.3.1
       jest-get-type: 29.2.0
       jest-haste-map: 29.3.1
       jest-matcher-utils: 29.3.1
-      jest-message-util: 29.3.1
-      jest-util: 29.3.1
+      jest-message-util: 29.4.2
+      jest-util: 29.4.2
       natural-compare: 1.4.0
       pretty-format: 29.3.1
       semver: 7.3.8
@@ -10204,7 +10305,7 @@ packages:
       '@types/prettier': 2.7.1
       babel-preset-current-node-syntax: 1.0.1_@babel+core@7.19.6
       chalk: 4.1.2
-      expect: 29.3.1
+      expect: 29.4.2
       graceful-fs: 4.2.10
       jest-diff: 29.3.1
       jest-get-type: 29.2.0
@@ -10267,7 +10368,7 @@ packages:
     resolution: {integrity: sha512-7YOVZaiX7RJLv76ZfHt4nbNEzzTRiMW/IiOG7ZOKmTXmoGBxUDefgMAxQubu6WPVqP5zSzAdZG0FfLcC7HOIFQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/types': 29.3.1
+      '@jest/types': 29.4.2
       '@types/node': 18.11.18
       chalk: 4.1.2
       ci-info: 3.5.0
@@ -10291,7 +10392,7 @@ packages:
     resolution: {integrity: sha512-eJXATaKaSnOuxNfs8CLHgdABFgUrd0TtWS8QckiJ4L/QVDF4KVbZFBBOwCBZHOS0Rc5fOxqngXeGXE3nGQkpQA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/types': 29.3.1
+      '@jest/types': 29.4.2
       camelcase: 6.3.0
       chalk: 4.1.2
       jest-get-type: 29.2.0
@@ -10303,7 +10404,7 @@ packages:
     resolution: {integrity: sha512-N9Lr3oYR2Mpzuelp1F8negJR3YE+L1ebk1rYA5qYo9TTY3f9OWdptLoNSPP9itOCBIRBqjt/S5XHlzYglLN67g==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/types': 29.3.1
+      '@jest/types': 29.4.2
       camelcase: 6.3.0
       chalk: 4.1.2
       jest-get-type: 29.2.0
@@ -10328,12 +10429,12 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/test-result': 29.3.1
-      '@jest/types': 29.3.1
+      '@jest/types': 29.4.2
       '@types/node': 18.11.18
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
-      jest-util: 29.3.1
+      jest-util: 29.4.2
       string-length: 4.0.2
     dev: true
 
@@ -10342,12 +10443,12 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/test-result': 29.3.1
-      '@jest/types': 29.3.1
+      '@jest/types': 29.4.2
       '@types/node': 18.11.18
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
-      jest-util: 29.3.1
+      jest-util: 29.4.2
       string-length: 4.0.2
     dev: true
 
@@ -13158,7 +13259,7 @@ packages:
     resolution: {integrity: sha512-FyLnmb1cYJV8biEIiRyzRFvs2lry7PPIvOqKVe1GCUEYg4YGmlx1qG9EJNMxArYm7piII4qb8UV1Pncq5dxmcg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/schemas': 29.0.0
+      '@jest/schemas': 29.4.2
       ansi-styles: 5.2.0
       react-is: 18.2.0
     dev: true
@@ -14936,7 +15037,7 @@ packages:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       jest: 29.4.2_@types+node@14.18.33
-      jest-util: 29.3.1
+      jest-util: 29.4.2
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -14969,7 +15070,7 @@ packages:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       jest: 29.3.1_zfha7dvnw4nti6zkbsmhmn6xo4
-      jest-util: 29.3.1
+      jest-util: 29.4.2
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6

--- a/testapps/hooks/.gitignore
+++ b/testapps/hooks/.gitignore
@@ -1,0 +1,44 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+.vscode
+.idea
+
+# jest compilation
+test/*.js
+
+# WunderGraph build output
+.wundergraph/cache
+.wundergraph/generated
+
+# dependencies
+node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# vercel
+.vercel

--- a/testapps/hooks/.graphqlrc.yaml
+++ b/testapps/hooks/.graphqlrc.yaml
@@ -1,0 +1,12 @@
+# This file provides autocompletion in .graphql files
+# Some IDEs, like VS code require this file to be at the
+# root of your workspace. If you move it around, make sure
+# to update schema and documents with the new paths.
+schema: '.wundergraph/generated/wundergraph.schema.graphql'
+documents: '.wundergraph/operations/**/*.graphql'
+extensions:
+  endpoint:
+    introspect: false
+    url: 'http://localhost:9991/graphql'
+    headers:
+      user-agent: 'WunderGraph Client'

--- a/testapps/hooks/.wundergraph/.graphqlconfig
+++ b/testapps/hooks/.wundergraph/.graphqlconfig
@@ -1,0 +1,14 @@
+{
+  "project": {
+    "schemaPath": "generated/wundergraph.schema.graphql",
+    "extensions": {
+      "endpoint": {
+        "introspect": false,
+        "url": "http://localhost:9991/graphql",
+        "headers": {
+          "user-agent": "WunderGraph Client"
+        }
+      }
+    }
+  }
+}

--- a/testapps/hooks/.wundergraph/operations/Continents.graphql
+++ b/testapps/hooks/.wundergraph/operations/Continents.graphql
@@ -1,0 +1,6 @@
+query {
+	countries_continents {
+		name
+		code
+	}
+}

--- a/testapps/hooks/.wundergraph/operations/PreResolveChain.graphql
+++ b/testapps/hooks/.wundergraph/operations/PreResolveChain.graphql
@@ -1,0 +1,3 @@
+query ($s: String!) {
+	echo_string(input: $s)
+}

--- a/testapps/hooks/.wundergraph/operations/PreResolveFailure.graphql
+++ b/testapps/hooks/.wundergraph/operations/PreResolveFailure.graphql
@@ -1,0 +1,3 @@
+query ($s: String!) {
+	echo_string(input: $s)
+}

--- a/testapps/hooks/.wundergraph/operations/RecursiveContinents.graphql
+++ b/testapps/hooks/.wundergraph/operations/RecursiveContinents.graphql
@@ -1,0 +1,6 @@
+query {
+	countries_continents {
+		name
+		code
+	}
+}

--- a/testapps/hooks/.wundergraph/wundergraph.config.ts
+++ b/testapps/hooks/.wundergraph/wundergraph.config.ts
@@ -1,0 +1,32 @@
+import { configureWunderGraphApplication, cors, introspect, templates } from '@wundergraph/sdk';
+import server from './wundergraph.server';
+import operations from './wundergraph.operations';
+
+const countries = introspect.graphql({
+	apiNamespace: 'countries',
+	url: 'https://countries.trevorblades.com/',
+});
+
+// configureWunderGraph emits the configuration
+configureWunderGraphApplication({
+	apis: [countries],
+	server,
+	operations,
+	codeGenerators: [
+		{
+			templates: [
+				// use all the typescript react templates to generate a client
+				...templates.typescript.all,
+			],
+			// create-react-app expects all code to be inside /src
+			// path: "../frontend/src/generated",
+		},
+	],
+	cors: {
+		...cors.allowAll,
+		allowedOrigins: ['http://localhost:9991', 'http://127.0.0.1:9991'],
+	},
+	security: {
+		enableGraphQLEndpoint: true,
+	},
+});

--- a/testapps/hooks/.wundergraph/wundergraph.operations.ts
+++ b/testapps/hooks/.wundergraph/wundergraph.operations.ts
@@ -1,0 +1,32 @@
+import { configureWunderGraphOperations } from '@wundergraph/sdk';
+import type { OperationsConfiguration } from './generated/wundergraph.operations';
+
+export default configureWunderGraphOperations<OperationsConfiguration>({
+	operations: {
+		defaultConfig: {
+			authentication: {
+				required: false,
+			},
+		},
+		queries: (config) => ({
+			...config,
+			caching: {
+				enable: false,
+				staleWhileRevalidate: 60,
+				maxAge: 60,
+				public: true,
+			},
+			liveQuery: {
+				enable: true,
+				pollingIntervalSeconds: 1,
+			},
+		}),
+		mutations: (config) => ({
+			...config,
+		}),
+		subscriptions: (config) => ({
+			...config,
+		}),
+		custom: {},
+	},
+});

--- a/testapps/hooks/.wundergraph/wundergraph.server.ts
+++ b/testapps/hooks/.wundergraph/wundergraph.server.ts
@@ -1,0 +1,100 @@
+import { GraphQLObjectType, GraphQLSchema, GraphQLString, GraphQLInt, GraphQLFloat, GraphQLBoolean } from 'graphql';
+
+import { configureWunderGraphServer } from '@wundergraph/sdk/server';
+import type { HooksConfig } from './generated/wundergraph.hooks';
+import type { InternalClient } from './generated/wundergraph.internal.client';
+
+export default configureWunderGraphServer<HooksConfig, InternalClient>(() => ({
+	hooks: {
+		queries: {
+			PreResolveFailure: {
+				preResolve: async (hook) => {
+					console.log(`preResolve: ${hook.input}`);
+					throw new Error('stop');
+				},
+			},
+			PreResolveChain: {
+				preResolve: async (hook) => {
+					console.log(`preResolve: ${hook.input}`);
+				},
+				mutatingPreResolve: async (hook) => {
+					console.log(`mutatingPreResolve: ${hook.input}`);
+					return {
+						s: hook.input.s + '.mutatingPreResolve',
+					};
+				},
+			},
+			RecursiveContinents: {
+				customResolve: async (hook) => {
+					console.log('CUSTOM RESOLVE - RecursiveContinents');
+					return hook.internalClient.queries.Continents();
+				},
+			},
+			Continents: {
+				customResolve: async () => {
+					console.log('CUSTOM RESOLVE - Continents');
+					return {
+						data: {
+							countries_continents: [
+								{
+									code: '123',
+									name: 'abc',
+								},
+							],
+						},
+					};
+				},
+			},
+		},
+		mutations: {},
+	},
+	graphqlServers: [
+		{
+			serverName: 'echo',
+			apiNamespace: 'echo',
+			schema: new GraphQLSchema({
+				query: new GraphQLObjectType({
+					name: 'RootQueryType',
+					fields: {
+						boolean: {
+							args: {
+								input: { type: GraphQLBoolean },
+							},
+							type: GraphQLString,
+							resolve(obj, args, context, info) {
+								return `boolean: ${args.input}`;
+							},
+						},
+						int: {
+							args: {
+								input: { type: GraphQLInt },
+							},
+							type: GraphQLString,
+							resolve(obj, args, context, info) {
+								return `int: ${args.input}`;
+							},
+						},
+						float: {
+							args: {
+								input: { type: GraphQLFloat },
+							},
+							type: GraphQLString,
+							resolve(obj, args, context, info) {
+								return `float: ${args.input}`;
+							},
+						},
+						string: {
+							args: {
+								input: { type: GraphQLString },
+							},
+							type: GraphQLString,
+							resolve(obj, args, context, info) {
+								return `string: ${args.input}`;
+							},
+						},
+					},
+				}),
+			}),
+		},
+	],
+}));

--- a/testapps/hooks/jest.config.js
+++ b/testapps/hooks/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+	roots: ['<rootDir>/test/'],
+	transform: {
+		'^.+\\.tsx?$': 'ts-jest',
+	},
+	testRegex: '(/__tests__/.*|\\.(test|spec))\\.[tj]sx?$',
+	moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+};

--- a/testapps/hooks/package.json
+++ b/testapps/hooks/package.json
@@ -1,0 +1,37 @@
+{
+  "private": true,
+  "name": "@test/hooks",
+  "version": "0.1.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/wundergraph/wundergraph.git"
+  },
+  "homepage": "https://wundergraph.com",
+  "author": {
+    "name": "WunderGraph Maintainers",
+    "email": "info@wundergraph.com"
+  },
+  "bugs": {
+    "url": "https://github.com/wundergraph/wundergraph/issues"
+  },
+  "scripts": {
+    "dev": "wunderctl up --debug",
+    "build": "pnpm generate && pnpm check",
+    "start": "wunderctl start --debug",
+    "generate": "wunderctl generate --debug",
+    "test": "jest",
+    "check": "tsc"
+  },
+  "dependencies": {
+    "@types/node": "^14.14.37",
+    "@wundergraph/sdk": "workspace:*",
+    "graphql": "^16.3.0",
+    "typescript": "^4.8.2"
+  },
+  "sideEffects": false,
+  "devDependencies": {
+    "@jest/globals": "^29.3.1",
+    "jest": "^29.4.2",
+    "ts-jest": "^29.0.5"
+  }
+}

--- a/testapps/hooks/test/index.test.ts
+++ b/testapps/hooks/test/index.test.ts
@@ -1,0 +1,40 @@
+import { afterAll, beforeAll, describe, expect, test } from '@jest/globals';
+import { createTestServer } from '../.wundergraph/generated/testing';
+
+const wg = createTestServer();
+
+beforeAll(() => wg.start());
+afterAll(() => wg.stop());
+
+describe('test recursive operation calls hooks', () => {
+	// test('valid token', async () => {
+	// 	const client = wg.client();
+	// 	const result = await client.query({
+	// 		operationName: 'RecursiveContinents',
+	// 	});
+	// 	console.log(result);
+	// });
+});
+
+describe('preResolve chain', () => {
+	test('preResolve failure is reported', async () => {
+		const client = wg.client();
+		const result = await client.query({
+			operationName: 'PreResolveFailure',
+			input: {
+				s: 'initial',
+			},
+		});
+		expect(result.data).toBeUndefined();
+		expect(result.error?.message).toMatch(/preResolve.*failed/i);
+	});
+	test('mutatingPreResolve is called', async () => {
+		const client = wg.client();
+		const result = await client.query({
+			operationName: 'PreResolveChain',
+			input: {
+				s: 'initial',
+			},
+		});
+	});
+});

--- a/testapps/hooks/tsconfig.json
+++ b/testapps/hooks/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "commonjs",
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": [".wundergraph/**/*.ts"]
+}


### PR DESCRIPTION
- refactor: add hooks.Pipeline to run operation hooks
- refactor: use hooks.Pipeline in Query, Mutation and Subscription handlers
- refactor: expose hookBaseData as hooks.EncodeData()

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

<!--
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->
