### PR TITLE
feat: mark operations as internal when inside internal folder

### DIFF
--- a/docs-website/src/pages/docs/directives-reference/internal-operation-directive.md
+++ b/docs-website/src/pages/docs/directives-reference/internal-operation-directive.md
@@ -5,7 +5,7 @@ description:
 ---
 
 {% callout type="warning" %}
-This directive is deprecated. Operations are now automatically marked internal when inside a folder named _internal_ (even if nested).
+This directive is deprecated. Operations are now automatically marked internal when inside a directory named _internal_ (even if nested).
 {% /callout %}
 
 The `@internalOperation` directive marks an Operation as internal.

--- a/docs-website/src/pages/docs/directives-reference/internal-operation-directive.md
+++ b/docs-website/src/pages/docs/directives-reference/internal-operation-directive.md
@@ -4,6 +4,10 @@ pageTitle: WunderGraph - Directives - @internalOperation
 description:
 ---
 
+{% callout type="warning" %}
+This directive is deprecated. Operations are now automatically marked internal when inside a folder named _internal_ (even if nested).
+{% /callout %}
+
 The `@internalOperation` directive marks an Operation as internal.
 The Operation will no longer be accessible from the public API.
 It can only be used from internal hooks.
@@ -28,11 +32,7 @@ If the user exists already, we update the lastLogin field.
 
 ```graphql
 # UpsertLastLogin.graphql
-mutation (
-  $email: String!
-  $name: String!
-  $now: DateTime! @injectCurrentDateTime
-) @internalOperation {
+mutation ($email: String!, $name: String!, $now: DateTime! @injectCurrentDateTime) @internalOperation {
   upsertOneusers(
     where: { email: $email }
     update: { lastlogin: { set: $now } }
@@ -57,18 +57,18 @@ const server = configureWunderGraphServer(() => ({
     authentication: {
       postAuthentication: async (user) => {
         if (!user.email || !user.name) {
-          return
+          return;
         }
         await client.mutations.UpsertLastLogin({
           email: user.email,
           name: user.name,
-        })
+        });
       },
     },
     queries: {},
     mutations: {},
   },
-}))
+}));
 ```
 
 ## Conclusion

--- a/docs-website/src/pages/docs/typescript-operations-reference/security.md
+++ b/docs-website/src/pages/docs/typescript-operations-reference/security.md
@@ -32,8 +32,8 @@ Define an input schema using `zod` and you can trust that the request will be va
 
 ## Internal Operations
 
-Not all operations need to exposed to the public internet. In this case just place the operation file under a folder named _internal_ and the operation will automatically be marked as internal.
-The internal folder can be nested and the same applies to nested operations within the internal folder.
+Not all operations need to exposed to the public Internet. In this case, just place the operation file under a directory named _internal_, and the operation will automatically be marked as internal.
+The internal directory can be nested, and the same applies to nested operations within the internal directory.
 
 {% callout type="warning" %}
 The configuration for operations accepts and `internal` prop. This is deprecated. Please use the above method instead.

--- a/docs-website/src/pages/docs/typescript-operations-reference/security.md
+++ b/docs-website/src/pages/docs/typescript-operations-reference/security.md
@@ -29,3 +29,12 @@ The WunderGraph Gateway will validate the request against this JSON Schema befor
 
 This means, that if you're using TypeScript Operations, you don't have to worry about input validation.
 Define an input schema using `zod` and you can trust that the request will be validated before reaching the server.
+
+## Internal Operations
+
+Not all operations need to exposed to the public internet. In this case just place the operation file under a folder named _internal_ and the operation will automatically be marked as internal.
+The internal folder can be nested and the same applies to nested operations within the internal folder.
+
+{% callout type="warning" %}
+The configuration for operations accepts and `internal` prop. This is deprecated. Please use the above method instead.
+{% /callout %}

--- a/examples/learn-wundergraph/.wundergraph/operations/users/internal/getAdminUser.ts
+++ b/examples/learn-wundergraph/.wundergraph/operations/users/internal/getAdminUser.ts
@@ -1,0 +1,14 @@
+import { createOperation, z } from '../../../generated/wundergraph.factory';
+
+export default createOperation.query({
+	input: z.object({
+		id: z.string(),
+	}),
+	handler: async ({ input }) => {
+		return {
+			id: input.id,
+			name: 'Jens the Admin',
+			bio: 'Founder of WunderGraph',
+		};
+	},
+});

