### PR TITLE
feat: add auth middleware hook to nextjs client

### DIFF
--- a/packages/nextjs/src/auth-middleware.ts
+++ b/packages/nextjs/src/auth-middleware.ts
@@ -1,0 +1,37 @@
+import { BareFetcher, Middleware, SWRHook } from 'swr';
+import { useWunderGraphContext } from './context';
+
+type MiddlewareReturn = ReturnType<Middleware>;
+
+export type AuthMiddleware = (
+	useSWRNext: SWRHook,
+	/**
+	 * A function that returns an authentication token.
+	 * Returning null will unset the token header.
+	 */
+	getToken: () => Promise<string | null | undefined>
+) => MiddlewareReturn;
+
+export const useAuthMiddleware: AuthMiddleware = (useSWRNext, getToken) => {
+	return (key, fetcher, config) => {
+		const context = useWunderGraphContext();
+
+		const fetcherWithAuth: BareFetcher<Promise<unknown>> = async (...args) => {
+			try {
+				const token = await getToken();
+				if (token) {
+					context?.client.setAuthorizationToken(token);
+				} else if (token === null) {
+					context?.client.unsetAuthorization();
+				}
+			} catch (e: any) {
+				console.error(e);
+				context?.client.unsetAuthorization();
+			}
+
+			return fetcher?.(...args);
+		};
+
+		return useSWRNext(key, fetcherWithAuth, config);
+	};
+};

--- a/packages/nextjs/src/auth-middleware.ts
+++ b/packages/nextjs/src/auth-middleware.ts
@@ -7,7 +7,7 @@ export type AuthMiddleware = (
 	useSWRNext: SWRHook,
 	/**
 	 * A function that returns an authentication token.
-	 * Returning null will unset the token header.
+	 * Returning null will unset the authorization header.
 	 */
 	getToken: () => Promise<string | null | undefined>
 ) => MiddlewareReturn;
@@ -25,8 +25,8 @@ export const useAuthMiddleware: AuthMiddleware = (useSWRNext, getToken) => {
 					context?.client.unsetAuthorization();
 				}
 			} catch (e: any) {
-				console.error(e);
 				context?.client.unsetAuthorization();
+				throw e;
 			}
 
 			return fetcher?.(...args);

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -5,3 +5,7 @@ export type { WithWunderGraphOptions, SSRCache } from './types';
 export { createHooks } from '@wundergraph/swr';
 
 export { createWunderGraphNext } from './create-wundergraph';
+
+export { useWunderGraphContext } from './context';
+
+export { useAuthMiddleware, type AuthMiddleware } from './auth-middleware';

--- a/packages/nextjs/src/types.ts
+++ b/packages/nextjs/src/types.ts
@@ -1,4 +1,5 @@
 import { Client, User } from '@wundergraph/sdk/client';
+import { Middleware } from 'swr';
 
 export type SSRCache = Record<string, any>;
 
@@ -50,4 +51,8 @@ export interface WithWunderGraphOptions {
 	 * Custom WunderGraph cache context.
 	 */
 	context?: React.Context<WunderGraphContextValue | null>;
+	/**
+	 * Custom SWR middleware.
+	 */
+	use?: Middleware[];
 }

--- a/packages/nextjs/src/with-wundergraph.tsx
+++ b/packages/nextjs/src/with-wundergraph.tsx
@@ -26,6 +26,7 @@ export const withWunderGraph = (options: WithWunderGraphOptions) => {
 			fetchUserSSR,
 			logPrerenderTime,
 			logFetchErrors,
+			use = [],
 		} = _options;
 
 		const WithWunderGraph = (props: AppPropsType<NextRouter, any> & { ssrCache: SSRCache; user: User }) => {
@@ -33,7 +34,7 @@ export const withWunderGraph = (options: WithWunderGraphOptions) => {
 			const providerProps = { context, ssrCache, ssr, client, user };
 			return (
 				<WunderGraphProvider {...providerProps}>
-					<SWRConfig value={{ fallback: ssrCache, use: [SSRMiddleWare] }}>
+					<SWRConfig value={{ fallback: ssrCache, use: [SSRMiddleWare, ...use] }}>
 						<AppOrPage {...props} />
 					</SWRConfig>
 				</WunderGraphProvider>


### PR DESCRIPTION
This PR adds improvements to the Next.js client.

- Exported useWunderGraphContext from package.
- New useAuthMiddleware helper hook, that allows you to inject tokens into the client.
- withWunderGraph now supports SWR middleware