### PR TITLE
fix: graphql introspection with renamed query types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
 all: check-setup
 # Bootstrap pnpm workspace
-	./scripts/pnpm.sh
+	make pnpm
 # prepare and install engine
 	make engine-dev
+
+pnpm:
+	./scripts/pnpm.sh
 
 docs:
 	pnpm --filter="./docs-website" dev
@@ -63,4 +66,4 @@ run:
 install:
 	cd cmd/wunderctl && CGO_ENABLED=0 go install
 
-.PHONY: codegen build run tag install-proto format-templates dev all check-local docs wunderctl build-docs bootstrap-minio
+.PHONY: codegen build run tag install-proto format-templates dev all check-local docs wunderctl build-docs bootstrap-minio pnpm

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 all: check-setup
 # Bootstrap pnpm workspace
-	make pnpm
+	make bootstrap-pnpm
 # prepare and install engine
 	make engine-dev
 
-pnpm:
+bootstrap-pnpm:
 	./scripts/pnpm.sh
 
 docs:

--- a/Makefile
+++ b/Makefile
@@ -66,4 +66,4 @@ run:
 install:
 	cd cmd/wunderctl && CGO_ENABLED=0 go install
 
-.PHONY: codegen build run tag install-proto format-templates dev all check-local docs wunderctl build-docs bootstrap-minio pnpm
+.PHONY: codegen build run tag install-proto format-templates dev all check-local docs wunderctl build-docs bootstrap-minio bootstrap-pnpm

--- a/packages/sdk/src/graphql/__snapshots__/schema.test.ts.snap
+++ b/packages/sdk/src/graphql/__snapshots__/schema.test.ts.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`cleanupSchema custom Int/Float scalars should replace float scalar 1`] = `
+"type Query {
+  foo: Float
+}"
+`;
+
+exports[`cleanupSchema custom Int/Float scalars should replace int scalar 1`] = `
+"type Query {
+  foo: Int
+}"
+`;
+
+exports[`cleanupSchema renamed query types should rename query type 1`] = `
+"schema {
+  query: Query
+  mutation: Mutation
+  subscription: Subscription
+}
+
+type Query {
+  foo: String
+}
+
+type Mutation {
+  foo: String
+}
+
+type Subscription {
+  foo: String
+}
+
+type Foo {
+  queryViewer: Query
+  mutationViewer: Mutation
+  subscriptionViewer: Subscription
+}"
+`;

--- a/packages/sdk/src/graphql/schema.test.ts
+++ b/packages/sdk/src/graphql/schema.test.ts
@@ -1,11 +1,6 @@
-import { OperationDefinitionNode, parse } from 'graphql/index';
-import { configuration } from './configuration';
-import { assert } from 'chai';
 import { GraphQLIntrospection } from '../definition';
 import { cleanupSchema } from './schema';
-import { buildClientSchema } from 'graphql/utilities/buildClientSchema';
 import { buildSchema } from 'graphql';