--- a/examples/learn-wundergraph/.wundergraph/operations/weather/CountryWeather.ts
+++ b/examples/learn-wundergraph/.wundergraph/operations/weather/CountryWeather.ts
@@ -6,7 +6,7 @@ export default createOperation.query({
 	}),
 	handler: async ({ operations, input }) => {
 		const country = await operations.query({
-			operationName: 'weather/Country',
+			operationName: 'weather/internal/Country',
 			input: {
 				code: input.countryCode,
 			},
@@ -15,7 +15,7 @@ export default createOperation.query({
 			throw new Error('No capital found');
 		}
 		const weather = await operations.query({
-			operationName: 'weather/Weather',
+			operationName: 'weather/internal/Weather',
 			input: {
 				city: country.data?.countries_countries[0].capital,
 			},

--- a/examples/learn-wundergraph/.wundergraph/operations/weather/internal/Country.graphql
+++ b/examples/learn-wundergraph/.wundergraph/operations/weather/internal/Country.graphql
@@ -1,4 +1,4 @@
-query ($code: String!) @internalOperation {
+query ($code: String!) {
 	countries_countries(filter: { code: { eq: $code } }) {
 		code
 		name

--- a/examples/learn-wundergraph/.wundergraph/operations/weather/internal/Weather.graphql
+++ b/examples/learn-wundergraph/.wundergraph/operations/weather/internal/Weather.graphql
@@ -1,4 +1,4 @@
-query ($city: String!) @internalOperation {
+query ($city: String!) {
 	weather_getCityByName(name: $city) {
 		name
 		id

--- a/packages/sdk/src/configure/index.ts
+++ b/packages/sdk/src/configure/index.ts
@@ -1310,7 +1310,10 @@ const loadNodeJsOperation = async (wgDirAbs: string, file: TypeScriptOperationFi
 	const implementation = await loadNodeJsOperationDefaultModule(filePath);
 
 	if (implementation.internal) {
-		Logger.warn('Detected use of internal config. This will be deprecated soon. Please checkout the migration guide: ');
+		Logger.warn(
+			'Use of the internal prop will be deprecated soon. ' +
+				'More details here: https://docs.wundergraph.com/docs/typescript-operations-reference/security#internal-operations'
+		);
 	}
 	const isInternal = implementation.internal || RegExp(internalPathRegex).test(file.file_path);
 

--- a/packages/sdk/src/configure/index.ts
+++ b/packages/sdk/src/configure/index.ts
@@ -30,6 +30,7 @@ import {
 import { mergeApis } from '../definition/merge';
 import {
 	GraphQLOperation,
+	internalPathRegex,
 	isWellKnownClaim,
 	loadOperations,
 	LoadOperationsOutput,
@@ -1307,6 +1308,12 @@ const updateTypeScriptOperationsResponseSchemas = async (wgDirAbs: string, opera
 const loadNodeJsOperation = async (wgDirAbs: string, file: TypeScriptOperationFile) => {
 	const filePath = path.join(wgDirAbs, file.module_path);
 	const implementation = await loadNodeJsOperationDefaultModule(filePath);
+
+	if (implementation.internal) {
+		Logger.warn('Detected use of internal config. This will be deprecated soon. Please checkout the migration guide: ');
+	}
+	const isInternal = implementation.internal || RegExp(internalPathRegex).test(file.file_path);
+
 	const operation: TypeScriptOperation = {
 		Name: file.operation_name,
 		PathName: file.api_mount_path,
@@ -1359,7 +1366,7 @@ const loadNodeJsOperation = async (wgDirAbs: string, file: TypeScriptOperationFi
 		VariablesConfiguration: {
 			injectVariables: [],
 		},
-		Internal: implementation.internal ? implementation.internal : false,
+		Internal: isInternal,
 		PostResolveTransformations: undefined,
 	};
 	return { operation, implementation };

--- a/packages/sdk/src/configure/index.ts
+++ b/packages/sdk/src/configure/index.ts
@@ -30,7 +30,7 @@ import {
 import { mergeApis } from '../definition/merge';
 import {
 	GraphQLOperation,
-	isInternalOperationByPath,
+	isInternalOperationByAPIMountPath,
 	isWellKnownClaim,
 	loadOperations,
 	LoadOperationsOutput,
@@ -1315,7 +1315,7 @@ const loadNodeJsOperation = async (wgDirAbs: string, file: TypeScriptOperationFi
 				'More details here: https://docs.wundergraph.com/docs/typescript-operations-reference/security#internal-operations'
 		);
 	}
-	const isInternal = implementation.internal || isInternalOperationByPath(file.file_path);
+	const isInternal = implementation.internal || isInternalOperationByAPIMountPath(file.api_mount_path);
 
 	const operation: TypeScriptOperation = {
 		Name: file.operation_name,

--- a/packages/sdk/src/configure/index.ts
+++ b/packages/sdk/src/configure/index.ts
@@ -30,7 +30,7 @@ import {
 import { mergeApis } from '../definition/merge';
 import {
 	GraphQLOperation,
-	internalPathRegex,
+	isInternalOperationByPath,
 	isWellKnownClaim,
 	loadOperations,
 	LoadOperationsOutput,
@@ -1311,11 +1311,11 @@ const loadNodeJsOperation = async (wgDirAbs: string, file: TypeScriptOperationFi
 
 	if (implementation.internal) {
 		Logger.warn(
-			'Use of the internal prop will be deprecated soon. ' +
+			'Use of the internal prop is deprecated. ' +
 				'More details here: https://docs.wundergraph.com/docs/typescript-operations-reference/security#internal-operations'
 		);
 	}
-	const isInternal = implementation.internal || RegExp(internalPathRegex).test(file.file_path);
+	const isInternal = implementation.internal || isInternalOperationByPath(file.file_path);
 
 	const operation: TypeScriptOperation = {
 		Name: file.operation_name,

--- a/packages/sdk/src/graphql/operations.test.ts
+++ b/packages/sdk/src/graphql/operations.test.ts
@@ -1,5 +1,5 @@
 import {
-	internalPathRegex,
+	isInternalOperationByPath,
 	LoadOperationsOutput,
 	operationResponseToJSONSchema,
 	operationVariablesToJSONSchema,
@@ -1438,16 +1438,22 @@ input CreateEnvironment {
   edges: [ID!]
 }`;
 
-test('internalPathRegex', () => {
-	const regex = RegExp(internalPathRegex);
-	const publicPaths = ['foo.ts', 'bar.graphql', 'nested/bat.ts', 'internal.graphql', 'nested/internal.ts'];
+test('isInternalOperationByPath', () => {
+	const publicPaths = [
+		'foo.ts',
+		'bar.graphql',
+		'nested/bat.ts',
+		'internal.graphql',
+		'nested/internal.ts',
+		'hellointernal/bob.ts',
+	];
 	const internalPaths = ['internal/foo.ts', 'internal/bar.graphql', 'nested/internal/bat.ts'];
 
 	publicPaths.forEach((path) => {
-		expect(regex.test(path)).toBe(false);
+		expect(isInternalOperationByPath(path)).toBe(false);
 	});
 
 	internalPaths.forEach((path) => {
-		expect(regex.test(path)).toBe(true);
+		expect(isInternalOperationByPath(path)).toBe(true);
 	});
 });

--- a/packages/sdk/src/graphql/operations.test.ts
+++ b/packages/sdk/src/graphql/operations.test.ts
@@ -1,5 +1,5 @@
 import {
-	isInternalOperationByPath,
+	isInternalOperationByAPIMountPath,
 	LoadOperationsOutput,
 	operationResponseToJSONSchema,
 	operationVariablesToJSONSchema,
@@ -1439,7 +1439,7 @@ input CreateEnvironment {
   edges: [ID!]
 }`;
 
-test('isInternalOperationByPath', () => {
+test('isInternalOperationByAPIMountPath', () => {
 	const publicPaths = [
 		'foo.ts',
 		'bar.graphql',
@@ -1450,16 +1450,11 @@ test('isInternalOperationByPath', () => {
 	];
 	const internalPaths = ['internal/foo.ts', 'internal/bar.graphql', 'nested/internal/bat.ts'];
 
-	if (process.platform === 'win32') {
-		publicPaths.push('testinternal\\bat.ts');
-		internalPaths.push('test\\internal\\bat.ts');
-	}
-
 	publicPaths.forEach((path) => {
-		expect(isInternalOperationByPath(path)).toBe(false);
+		expect(isInternalOperationByAPIMountPath(path)).toBe(false);
 	});
 
 	internalPaths.forEach((path) => {
-		expect(isInternalOperationByPath(path)).toBe(true);
+		expect(isInternalOperationByAPIMountPath(path)).toBe(true);
 	});
 });

--- a/packages/sdk/src/graphql/operations.test.ts
+++ b/packages/sdk/src/graphql/operations.test.ts
@@ -12,6 +12,7 @@ import { JSONSchema7 as JSONSchema } from 'json-schema';
 import { ClaimType, OperationExecutionEngine, OperationType } from '@wundergraph/protobuf';
 import * as fs from 'fs';
 import path from 'path';
+import process from 'node:process';
 
 const MyReviews = `
 query {
@@ -1448,6 +1449,11 @@ test('isInternalOperationByPath', () => {
 		'hellointernal/bob.ts',
 	];
 	const internalPaths = ['internal/foo.ts', 'internal/bar.graphql', 'nested/internal/bat.ts'];
+
+	if (process.platform === 'win32') {
+		publicPaths.push('testinternal\\bat.ts');
+		internalPaths.push('test\\internal\\bat.ts');
+	}
 
 	publicPaths.forEach((path) => {
 		expect(isInternalOperationByPath(path)).toBe(false);

--- a/packages/sdk/src/graphql/operations.test.ts
+++ b/packages/sdk/src/graphql/operations.test.ts
@@ -1,4 +1,5 @@
 import {
+	internalPathRegex,
 	LoadOperationsOutput,
 	operationResponseToJSONSchema,
 	operationVariablesToJSONSchema,
@@ -1436,3 +1437,17 @@ input CreateEnvironment {
   kind: EnvironmentKind!
   edges: [ID!]
 }`;
+
+test('internalPathRegex', () => {
+	const regex = RegExp(internalPathRegex);
+	const publicPaths = ['foo.ts', 'bar.graphql', 'nested/bat.ts', 'internal.graphql', 'nested/internal.ts'];
+	const internalPaths = ['internal/foo.ts', 'internal/bar.graphql', 'nested/internal/bat.ts'];
+
+	publicPaths.forEach((path) => {
+		expect(regex.test(path)).toBe(false);
+	});
+
+	internalPaths.forEach((path) => {
+		expect(regex.test(path)).toBe(true);
+	});
+});

--- a/packages/sdk/src/graphql/operations.ts
+++ b/packages/sdk/src/graphql/operations.ts
@@ -40,12 +40,10 @@ import * as fs from 'fs';
 import process from 'node:process';
 import { OperationError } from '../client';
 
-export const isInternalOperationByPath = (path: string) => {
-	// Determine the directory separator based on the platform
-	const separator = process.platform === 'win32' ? '\\' : '/';
-
-	// Split the file path by the directory separator
-	const elements = path.split(separator);
+export const isInternalOperationByAPIMountPath = (path: string) => {
+	// Split the file path by the path separator
+	// The api mount path is always in UNIX style
+	const elements = path.split('/');
 
 	// Remove the last element (the file name)
 	elements.pop();
@@ -276,7 +274,8 @@ export const parseGraphQLOperations = (
 									'More details here: https://docs.wundergraph.com/docs/directives-reference/internal-operation-directive'
 							);
 						}
-						operation.Internal = internalOperationDirective || isInternalOperationByPath(operationFile.file_path);
+						operation.Internal =
+							internalOperationDirective || isInternalOperationByAPIMountPath(operationFile.api_mount_path);
 
 						if (wgRoleEnum && wgRoleEnum.kind === 'EnumTypeDefinition') {
 							const rbac = node.directives?.find((d) => d.name.value === 'rbac');

--- a/packages/sdk/src/graphql/operations.ts
+++ b/packages/sdk/src/graphql/operations.ts
@@ -260,7 +260,8 @@ export const parseGraphQLOperations = (
 							node.directives?.find((d) => d.name.value === 'internalOperation') !== undefined;
 						if (internalOperationDirective) {
 							Logger.warn(
-								'Detected use of internalOperation directive. This will be deprecated soon. Please checkout the migration guide: '
+								'Use of internalOperation directive will be deprecated soon. ' +
+									'More details here: https://docs.wundergraph.com/docs/directives-reference/internal-operation-directive'
 							);
 						}
 						operation.Internal = internalOperationDirective || RegExp(internalPathRegex).test(operationFile.file_path);

--- a/packages/sdk/src/graphql/operations.ts
+++ b/packages/sdk/src/graphql/operations.ts
@@ -40,7 +40,14 @@ import * as fs from 'fs';
 import process from 'node:process';
 import { OperationError } from '../client';
 
-export const internalPathRegex = '.*\\/?internal\\/.*';
+export const isInternalOperationByPath = (path: string) => {
+	return (
+		path.startsWith('internal/') ||
+		path.includes('/internal/') ||
+		path.startsWith('internal\\') ||
+		path.includes('\\internal\\')
+	);
+};
 
 export interface GraphQLOperation {
 	Name: string;
@@ -260,11 +267,11 @@ export const parseGraphQLOperations = (
 							node.directives?.find((d) => d.name.value === 'internalOperation') !== undefined;
 						if (internalOperationDirective) {
 							Logger.warn(
-								'Use of internalOperation directive will be deprecated soon. ' +
+								'Use of internalOperation directive is deprecated. ' +
 									'More details here: https://docs.wundergraph.com/docs/directives-reference/internal-operation-directive'
 							);
 						}
-						operation.Internal = internalOperationDirective || RegExp(internalPathRegex).test(operationFile.file_path);
+						operation.Internal = internalOperationDirective || isInternalOperationByPath(operationFile.file_path);
 
 						if (wgRoleEnum && wgRoleEnum.kind === 'EnumTypeDefinition') {
 							const rbac = node.directives?.find((d) => d.name.value === 'rbac');

--- a/packages/sdk/src/graphql/operations.ts
+++ b/packages/sdk/src/graphql/operations.ts
@@ -41,12 +41,17 @@ import process from 'node:process';
 import { OperationError } from '../client';
 
 export const isInternalOperationByPath = (path: string) => {
-	return (
-		path.startsWith('internal/') ||
-		path.includes('/internal/') ||
-		path.startsWith('internal\\') ||
-		path.includes('\\internal\\')
-	);
+	// Determine the directory separator based on the platform
+	const separator = process.platform === 'win32' ? '\\' : '/';
+
+	// Split the file path by the directory separator
+	const elements = path.split(separator);
+
+	// Remove the last element (the file name)
+	elements.pop();
+
+	// check if the resulting array contains internal
+	return elements.includes('internal');
 };
 
 export interface GraphQLOperation {

--- a/testapps/default/.wundergraph/operations/nested/InternalDirectoryWrapper.ts
+++ b/testapps/default/.wundergraph/operations/nested/InternalDirectoryWrapper.ts
@@ -1,0 +1,7 @@
+import { createOperation } from '../../generated/wundergraph.factory';
+
+export default createOperation.query({
+	handler: async ({ internalClient }) => {
+		return internalClient.queries.NestedInternalInternal();
+	},
+});

--- a/testapps/default/.wundergraph/operations/nested/internal/Internal.graphql
+++ b/testapps/default/.wundergraph/operations/nested/internal/Internal.graphql
@@ -1,0 +1,6 @@
+query {
+	chinook_findFirstAlbum {
+		AlbumId
+		Title
+	}
+}

--- a/testapps/default/test/index.test.ts
+++ b/testapps/default/test/index.test.ts
@@ -29,6 +29,22 @@ describe('functions', () => {
 			expect(result.data?.data?.chinook_findFirstAlbum?.AlbumId).toBe(1);
 		}
 	});
+
+	test('internal directory operation call from function', async () => {
+		const client = wg.client();
+		const promises = [];
+		for (let ii = 0; ii < 50; ii++) {
+			const op = client.query({
+				operationName: 'nested/InternalDirectoryWrapper',
+			});
+			promises.push(op);
+		}
+		const results = await Promise.all(promises);
+		for (const result of results) {
+			expect(result.error).toBeUndefined();
+			expect(result.data?.data?.chinook_findFirstAlbum?.AlbumId).toBe(1);
+		}
+	});
 });
 
 describe('@jsonSchema', () => {

--- a/testapps/default/test/index.test.ts
+++ b/testapps/default/test/index.test.ts
@@ -33,6 +33,9 @@ describe('functions', () => {
 	test('internal directory operation call from function', async () => {
 		const client = wg.client();
 		const promises = [];
+		// Call this 50 times to exercise some code paths that share cached
+		// buffers. If we have a race condition in there, the go race detector
+		// (which we use in CI) will likely catch it.
 		for (let ii = 0; ii < 50; ii++) {
 			const op = client.query({
 				operationName: 'nested/InternalDirectoryWrapper',


### PR DESCRIPTION
## Motivation and Context

Operations are now marked as internal when under an `internal` folder.

## Marketing Changelog

WunderGraph will now automatically consider operations as internal when placed inside a directory name `internal`. This can be nested as well. All operations below are internal.

```
.wundergraph/
└── operations/
    ├── internal/
    │   └── Weather.graphql
    └── hello/
        └── internal/
            ├── user.ts
            └── more/
                └── admin.ts
                
```

<!--
What changes does this PR introduce? Please describe the changes in simple terms that a user can understand
without being familiar with the codebase. Mention @advocates for review and tracking.
-->

#### Checklist

- [x] run `make test`
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)
