### PR TITLE
fix: make TS operation response schema generation more forgiving

### DIFF
--- a/packages/sdk/src/configure/index.ts
+++ b/packages/sdk/src/configure/index.ts
@@ -1284,7 +1284,7 @@ const typeScriptOperationsResponseSchemas = async (wgDirAbs: string, operations:
 	const cacheKey = `ts.operationTypes.${objectHash([contents, operationHashes])}`;
 	const cachedData = await cache.getJSON(cacheKey);
 	if (cachedData) {
-		return cachedData;
+		return cachedData as Record<string, JSONSchema>;
 	}
 
 	const basePath = path.join(wgDirAbs, 'generated');
@@ -1294,6 +1294,7 @@ const typeScriptOperationsResponseSchemas = async (wgDirAbs: string, operations:
 
 	const settings = {
 		required: true,
+		ignoreErrors: true,
 	};
 
 	// XXX: There's no way to silence warnings from TJS, override console.warn
@@ -1303,7 +1304,7 @@ const typeScriptOperationsResponseSchemas = async (wgDirAbs: string, operations:
 	const tsConfigPath = await findUp('tsconfig.json', wgDirAbs);
 	let generator: JsonSchemaGenerator | null = null;
 	if (tsConfigPath) {
-		const tsConfigProgram = programFromConfig(tsConfigPath);
+		const tsConfigProgram = programFromConfig(tsConfigPath, [programPath]);
 		if (tsConfigProgram) {
 			generator = buildGenerator(tsConfigProgram, settings);
 		}
@@ -1343,7 +1344,7 @@ const updateTypeScriptOperationsResponseSchemas = async (wgDirAbs: string, opera
 	for (const op of operations) {
 		const schema = schemas[op.Name];
 		if (schema) {
-			op.ResponseSchema = schemas[schema];
+			op.ResponseSchema = schema;
 		} else {
 			// For functions that don't return anything, we return an empty JSON object
 			op.ResponseSchema = {

--- a/testapps/default/test/index.test.ts
+++ b/testapps/default/test/index.test.ts
@@ -1,6 +1,10 @@
+import fs from 'fs/promises';
+import path from 'path';
+
 import { afterAll, beforeAll, describe, expect, test } from '@jest/globals';
 import { InputValidationError } from '@wundergraph/sdk/client';
 import { createTestServer } from '../.wundergraph/generated/testing';
+import users from '../.wundergraph/operations/nested/users';
 
 const wg = createTestServer();
 
@@ -175,5 +179,20 @@ describe('@transform directive', () => {
 		expect(country).toBeDefined();
 		expect(country?.capital).toBe('Madrid');
 		expect(country?.weather.temperature?.max).toBeDefined();
+	});
+});
+
+describe('OpenAPI generation', () => {
+	test('OpenAPI includes TypeScript operation response schema', async () => {
+		const filePath = path.join(__dirname, '..', '.wundergraph', 'generated', 'wundergraph.openapi.json');
+		const data = await fs.readFile(filePath, { encoding: 'utf-8' });
+		const spec = JSON.parse(data);
+		const usersGet = spec.paths?.['/users/get'];
+		expect(usersGet).toBeDefined();
+		const response = usersGet?.['get']?.['responses']?.['200'];
+		expect(response).toBeDefined();
+		const responseSchema = response['content']?.['application/json']?.['schema'];
+		expect(responseSchema).toBeDefined();
+		expect(responseSchema['properties']?.['hello']?.['type']).toBe('string');
 	});
 });


### PR DESCRIPTION
- Load only the .ts file with the response types instead of the whole
program
- Ignore non-fatal errors during schema generation
- Correctly set the schema in updateTypeScriptOperationsResponseSchemas()
before passing it to the OpenAPI builder (broken in #762)

