### PR TITLE
chore: delete example .env files for setting up dummy secrets

### DIFF
--- a/examples/apollo-federation/.env.example
+++ b/examples/apollo-federation/.env.example
@@ -1,3 +1,0 @@
-WG_SECURE_COOKIE_HASH_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-WG_SECURE_COOKIE_BLOCK_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-WG_CSRF_TOKEN_SECRET=aaaaaaaaaaa

--- a/examples/apollo-federation/README.md
+++ b/examples/apollo-federation/README.md
@@ -6,8 +6,7 @@ WunderGraph can introspect your federated SubGraphs, composes a SuperGraph for y
 
 ## Getting Started
 
-1. Copy the `.env.example` file to `.env` and fill in the required values.
-2. Install the dependencies and run the complete example in one command:
+1. Install the dependencies and run the complete example in one command:
 
 ```shell
 npm install && npm start

--- a/examples/caching/.env.example
+++ b/examples/caching/.env.example
@@ -1,3 +1,0 @@
-WG_SECURE_COOKIE_HASH_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-WG_SECURE_COOKIE_BLOCK_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-WG_CSRF_TOKEN_SECRET=aaaaaaaaaaa

--- a/examples/caching/README.md
+++ b/examples/caching/README.md
@@ -8,8 +8,7 @@ On subsequent requests, the client will automatically attach the ETag to the req
 
 ## Getting Started
 
-1. Copy the `.env.example` file to `.env` and fill in the required values.
-2. Install the dependencies and run the complete example in one command:
+1. Install the dependencies and run the complete example in one command:
 
 ```shell
 npm install && npm start

--- a/examples/hooks/.env.example
+++ b/examples/hooks/.env.example
@@ -1,3 +1,0 @@
-WG_SECURE_COOKIE_HASH_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-WG_SECURE_COOKIE_BLOCK_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-WG_CSRF_TOKEN_SECRET=aaaaaaaaaaa

--- a/examples/hooks/README.md
+++ b/examples/hooks/README.md
@@ -4,8 +4,7 @@ This example demonstrates how to use the `mutatingPostResolve` hook to change th
 
 ## Getting Started
 
-1. Copy the `.env.example` file to `.env` and fill in the required values.
-2. Install the dependencies and run the complete example in one command:
+1. Install the dependencies and run the complete example in one command:
 
 ```shell
 npm install && npm start

--- a/examples/learn-wundergraph/.env.example
+++ b/examples/learn-wundergraph/.env.example
@@ -1,3 +1,0 @@
-WG_SECURE_COOKIE_HASH_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-WG_SECURE_COOKIE_BLOCK_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-WG_CSRF_TOKEN_SECRET=aaaaaaaaaaa

--- a/examples/learn-wundergraph/README.md
+++ b/examples/learn-wundergraph/README.md
@@ -4,8 +4,7 @@ This example demonstrates how to use WunderGraph with Next.js. We are going to m
 
 ## Getting Started
 
-1. Copy the `.env.example` file to `.env` and fill in the required values.
-2. Install the dependencies and run the complete example in one command:
+1. Install the dependencies and run the complete example in one command:
 
 ```shell
 npm install && npm start

--- a/examples/nextjs-postgres-prisma/.env.example
+++ b/examples/nextjs-postgres-prisma/.env.example
@@ -1,3 +1,0 @@
-WG_SECURE_COOKIE_HASH_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-WG_SECURE_COOKIE_BLOCK_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-WG_CSRF_TOKEN_SECRET=aaaaaaaaaaa

