### PR TITLE
fix: should skip file when file in diff dir

### DIFF
--- a/pkg/loadoperations/loader.go
+++ b/pkg/loadoperations/loader.go
@@ -160,15 +160,6 @@ func (l *Loader) readGraphQLOperation(filePath string) {
 	}
 
 	operationName := normalizeOperationName(fileName)
-
-	for _, file := range l.out.GraphQLOperationFiles {
-		if file.OperationName == operationName {
-			l.out.Info = append(l.out.Info, fmt.Sprintf(
-				"skipping file %s. Operation name collides with operation defined in: %s", filePath, file.FilePath))
-			return
-		}
-	}
-
 	l.out.GraphQLOperationFiles = append(l.out.GraphQLOperationFiles, GraphQLOperationFile{
 		OperationName: operationName,
 		ApiMountPath:  fileName,


### PR DESCRIPTION
i do not think we should filter operation file under dir. when file in different dir, it will be skiped, such as:
AB.graphql
A/B.graphql
both operation name will be AB, so it will skip A/B. So. i del filer logic. is there any other design to slove this problem?