### PR TITLE
fix: multiple fixes in authentication hooks

### DIFF
--- a/pkg/authentication/authentication.go
+++ b/pkg/authentication/authentication.go
@@ -132,10 +132,18 @@ func (u *UserLoader) userFromToken(token *jwt.Token, cfg *UserLoadConfig, user *
 	tempUser.ProviderName = "token"
 	tempUser.ProviderID = issuer
 	tempUser.AccessToken = tryParseJWT(token.Raw)
-	u.hooks.PostAuthentication(ctx, tempUser)
+	if err := u.hooks.PostAuthentication(ctx, tempUser); err != nil {
+		return err
+	}
 	tempUser, err := u.hooks.MutatingPostAuthentication(ctx, tempUser)
 	if err != nil {
-		return fmt.Errorf("access denied: %w", err)
+		return err
+	}
+	if revalidate {
+		tempUser, err = u.hooks.RevalidateAuthentication(ctx, tempUser)
+		if err != nil {
+			return err
+		}
 	}
 	*user = *tempUser
 	if cfg.cacheTtlSeconds > 0 {
@@ -316,7 +324,7 @@ func (u *User) Load(loader *UserLoader, r *http.Request) error {
 			return fmt.Errorf("invalid authorization Header")
 		}
 		tokenString := strings.TrimPrefix(authorizationHeader, "Bearer ")
-		revalidate := r.URL.Query().Get("revalidate") == "true"
+		revalidate := r.URL.Query().Has("revalidate")
 		for _, config := range loader.userLoadConfigs {
 			keyFunc := config.Keyfunc()
 			token, err := jwt.Parse(tokenString, keyFunc)

--- a/testapps/auth/.wundergraph/wundergraph.config.ts
+++ b/testapps/auth/.wundergraph/wundergraph.config.ts
@@ -44,7 +44,7 @@ configureWunderGraphApplication({
 				jsonPath: 'currency',
 			},
 		},
-		publicClaims: ['SUBJECT', 'shopID'],
+		publicClaims: ['SUBJECT', 'GIVEN_NAME', 'FAMILY_NAME', 'shopID'],
 	},
 	codeGenerators: [
 		{


### PR DESCRIPTION
- Don't ignore error on postAuthentication with tokens
- Fix revalidation from Client when using token based authentication
- Call revalidation hook appropriately
- Unify error messages returned to callers from hooks that can deny auth
- Add tests for authentication hooks

