### PR TITLE
fix: include config headers in graphiql

### DIFF
--- a/pkg/graphiql/graphiql.html
+++ b/pkg/graphiql/graphiql.html
@@ -49,15 +49,16 @@
 		<div id="graphiql">Loading...</div>
 		<script src="https://unpkg.com/graphiql/graphiql.min.js" type="application/javascript"></script>
 		<script>
-			function graphQLFetcher(graphQLParams) {
+			function graphQLFetcher(graphQLParams,config) {
 				return fetch('{{apiURL}}/graphql', {
 					method: 'post',
 					headers: {
+						...config.headers || {},
 						Accept: 'application/json',
 						'Content-Type': 'application/json',
 					},
 					body: JSON.stringify(graphQLParams),
-					credentials: 'omit',
+					credentials: 'include',
 				}).then(function (response) {
 					return response.json().catch(function () {
 						return response.text();

--- a/testapps/default/.wundergraph/wundergraph.config.ts
+++ b/testapps/default/.wundergraph/wundergraph.config.ts
@@ -34,15 +34,19 @@ const federatedApi = introspect.federation({
 	upstreams: [
 		{
 			url: 'https://wg-federation-demo-accounts.fly.dev/graphql',
+			headers: (b) => b.addClientRequestHeader('Authorization', 'Authorization'),
 		},
 		{
 			url: 'https://wg-federation-demo-products.fly.dev/graphql',
+			headers: (b) => b.addClientRequestHeader('Authorization', 'Authorization'),
 		},
 		{
 			url: 'https://wg-federation-demo-reviews.fly.dev/graphql',
+			headers: (b) => b.addClientRequestHeader('Authorization', 'Authorization'),
 		},
 		{
 			url: 'https://wg-federation-demo-inventory.fly.dev/graphql',
+			headers: (b) => b.addClientRequestHeader('Authorization', 'Authorization'),
 		},
 	],
 });


### PR DESCRIPTION
## Motivation and Context

This fix includes user-defined headers in graphiql. Previously, we've omitted them in the custom GraphQL fetcher.