### PR TITLE
fix: svelte-query livequery config

### DIFF
--- a/packages/svelte-query/README.md
+++ b/packages/svelte-query/README.md
@@ -100,6 +100,99 @@ Now you can use svelte-query to call your wundergraph operations!
 </div>
 ```
 
+### createQuery
+
+```ts
+createQuery({
+  operationName: 'Weather',
+  input: { forCity: city },
+});
+```
+
+### createQuery (Live query)
+
+```ts
+createQuery({
+  operationName: 'Weather',
+  input: { forCity: city },
+  liveQuery: true,
+});
+```
+
+### createSubscription
+
+```ts
+createSubscription({
+  operationName: 'Weather',
+  input: {
+    forCity: 'Berlin',
+  },
+});
+```
+
+### createMutation
+
+```ts
+const mutation = createMutation({
+  operationName: 'SetName',
+});
+
+$mutation.mutate({ name: 'WunderGraph' });
+
+await $mutation.mutateAsync({ name: 'WunderGraph' });
+```
+
+### createFileUpload
+
+```ts
+const fileUploader = createFileUpload();
+
+$fileUploader.upload({
+  provider: 'minio',
+  files: new FileList(),
+});
+
+await $fileUploader.upload({
+  provider: 'minio',
+  files: new FileList(),
+});
+
+$fileUploader.fileKeys; // files that have been uploaded
+```
+
+### getAuth
+
+```ts
+const auth = getAuth();
+
+$auth.login('github');
+
+$auth.logout({ logoutOpenidConnectProvider: true });
+```
+
+### getUser
+
+```ts
+const userQuery = getUser();
+```
+
+### queryKey
+
+You can use the `queryKey` helper function to create a unique key for the query in a typesafe way. This is useful if you want to invalidate the query after mutating.
+
+```ts
+const queryClient = useQueryClient();
+
+const mutation = createMutation({
+  operationName: 'SetName',
+  onSuccess() {
+    queryClient.invalidateQueries(queryKey({ operationName: 'Profile' }));
+  },
+});
+
+$mutation.mutate({ name: 'WunderGraph' });
+```
+
 ## SSR
 
 If you are working with SvelteKit, this package provides `prefetchQuery` utility to help with SSR

--- a/packages/svelte-query/src/lib/createSvelteClient.ts
+++ b/packages/svelte-query/src/lib/createSvelteClient.ts
@@ -129,17 +129,16 @@ export function createSvelteClient<Operations extends OperationsDefinition>(clie
 			refetchOnWindowFocus: liveQuery ? false : refetchOnWindowFocus,
 		});
 
-		const subscriptionState = createSubscribeTo({
-			queryHash,
-			operationName,
-			input,
-			liveQuery,
-			enabled: options.enabled !== false && liveQuery,
-			onSuccess: options.onSuccess,
-			onError: options.onError,
-		});
-
 		if (liveQuery) {
+			const subscriptionState = createSubscribeTo({
+				queryHash,
+				operationName,
+				input,
+				liveQuery,
+				enabled: options.enabled !== false && liveQuery,
+				onSuccess: options.onSuccess,
+				onError: options.onError,
+			});
 			const liveQueryResult = withSubscriptionState(queryResult, subscriptionState);
 			return liveQueryResult;
 		}

--- a/packages/svelte-query/src/lib/createSvelteClient.ts
+++ b/packages/svelte-query/src/lib/createSvelteClient.ts
@@ -268,38 +268,40 @@ export function createSvelteClient<Operations extends OperationsDefinition>(clie
 			}
 
 			subscriptionState.set({ isLoading: true, isSubscribed: false });
-			unsubscribe = subscribeTo({
-				operationName,
-				input,
-				liveQuery,
-				subscribeOnce,
-				onError(error) {
-					subscriptionState.set({ isLoading: false, isSubscribed: false });
-					onError?.(error);
-					startedAtRef = null;
-				},
-				onResult(result) {
-					if (!startedAtRef) {
-						subscriptionState.set({ isLoading: false, isSubscribed: true });
-						onSuccess?.(result);
-						startedAtRef = new Date().getTime();
-					}
-
-					// Promise is not handled because we are not interested in the result
-					// Errors are handled by React Query internally
-					client.setQueryData([operationName, input], () => {
-						if (result.error) {
-							throw result.error;
+			if (enabled) {
+				unsubscribe = subscribeTo({
+					operationName,
+					input,
+					liveQuery,
+					subscribeOnce,
+					onError(error) {
+						subscriptionState.set({ isLoading: false, isSubscribed: false });
+						onError?.(error);
+						startedAtRef = null;
+					},
+					onResult(result) {
+						if (!startedAtRef) {
+							subscriptionState.set({ isLoading: false, isSubscribed: true });
+							onSuccess?.(result);
+							startedAtRef = new Date().getTime();
 						}
 
-						return result.data;
-					});
-				},
-				onAbort() {
-					subscriptionState.set({ isLoading: false, isSubscribed: false });
-					startedAtRef = null;
-				},
-			});
+						// Promise is not handled because we are not interested in the result
+						// Errors are handled by React Query internally
+						client.setQueryData([operationName, input], () => {
+							if (result.error) {
+								throw result.error;
+							}
+
+							return result.data;
+						});
+					},
+					onAbort() {
+						subscriptionState.set({ isLoading: false, isSubscribed: false });
+						startedAtRef = null;
+					},
+				});
+			}
 		});
 
 		onDestroy(() => {

--- a/packages/svelte-query/tests/queryUtils.test.ts
+++ b/packages/svelte-query/tests/queryUtils.test.ts
@@ -237,33 +237,25 @@ describe('Svelte Query - createMutation', () => {
 	});
 
 	it('should invalidate query', async () => {
-		const mutation = nockMutation('SetNameWithoutAuth', { name: 'Not Rick Astley' })
-			.mutation.once()
-			.reply(200, {
-				data: {
-					name: 'Rick Astley',
-				},
-			});
-
 		const scope = nockQuery()
 			.reply(200, {
 				data: {
 					id: '1',
-					name: 'Rick Astley',
+					name: 'Test',
 				},
 			})
 			.matchHeader('accept', 'application/json')
 			.matchHeader('content-type', 'application/json')
 			.matchHeader('WG-SDK-Version', '1.0.0')
-			.get('/operations/Weather')
+			.post('/operations/SetNameWithoutAuth', { name: 'Not Rick Astley' })
 			.query({ wg_api_hash: '123' })
-			.reply(200, { data: { id: '1', name: 'Not Ricky Astley' } })
+			.reply(200, { data: { id: '1', name: 'Not Rick Astley' } })
 			.matchHeader('accept', 'application/json')
 			.matchHeader('content-type', 'application/json')
 			.matchHeader('WG-SDK-Version', '1.0.0')
 			.get('/operations/Weather')
 			.query({ wg_api_hash: '123' })
-			.reply(200, { data: { id: '1', name: 'Not Rick Astley' } });
+			.reply(200, { data: { id: '1', name: 'Rick Astley' } });
 
 		const queryCache = new QueryCache();
 		const queryClient = new QueryClient({ queryCache });
@@ -284,25 +276,14 @@ describe('Svelte Query - createMutation', () => {
 		render(MutationWithInvalidationWrapper, { queryClient, queryCreator, mutationCreator });
 
 		await waitFor(() => {
-			screen.getByText('Rick Astley');
+			screen.getByText('Test');
 		});
-
-		await sleep(1000);
 
 		fireEvent.click(screen.getByText('submit'));
 
-		await sleep(1000);
-
-		await waitFor(
-			() => {
-				screen.getByText('Not Rick Astley');
-			},
-			{
-				timeout: 1000,
-			}
-		);
-
-		mutation.done();
+		await waitFor(() => {
+			screen.getByText('Rick Astley');
+		});
 		scope.done();
 	});
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

## Motivation and Context

Fixes an issue with svelte query's liveQuery which gets connected even when livequery config is set to false

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

## Marketing Changelog

<!--
What changes does this PR introduce? Please describe the changes in simple terms that a user can understand
without being familiar with the codebase. Mention @advocates for review and tracking.
-->

#### Checklist

- [x] run `make test`
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)
