### PR TITLE
chore: add cloud error docs

### DIFF
--- a/docs-website/config/navigation.tsx
+++ b/docs-website/config/navigation.tsx
@@ -1,23 +1,22 @@
 import {
-	HomeIcon,
+	AcademicCapIcon,
+	ArrowUpCircleIcon,
 	BoltIcon,
-	CircleStackIcon,
-	LockClosedIcon,
-	ShareIcon,
-	ServerIcon,
 	BookOpenIcon,
-	CubeIcon,
+	CircleStackIcon,
 	CloudIcon,
-	ComputerDesktopIcon,
 	CogIcon,
 	CommandLineIcon,
-	QuestionMarkCircleIcon,
-	WrenchIcon,
-	ArrowUpCircleIcon,
+	ComputerDesktopIcon,
+	CubeIcon,
+	HomeIcon,
 	LightBulbIcon,
 	ListBulletIcon,
-	CloudArrowUpIcon,
-	AcademicCapIcon,
+	LockClosedIcon,
+	QuestionMarkCircleIcon,
+	ServerIcon,
+	ShareIcon,
+	WrenchIcon,
 } from '@heroicons/react/24/solid';
 
 const navigation = [
@@ -857,6 +856,10 @@ const navigation = [
 			{
 				title: 'Workspace Configuration (wg.toml)',
 				href: '/docs/cloud/configuration',
+			},
+			{
+				title: 'Errors',
+				href: '/docs/cloud/errors',
 			},
 			{
 				title: 'Deployments',

--- a/docs-website/src/pages/docs/cloud/errors.md
+++ b/docs-website/src/pages/docs/cloud/errors.md
@@ -1,0 +1,35 @@
+---
+title: 'Cloud Errors'
+pageTitle: WunderGraph - Cloud Errors
+description: Common errors and how to rectify them
+---
+
+This page contains a list of WunderGraph Cloud error codes, what they mean, and how to fix them.
+In the case that your problem persists, we would be happy to assist you [on Discord](https://wundergraph.com/discord).
+
+## CONFIG_NOT_FOUND
+
+**Meaning**: No `wundergraph.config.ts` file was found in your project.  
+**Why?**: Only WunderGraph applications can be deployed to WunderGraph Cloud.  
+**Fix**: [Learn how to create a WunderGraph app (with common framework integrations)](docs/getting-started)
+
+## PACKAGE_JSON_NOT_FOUND
+
+**Meaning**: No `package.json` file was found in your project.  
+**Why?**: The `package.json` stores necessary version information for your dependencies including WunderGraph.  
+**Fix**: Make sure the `package.json` for your WunderGraph application was committed to your repository.
+
+## PACKAGE_MANAGER_UNKNOWN
+
+**Meaning**: No package manager was detected in your project, or your chosen package manager is currently unsupported.  
+**Why?**: WunderGraph currently supports [npm](https://docs.npmjs.com/about-npm),
+[yarn](https://yarnpkg.com/getting-started), or [pnpm](https://pnpm.io/installation).
+If you think we're missing support for a popular manager, please [contact us](https://wundergraph.com/discord).
+**Fix**: Make sure you're using one of the following package managers: `npm`, `yarn`, or `pnpm`,
+and that the relevant package manager files have been committed to the repository.
+
+## ROOT_NOT_FOUND
+
+**Meaning**: No WunderGraph project root was found in your project.  
+**Why?**: The root for your WunderGraph project (path to the `package.json`) was not found.  
+**Fix**: If you receive this error, please [contact us](https://wundergraph.com/discord).


### PR DESCRIPTION
## Motivation and Context

Documentation for Cloud build errors.
Build errors PR: https://github.com/wundergraph/cloud/pull/348/files

## Marketing Changelog

<!--
What changes does this PR introduce? Please describe the changes in simple terms that a user can understand
without being familiar with the codebase. Mention @advocates for review and tracking.
-->

#### Checklist

- [ ] run `make test`
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)
