### PR TITLE
fix: allow prisma to load from .env

### DIFF
--- a/pkg/datasources/database/engine.go
+++ b/pkg/datasources/database/engine.go
@@ -271,7 +271,10 @@ func (e *Engine) StartQueryEngine(schema string) error {
 	// this is important for sqlite support as it's expected that the path of the sqlite file is the same
 	// (relative to the .wundergraph directory) during introspection and at runtime
 	e.cmd.Dir = e.wundergraphDir
-	e.cmd.Env = append(e.cmd.Env, "PRISMA_DML="+schema)
+
+	// append all environment variables, as demonstrated in prisma/prisma/BinaryEngine.ts
+	e.cmd.Env = append(os.Environ(), "PRISMA_DML="+schema)
+
 	e.cmd.Stdout = os.Stdout
 	e.cmd.Stderr = os.Stderr
 	e.url = "http://localhost:" + port

--- a/pkg/datasources/database/engine.go
+++ b/pkg/datasources/database/engine.go
@@ -272,8 +272,10 @@ func (e *Engine) StartQueryEngine(schema string) error {
 	// (relative to the .wundergraph directory) during introspection and at runtime
 	e.cmd.Dir = e.wundergraphDir
 
-	// append all environment variables, as demonstrated in prisma/prisma/BinaryEngine.ts
-	e.cmd.Env = append(os.Environ(), "PRISMA_DML="+schema)
+	// append all environment variables, as demonstrated in the following:
+	// https://github.com/prisma/prisma/blob/304c54c732921c88bfb57f5730c7f81405ca83ea/packages/engine-core/src/binary/BinaryEngine.ts#L479
+	e.cmd.Env = append(e.cmd.Env, os.Environ()...)
+	e.cmd.Env = append(e.cmd.Env, "PRISMA_DML="+schema)
 
 	e.cmd.Stdout = os.Stdout
 	e.cmd.Stderr = os.Stderr


### PR DESCRIPTION
## Motivation and Context

Prisma was not loading variables from .env files. Consequently, `env(VAR_NAME)` will fail in a `schema.prisma`.

## Marketing Changelog

<!--
What changes does this PR introduce? Please describe the changes in simple terms that a user can understand
without being familiar with the codebase. Mention @advocates for review and tracking.
-->

#### Checklist

- [ ] run `make test`
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)