--- a/examples/nextjs-postgres-prisma/README.md
+++ b/examples/nextjs-postgres-prisma/README.md
@@ -8,8 +8,7 @@ WunderGraph supports GraphQL Subscriptions and Live Queries (via server-side pol
 
 ## Getting Started
 
-1. Copy the `.env.example` file to `.env` and fill in the required values.
-2. Install the dependencies and run the complete example in one command:
+1. Install the dependencies and run the complete example in one command:
 
 ```shell
 npm install && npm start

--- a/examples/nextjs-postgres-user-filters/.env.example
+++ b/examples/nextjs-postgres-user-filters/.env.example
@@ -1,3 +1,0 @@
-WG_SECURE_COOKIE_HASH_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-WG_SECURE_COOKIE_BLOCK_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-WG_CSRF_TOKEN_SECRET=aaaaaaaaaaa

--- a/examples/nextjs-postgres-user-filters/README.md
+++ b/examples/nextjs-postgres-user-filters/README.md
@@ -17,8 +17,7 @@ so you can easily stream updates to the client.
 
 ## Getting Started
 
-1. Copy the `.env.example` file to `.env` and fill in the required values.
-2. Install the dependencies and run the complete example in one command:
+1. Install the dependencies and run the complete example in one command:
 
 ```shell
 npm install && npm start

--- a/examples/nextjs-react-query/.env.example
+++ b/examples/nextjs-react-query/.env.example
@@ -1,3 +1,0 @@
-WG_SECURE_COOKIE_HASH_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-WG_SECURE_COOKIE_BLOCK_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-WG_CSRF_TOKEN_SECRET=aaaaaaaaaaa

--- a/examples/nextjs-react-query/README.md
+++ b/examples/nextjs-react-query/README.md
@@ -4,8 +4,7 @@ This example demonstrates how to use WunderGraph with Next.js and React Query. W
 
 ## Getting Started
 
-1. Copy the `.env.example` file to `.env` and fill in the required values.
-2. Install the dependencies and run the complete example in one command:
+1. Install the dependencies and run the complete example in one command:
 
 ```shell
 npm install && npm start

--- a/examples/nextjs-typescript-functions/.env.example
+++ b/examples/nextjs-typescript-functions/.env.example
@@ -1,3 +1,0 @@
-WG_SECURE_COOKIE_HASH_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-WG_SECURE_COOKIE_BLOCK_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-WG_CSRF_TOKEN_SECRET=aaaaaaaaaaa

--- a/examples/nextjs-typescript-functions/README.md
+++ b/examples/nextjs-typescript-functions/README.md
@@ -4,8 +4,7 @@ This example demonstrates how to use WunderGraph with Next.js. We are going to m
 
 ## Getting Started
 
-1. Copy the `.env.example` file to `.env` and fill in the required values.
-2. Install the dependencies and run the complete example in one command:
+1. Install the dependencies and run the complete example in one command:
 
 ```shell
 npm install && npm start

--- a/examples/nextjs/.env.example
+++ b/examples/nextjs/.env.example
@@ -1,3 +1,0 @@
-WG_SECURE_COOKIE_HASH_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-WG_SECURE_COOKIE_BLOCK_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-WG_CSRF_TOKEN_SECRET=aaaaaaaaaaa

--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -4,8 +4,7 @@ This example demonstrates how to use WunderGraph with Next.js. We are going to m
 
 ## Getting Started
 
-1. Copy the `.env.example` file to `.env` and fill in the required values.
-2. Install the dependencies and run the complete example in one command:
+1. Install the dependencies and run the complete example in one command:
 
 ```shell
 npm install && npm start

--- a/examples/vite-swr/.env.example
+++ b/examples/vite-swr/.env.example
@@ -1,3 +1,0 @@
-WG_SECURE_COOKIE_HASH_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-WG_SECURE_COOKIE_BLOCK_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-WG_CSRF_TOKEN_SECRET=aaaaaaaaaaa

--- a/examples/vite-swr/README.md
+++ b/examples/vite-swr/README.md
@@ -8,8 +8,7 @@ SWR is a React library for data fetching. With just one hook, you can significan
 
 ## Getting Started
 
-1. Copy the `.env.example` file to `.env` and fill in the required values.
-2. Install the dependencies and run the complete example in one command:
+1. Install the dependencies and run the complete example in one command:
 
 ```shell
 npm install && npm start

--- a/examples/webhooks/.env.example
+++ b/examples/webhooks/.env.example
@@ -1,3 +1,0 @@
-WG_SECURE_COOKIE_HASH_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-WG_SECURE_COOKIE_BLOCK_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-WG_CSRF_TOKEN_SECRET=aaaaaaaaaaa


### PR DESCRIPTION
Dummy secrets are now set by default in development mode

