### PR TITLE
feat: annotate OpenAPI spec with operation types and auth requirements

### DIFF
--- a/packages/sdk/src/openapibuilder/__snapshots__/index.test.ts.snap
+++ b/packages/sdk/src/openapibuilder/__snapshots__/index.test.ts.snap
@@ -70,6 +70,8 @@ exports[`OpenAPI builder OpenAPI Builder 1`] = `
             "description": "Invalid input",
           },
         },
+        "x-wundergraph-operation-type": "query",
+        "x-wundergraph-requires-authentication": false,
       },
     },
     "/GetRootObj2": {
@@ -96,9 +98,11 @@ exports[`OpenAPI builder OpenAPI Builder 1`] = `
             "description": "Invalid input",
           },
         },
+        "x-wundergraph-operation-type": "query",
+        "x-wundergraph-requires-authentication": false,
       },
     },
-    "/item/GetID": {
+    "/users/get": {
       "get": {
         "operationId": "GetUser",
         "parameters": [],
@@ -122,6 +126,76 @@ exports[`OpenAPI builder OpenAPI Builder 1`] = `
             "description": "Invalid input",
           },
         },
+        "x-wundergraph-operation-type": "query",
+        "x-wundergraph-requires-authentication": false,
+      },
+    },
+    "/users/put": {
+      "post": {
+        "operationId": "PutUser",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "definitions": {},
+                "properties": {},
+                "type": "object",
+              },
+            },
+          },
+          "required": true,
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": undefined,
+              },
+            },
+            "description": "Success",
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvalidInputError",
+                },
+              },
+            },
+            "description": "Invalid input",
+          },
+        },
+        "x-wundergraph-operation-type": "mutation",
+        "x-wundergraph-requires-authentication": true,
+      },
+    },
+    "/users/subscribe": {
+      "get": {
+        "operationId": "SubscribeToUser",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": undefined,
+              },
+            },
+            "description": "Success",
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvalidInputError",
+                },
+              },
+            },
+            "description": "Invalid input",
+          },
+        },
+        "x-wundergraph-operation-type": "subscription",
+        "x-wundergraph-requires-authentication": false,
       },
     },
   },

--- a/packages/sdk/src/openapibuilder/__snapshots__/index.test.ts.snap
+++ b/packages/sdk/src/openapibuilder/__snapshots__/index.test.ts.snap
@@ -46,7 +46,7 @@ exports[`OpenAPI builder OpenAPI Builder 1`] = `
   },
   "openapi": "3.1.0",
   "paths": {
-    "/operations/GetRootObj": {
+    "/GetRootObj": {
       "get": {
         "operationId": "GetRootObj",
         "parameters": [],
@@ -72,7 +72,7 @@ exports[`OpenAPI builder OpenAPI Builder 1`] = `
         },
       },
     },
-    "/operations/GetRootObj2": {
+    "/GetRootObj2": {
       "get": {
         "operationId": "GetRootObj2",
         "parameters": [],
@@ -98,7 +98,7 @@ exports[`OpenAPI builder OpenAPI Builder 1`] = `
         },
       },
     },
-    "/operations/item/GetID": {
+    "/item/GetID": {
       "get": {
         "operationId": "GetUser",
         "parameters": [],
@@ -127,7 +127,7 @@ exports[`OpenAPI builder OpenAPI Builder 1`] = `
   },
   "servers": [
     {
-      "url": "http://localhost:9991",
+      "url": "http://localhost:9991/operations",
     },
   ],
 }

--- a/packages/sdk/src/openapibuilder/index.test.ts
+++ b/packages/sdk/src/openapibuilder/index.test.ts
@@ -29,9 +29,34 @@ const operations = [
 	},
 	{
 		Name: 'GetUser',
-		PathName: 'item/GetID',
+		PathName: 'users/get',
 		OperationType: OperationType.QUERY,
 		ExecutionEngine: OperationExecutionEngine.ENGINE_GRAPHQL,
+		VariablesSchema: {
+			type: 'object',
+			properties: {},
+			additionalProperties: false,
+			definitions: {},
+		},
+	},
+	{
+		Name: 'SubscribeToUser',
+		PathName: 'users/subscribe',
+		OperationType: OperationType.SUBSCRIPTION,
+		ExecutionEngine: OperationExecutionEngine.ENGINE_GRAPHQL,
+		VariablesSchema: {
+			type: 'object',
+			properties: {},
+			additionalProperties: false,
+			definitions: {},
+		},
+	},
+	{
+		Name: 'PutUser',
+		PathName: 'users/put',
+		OperationType: OperationType.MUTATION,
+		ExecutionEngine: OperationExecutionEngine.ENGINE_GRAPHQL,
+		AuthenticationConfig: { required: true },
 		VariablesSchema: {
 			type: 'object',
 			properties: {},
@@ -162,6 +187,43 @@ describe('OpenAPI builder', () => {
 		expect(Object.keys(result.paths).length).toBe(1);
 		expect(result.paths['/QueryPath']).toBeDefined();
 		expect(result.paths['/InternalQueryPath']).toBeUndefined();
+	});
+
+	test('annotate operations', async () => {
+		const operations = [
+			{
+				Name: 'Query',
+				PathName: 'QueryPath',
+				OperationType: OperationType.QUERY,
+			},
+			{
+				Name: 'Mutation',
+				PathName: 'MutationPath',
+				OperationType: OperationType.MUTATION,
+				AuthenticationConfig: { required: true },
+			},
+			{
+				Name: 'Subscription',
+				PathName: 'SubscriptionPath',
+				OperationType: OperationType.SUBSCRIPTION,
+			},
+		] as unknown as GraphQLOperation[];
+		const builder = new OpenApiBuilder({
+			title: 'WunderGraph',
+			version: '0',
+			baseURL: 'http://localhost:9991',
+		});
+		const result = builder.build(operations);
+		expect(Object.keys(result.paths).length).toBe(3);
+		const query = result.paths['/QueryPath'].get;
+		expect(query?.['x-wundergraph-operation-type']).toBe('query');
+		expect(query?.['x-wundergraph-requires-authentication']).toBe(false);
+		const mutation = result.paths['/MutationPath'].post;
+		expect(mutation?.['x-wundergraph-operation-type']).toBe('mutation');
+		expect(mutation?.['x-wundergraph-requires-authentication']).toBe(true);
+		const subscription = result.paths['/SubscriptionPath'].get;
+		expect(subscription?.['x-wundergraph-operation-type']).toBe('subscription');
+		expect(subscription?.['x-wundergraph-requires-authentication']).toBe(false);
 	});
 
 	test('OpenAPI Builder', async () => {

--- a/packages/sdk/src/openapibuilder/index.ts
+++ b/packages/sdk/src/openapibuilder/index.ts
@@ -251,6 +251,9 @@ export class OpenApiBuilder {
 		const paths: Record<string, OpenApiPath> = {};
 
 		for (const op of operations) {
+			if (op.Internal) {
+				continue;
+			}
 			let opPath: OpenApiPath | undefined;
 			switch (op.OperationType) {
 				case OperationType.QUERY:
@@ -266,7 +269,7 @@ export class OpenApiBuilder {
 					break;
 			}
 			if (opPath) {
-				paths[`/operations/${op.PathName}`] = opPath;
+				paths[`/${op.PathName}`] = opPath;
 			}
 		}
 
@@ -279,7 +282,7 @@ export class OpenApiBuilder {
 				title: this.config.title ? this.config.title : this.config.baseURL,
 				version: this.config.version,
 			},
-			servers: [{ url: this.config.baseURL }],
+			servers: [{ url: `${this.config.baseURL}/operations` }],
 			paths,
 			components: {
 				schemas: schemas,

--- a/packages/sdk/src/openapibuilder/index.ts
+++ b/packages/sdk/src/openapibuilder/index.ts
@@ -73,11 +73,17 @@ interface OpenApiResponse {
 	content: Record<string, OpenApiMediaType>;
 }
 
+type OperationTypeName = 'query' | 'mutation' | 'subscription';
+
 interface OpenApiOperation {
 	operationId: string;
 	parameters?: OpenApiParameter[];
 	requestBody?: OpenApiRequestBody;
 	responses: Record<string, OpenApiResponse>;
+
+	// WunderGraph extensions
+	'x-wundergraph-operation-type': OperationTypeName;
+	'x-wundergraph-requires-authentication': boolean;
 }
 
 interface OpenApiPath {
@@ -139,6 +145,26 @@ export class OpenApiBuilder {
 		};
 	}
 
+	private commonOperation(op: GraphQLOperation) {
+		let operationType: OperationTypeName;
+		switch (op.OperationType) {
+			case OperationType.QUERY:
+				operationType = 'query';
+				break;
+			case OperationType.MUTATION:
+				operationType = 'mutation';
+				break;
+			case OperationType.SUBSCRIPTION:
+				operationType = 'subscription';
+				break;
+		}
+		return {
+			operationId: op.Name,
+			'x-wundergraph-operation-type': operationType,
+			'x-wundergraph-requires-authentication': op?.AuthenticationConfig?.required ?? false,
+		};
+	}
+
 	private queryOperation(op: GraphQLOperation): OpenApiOperation {
 		const parameters: OpenApiParameter[] = [];
 		const paths: JSONSchemaParameterPath[] = [];
@@ -157,7 +183,7 @@ export class OpenApiBuilder {
 		}
 
 		return {
-			operationId: op.Name,
+			...this.commonOperation(op),
 			parameters: parameters,
 			responses: this.operationResponses(op),
 		};
@@ -165,7 +191,7 @@ export class OpenApiBuilder {
 
 	private mutationOperation(op: GraphQLOperation): OpenApiOperation {
 		return {
-			operationId: op.Name,
+			...this.commonOperation(op),
 			requestBody: {
 				content: {
 					'application/json': {

--- a/packages/sdk/src/openapibuilder/operations.ts
+++ b/packages/sdk/src/openapibuilder/operations.ts
@@ -14,7 +14,7 @@ export function buildPath(
 	obj: JSONSchema7Definition,
 	paths: JSONSchemaParameterPath[]
 ) {
-	if (typeof obj === 'boolean') return;
+	if (typeof obj === 'boolean' || typeof obj === 'undefined') return;
 
 	// those nodes are limited due to recursion
 	if (!obj.type) return;


### PR DESCRIPTION
- fix: skip internal operations during OAS generation
- feat: annotate OAS operations with type and authentication requirements

