### PR TITLE
fix: fixing multidimensional array schema in codegen (#731)Co-authored-by: abdelhameedalsayed <abdulhameed.azab@gmail.com>

### DIFF
--- a/packages/sdk/src/codegen/templates/typescript/index.ts
+++ b/packages/sdk/src/codegen/templates/typescript/index.ts
@@ -285,10 +285,11 @@ const JSONSchemaToTypescriptInterface = (
 		},
 		array: {
 			enter: (name, isRequired, isArray) => {
+				if (name === '') return;
 				out += `${name + (isRequired ? '' : '?')}: `;
 			},
 			leave: (name, isRequired, isArray) => {
-				out += '[],';
+				out += name === '' ? '[]' : '[],';
 			},
 		},
 		string: (name, isRequired, isArray, enumValues) => {

--- a/testapps/openapi/geojson/.gitignore
+++ b/testapps/openapi/geojson/.gitignore
@@ -1,0 +1,44 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+.vscode
+.idea
+
+# jest compilation
+test/*.js
+
+# WunderGraph build output
+.wundergraph/cache
+.wundergraph/generated
+
+# dependencies
+node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# vercel
+.vercel

--- a/testapps/openapi/geojson/.graphqlrc.yaml
+++ b/testapps/openapi/geojson/.graphqlrc.yaml
@@ -1,0 +1,12 @@
+# This file provides autocompletion in .graphql files
+# Some IDEs, like VS code require this file to be at the
+# root of your workspace. If you move it around, make sure
+# to update schema and documents with the new paths.
+schema: '.wundergraph/generated/wundergraph.schema.graphql'
+documents: '.wundergraph/operations/**/*.graphql'
+extensions:
+  endpoint:
+    introspect: false
+    url: 'http://localhost:9991/graphql'
+    headers:
+      user-agent: 'WunderGraph Client'

--- a/testapps/openapi/geojson/.wundergraph/geojson.yaml
+++ b/testapps/openapi/geojson/.wundergraph/geojson.yaml
@@ -1,0 +1,77 @@
+---
+openapi: 3.0.1
+info:
+  title: defaultTitle
+  description: defaultDescription
+  version: '0.1'
+servers:
+  - url: https://sampleserver6.arcgisonline.com
+paths:
+  /arcgis/rest/services/WorldTimeZones/MapServer/2/query:
+    get:
+      description: Auto generated using Swagger Inspector
+      parameters:
+        - name: f
+          in: query
+          schema:
+            type: string
+          example: geojson
+        - name: where
+          in: query
+          schema:
+            type: string
+          example: OBJECTID
+      responses:
+        200:
+          description: Auto generated using Swagger Inspector
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  type:
+                    type: string
+                  features:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        type:
+                          type: string
+                        geometry:
+                          type: object
+                          properties:
+                            type:
+                              type: string
+                            coordinates:
+                              type: array
+                              items:
+                                type: array
+                                items:
+                                  type: array
+                                  items:
+                                    type: array
+                                    items:
+                                      type: number
+                          required:
+                            - type
+                            - coordinates
+                        properties:
+                          type: object
+                          properties:
+                            REGION:
+                              type: string
+                          required:
+                            - REGION
+                      required:
+                        - type
+                        - geometry
+                        - properties
+                required:
+                  - type
+                  - features
+      servers:
+        - url: https://sampleserver6.arcgisonline.com
+    servers:
+      - url: https://sampleserver6.arcgisonline.com
+components: {}

--- a/testapps/openapi/geojson/.wundergraph/operations/Location.graphql
+++ b/testapps/openapi/geojson/.wundergraph/operations/Location.graphql
@@ -1,0 +1,14 @@
+query {
+	geojson: geojson_getArcgisRestServicesWorldTimeZonesMapServer2Query(f: "geojson", where: "OBJECTID=3") {
+		type
+		features {
+			type
+			geometry {
+				coordinates
+			}
+			properties {
+				REGION
+			}
+		}
+	}
+}

--- a/testapps/openapi/geojson/.wundergraph/wundergraph.config.ts
+++ b/testapps/openapi/geojson/.wundergraph/wundergraph.config.ts
@@ -1,0 +1,39 @@
+import { configureWunderGraphApplication, cors, EnvironmentVariable, introspect, templates } from '@wundergraph/sdk';
+import server from './wundergraph.server';
+import operations from './wundergraph.operations';
+
+const geojson = introspect.openApi({
+	apiNamespace: 'geojson',
+	source: {
+		kind: 'file',
+		filePath: './geojson.yaml',
+	},
+});
+
+// configureWunderGraph emits the configuration
+configureWunderGraphApplication({
+	apis: [geojson],
+	server,
+	operations,
+	codeGenerators: [
+		{
+			templates: [
+				// use all the typescript react templates to generate a client
+				...templates.typescript.all,
+			],
+		},
+	],
+	cors: {
+		...cors.allowAll,
+		allowedOrigins:
+			process.env.NODE_ENV === 'production'
+				? [
+						// change this before deploying to production to the actual domain where you're deploying your app
+						'http://localhost:3000',
+				  ]
+				: ['http://localhost:3000', new EnvironmentVariable('WG_ALLOWED_ORIGIN')],
+	},
+	security: {
+		enableGraphQLEndpoint: process.env.NODE_ENV !== 'production' || process.env.GITPOD_WORKSPACE_ID !== undefined,
+	},
+});

--- a/testapps/openapi/geojson/.wundergraph/wundergraph.operations.ts
+++ b/testapps/openapi/geojson/.wundergraph/wundergraph.operations.ts
@@ -1,0 +1,32 @@
+import { configureWunderGraphOperations } from '@wundergraph/sdk';
+import type { OperationsConfiguration } from './generated/wundergraph.operations';
+
+export default configureWunderGraphOperations<OperationsConfiguration>({
+	operations: {
+		defaultConfig: {
+			authentication: {
+				required: false,
+			},
+		},
+		queries: (config) => ({
+			...config,
+			caching: {
+				enable: false,
+				staleWhileRevalidate: 60,
+				maxAge: 60,
+				public: true,
+			},
+			liveQuery: {
+				enable: true,
+				pollingIntervalSeconds: 1,
+			},
+		}),
+		mutations: (config) => ({
+			...config,
+		}),
+		subscriptions: (config) => ({
+			...config,
+		}),
+		custom: {},
+	},
+});

--- a/testapps/openapi/geojson/.wundergraph/wundergraph.server.ts
+++ b/testapps/openapi/geojson/.wundergraph/wundergraph.server.ts
@@ -1,0 +1,11 @@
+import { GraphQLObjectType, GraphQLSchema, GraphQLString } from 'graphql';
+import { configureWunderGraphServer } from '@wundergraph/sdk/server';
+import type { HooksConfig } from './generated/wundergraph.hooks';
+import type { InternalClient } from './generated/wundergraph.internal.client';
+
+export default configureWunderGraphServer<HooksConfig, InternalClient>(() => ({
+	hooks: {
+		queries: {},
+		mutations: {},
+	},
+}));

--- a/testapps/openapi/geojson/README.md
+++ b/testapps/openapi/geojson/README.md
@@ -1,0 +1,13 @@
+# WunderGraph simple example
+
+#### Getting started
+
+```shell
+npm install && npm start
+```
+
+#### Get all Locations
+
+```shell
+curl http://localhost:9991/operations/Location
+```

--- a/testapps/openapi/geojson/jest.config.js
+++ b/testapps/openapi/geojson/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+	roots: ['<rootDir>/test/'],
+	transform: {
+		'^.+\\.tsx?$': 'ts-jest',
+	},
+	testRegex: '(/__tests__/.*|\\.(test|spec))\\.[tj]sx?$',
+	testTimeout: 100 * 1000,
+	moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+};

--- a/testapps/openapi/geojson/package.json
+++ b/testapps/openapi/geojson/package.json
@@ -1,0 +1,41 @@
+{
+  "private": true,
+  "name": "@test/openapi",
+  "version": "0.0.1",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/wundergraph/wundergraph.git"
+  },
+  "homepage": "https://wundergraph.com",
+  "author": {
+    "name": "WunderGraph Maintainers",
+    "email": "info@wundergraph.com"
+  },
+  "bugs": {
+    "url": "https://github.com/wundergraph/wundergraph/issues"
+  },
+  "scripts": {
+    "dev": "wunderctl up --debug",
+    "build": "pnpm generate && pnpm check",
+    "start": "wunderctl start --debug",
+    "generate": "wunderctl generate --debug",
+    "check": "tsc",
+    "test": "pnpm generate && jest"
+  },
+  "dependencies": {
+    "@types/node-fetch": "2.6.2",
+    "@wundergraph/sdk": "workspace:*",
+    "graphql": "^16.3.0",
+    "node-fetch": "2.6.7",
+    "typescript": "^4.8.2"
+  },
+  "sideEffects": false,
+  "devDependencies": {
+    "@jest/globals": "^29.3.1",
+    "@types/node": "^18.11.18",
+    "jest": "^29.3.1",
+    "jose": "^4.11.1",
+    "ts-jest": "^29.0.5",
+    "ts-node": "^10.9.1"
+  }
+}

