### PR TITLE
feat: add createPrefetchQuery @wundergraph/svelte-query

### DIFF
--- a/packages/svelte-query/src/lib/types.ts
+++ b/packages/svelte-query/src/lib/types.ts
@@ -15,6 +15,7 @@ import type {
 	CreateMutationOptions as TanstackCreateMutationOptions,
 	CreateMutationResult,
 	QueryObserverResult,
+	QueryFunction,
 } from '@tanstack/svelte-query';
 import type { Writable, Readable } from 'svelte/store';
 
@@ -89,6 +90,20 @@ export type CreateQuery<Operations extends OperationsDefinition, ExtraOptions ex
 			isLoading: boolean;
 			isSubscribed: boolean;
 		}>;
+	};
+};
+
+export type CreatePrefetchQuery<Operations extends OperationsDefinition, ExtraOptions extends object = {}> = {
+	<
+		OperationName extends Extract<keyof Operations['queries'], string>,
+		Input extends Operations['queries'][OperationName]['input'] = Operations['queries'][OperationName]['input'],
+		Response extends Operations['queries'][OperationName]['response'] = Operations['queries'][OperationName]['response'],
+		LiveQuery extends Operations['queries'][OperationName]['liveQuery'] = Operations['queries'][OperationName]['liveQuery']
+	>(
+		options: CreateQueryOptions<Response['data'], Response['error'], Input, OperationName, LiveQuery> & ExtraOptions
+	): {
+		queryKey: (OperationName | Input | undefined)[];
+		queryFn: QueryFunction<Response['data'], (OperationName | Input | undefined)[]>;
 	};
 };
 


### PR DESCRIPTION
## Motivation and Context

`svelte-query` supports 2 ways of prefetching data during SSR.  `initialData` or `prefetchQuery`. 
 (https://tanstack.com/query/v4/docs/svelte/ssr)
 
For the `prefetchQuery`  to work we need to import the generated TS client, import the `@wundergraph/svelte-query` `queryKey` function. Call the `queryKey` from the `@wundergraph/svelte-query` and the fetch function from the TS client.

```ts
//+page.ts
import { createClient } from '$lib/generated/client'
import { createSvelteClient } from '@wundergraph/svelte-query'
import type { PageLoad } from './$types'

export const load: PageLoad = async ({ parent, fetch }) => {
  const { queryClient } = await parent()
  
  const client = createClient({
    customFetch: fetch
  })
  const {queryKey} = createSvelteClient(client)

  await queryClient.prefetchQuery({
    queryKey: queryKey({
        operationName: 'user/Me'
    }),
    queryFn: () => client.query({
        operationName: 'user/Me'
    }) as any
  })
}
``` 

this PR makes this process a bit more intuitive adding a `createPrefetchQuery` function to the `@wundergraph/svelte-query`

```ts
//+page.ts
import { createWGClient } from '$lib/svelte-query'
import type { PageLoad } from './$types'

export const load: PageLoad = async ({ parent, fetch }) => {
  const { queryClient } = await parent()
  
  const {createPrefetchQuery} = createWGClient(fetch)  

  await queryClient.prefetchQuery(createPrefetchQuery({
    operationName: "user/Me"
  }))
}
```



<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

## Marketing Changelog

<!--
What changes does this PR introduce? Please describe the changes in simple terms that a user can understand
without being familiar with the codebase. Mention @advocates for review and tracking.
-->

#### Checklist

- [ ] run `make test`
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)
