### PR TITLE
fix: crash in ServerPortFromConfig when configuration is invalid

### DIFF
--- a/cli/helpers/process.go
+++ b/cli/helpers/process.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -21,7 +22,7 @@ func ServerPortFromConfig(configJsonPath string) (int, error) {
 	}
 
 	if len(data) == 0 {
-		return 0, fmt.Errorf("config file is empty")
+		return 0, errors.New("config file is empty")
 	}
 
 	var graphConfig struct {
@@ -33,8 +34,13 @@ func ServerPortFromConfig(configJsonPath string) (int, error) {
 		return 0, err
 	}
 
-	newPort := loadvariable.Int(graphConfig.Api.ServerOptions.Listen.Port)
-	return newPort, nil
+	if graphConfig.Api != nil && graphConfig.Api.ServerOptions != nil {
+		variable := graphConfig.Api.ServerOptions.GetListen().GetPort()
+		if variable != nil {
+			return loadvariable.Int(variable), nil
+		}
+	}
+	return 0, errors.New("configuration is invalid")
 }
 
 // KillExistingHooksProcess kills the existing hooks process before we start the new one


### PR DESCRIPTION
Allows us to provide a better error message than crashing without an
explanation

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

<!--
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->