-import { operationResponseToJSONSchema, operationVariablesToJSONSchema } from './operations';
 
 interface TestCase {
 	schema: string;

--- a/packages/sdk/src/graphql/schema.test.ts
+++ b/packages/sdk/src/graphql/schema.test.ts
@@ -1,0 +1,90 @@
+import { OperationDefinitionNode, parse } from 'graphql/index';
+import { configuration } from './configuration';
+import { assert } from 'chai';
+import { GraphQLIntrospection } from '../definition';
+import { cleanupSchema } from './schema';
+import { buildClientSchema } from 'graphql/utilities/buildClientSchema';
+import { buildSchema } from 'graphql';
+import { operationResponseToJSONSchema, operationVariablesToJSONSchema } from './operations';
+
+interface TestCase {
+	schema: string;
+	introspection: GraphQLIntrospection;
+}
+
+const runTest = (testCase: TestCase, snapshotName: string) => {
+	const schema = buildSchema(testCase.schema);
+	const resultSchema = cleanupSchema(schema, testCase.introspection);
+	expect(resultSchema).toMatchSnapshot();
+};
+
+describe('cleanupSchema', () => {
+	describe('renamed query types', function () {
+		const testCase = {
+			schema: `
+				schema {
+					query: QueryType
+					mutation: MutationType
+					subscription: SubscriptionType
+				}
+				type QueryType {
+					foo: String
+				}
+				type MutationType {
+					foo: String
+				}
+				type SubscriptionType {
+					foo: String
+				}
+				type Foo {
+					queryViewer: QueryType
+					mutationViewer: MutationType
+					subscriptionViewer: SubscriptionType
+				}
+			`,
+			introspection: {
+				url: 'http://dummy',
+			},
+		};
+
+		it('should rename query type', function () {
+			runTest(testCase, 'renamed query type');
+		});
+	});
+
+	describe('custom Int/Float scalars', function () {
+		it('should replace int scalar', function () {
+			const testCase = {
+				schema: `
+					scalar CustomInt
+					type Query {
+						foo: CustomInt
+					}
+				`,
+				introspection: {
+					url: 'http://dummy',
+					customIntScalars: ['CustomInt'],
+				},
+			};
+
+			runTest(testCase, 'custom int scalar');
+		});
+
+		it('should replace float scalar', function () {
+			const testCase = {
+				schema: `
+					scalar CustomFloat
+					type Query {
+						foo: CustomFloat
+					}
+					`,
+				introspection: {
+					url: 'http://dummy',
+					customFloatScalars: ['CustomFloat'],
+				},
+			};
+
+			runTest(testCase, 'custom float scalar');
+		});
+	});
+});

--- a/packages/sdk/src/graphql/schema.ts
+++ b/packages/sdk/src/graphql/schema.ts
@@ -24,28 +24,25 @@ export const cleanupSchema = (schema: GraphQLSchema, introspection: GraphQLIntro
 	const subscriptionTypeName = schema.getSubscriptionType()?.name;
 
 	const replaceOperationTypeName = (name: NameNode): NameNode => {
-		if (name.value === queryTypeName) {
-			return {
-				...name,
-				value: 'Query',
-			};
+		switch (name.value) {
+			case queryTypeName:
+				return {
+					...name,
+					value: 'Query',
+				};
+			case mutationTypeName:
+				return {
+					...name,
+					value: 'Mutation',
+				};
+			case subscriptionTypeName:
+				return {
+					...name,
+					value: 'Subscription',
+				};
+			default:
+				return name;
 		}
-
-		if (name.value === mutationTypeName) {
-			return {
-				...name,
-				value: 'Mutation',
-			};
-		}
-
-		if (name.value === subscriptionTypeName) {
-			return {
-				...name,
-				value: 'Subscription',
-			};
-		}
-
-		return name;
 	};
 
 	const cleanAst = visit(ast, {

--- a/testapps/simple/.wundergraph/operations/Hello.graphql
+++ b/testapps/simple/.wundergraph/operations/Hello.graphql
@@ -1,3 +1,0 @@
-query {
-	gql_hello
-}

--- a/testapps/simple/.wundergraph/wundergraph.server.ts
+++ b/testapps/simple/.wundergraph/wundergraph.server.ts
@@ -1,4 +1,3 @@
-import { GraphQLObjectType, GraphQLSchema, GraphQLString } from 'graphql';
 import { configureWunderGraphServer } from '@wundergraph/sdk/server';
 import type { HooksConfig } from './generated/wundergraph.hooks';
 import type { InternalClient } from './generated/wundergraph.internal.client';
@@ -8,23 +7,4 @@ export default configureWunderGraphServer<HooksConfig, InternalClient>(() => ({
 		queries: {},
 		mutations: {},
 	},
-	graphqlServers: [
-		{
-			serverName: 'gql',
-			apiNamespace: 'gql',
-			schema: new GraphQLSchema({
-				query: new GraphQLObjectType({
-					name: 'RootQueryType',
-					fields: {
-						hello: {
-							type: GraphQLString,
-							resolve() {
-								return 'world';
-							},
-						},
-					},
-				}),
-			}),
-		},
-	],
 }));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `make test`
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)

<!--
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->