--- a/testapps/openapi/geojson/test/index.test.ts
+++ b/testapps/openapi/geojson/test/index.test.ts
@@ -1,0 +1,17 @@
+import { afterAll, beforeAll, describe, expect, test } from '@jest/globals';
+import fetch from 'node-fetch';
+import { createTestServer } from '../.wundergraph/generated/testing';
+
+const wg = createTestServer({ fetch: fetch as any });
+beforeAll(() => wg.start());
+afterAll(() => wg.stop());
+
+describe('test Countries API', () => {
+	test('geojson', async () => {
+		const result = await wg.client().query({
+			operationName: 'Location',
+		});
+		const pointCoordArrLength = result.data?.geojson?.features[0].geometry.coordinates[0][0][0].length;
+		expect(pointCoordArrLength).toBe(2);
+	});
+});

--- a/testapps/openapi/geojson/tsconfig.json
+++ b/testapps/openapi/geojson/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "commonjs",
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": [".wundergraph/**/*.ts"]
+}


### PR DESCRIPTION
when trying to introspect an openapi datasource, 
with multi-dim array of numbers 

getting the following error:

```2023-03-07T00:26:14+02:00 FATAL: Couldn't configure your WunderNode: SyntaxError: Type expected. (6:14)
  4 | features: {
  5 | geometry: {
> 6 | coordinates: : : : number[],[],[],[],},
    |              ^
  7 | }[],},
  8 | }
```

Error: 
```
coordinates: : : : number[],[],[],[]
```
expected to be 
```
coordinates: number[][][][]
```
a repo to reproduce error:
https://github.com/abdelhameedhamdy/geojson-api

a small fix added should fix the issue.

re-run introspection, error disappeared, schema generated as expected
coordinates: [[[[Int]]]]



