### PR TITLE
fix: don't override request context after assigning client request (#866

### DIFF
--- a/packages/testsuite/apps/basic/.wundergraph/operations/clientrequest/Header.graphql
+++ b/packages/testsuite/apps/basic/.wundergraph/operations/clientrequest/Header.graphql
@@ -1,0 +1,3 @@
+query ($header: String!) {
+	embedded_clientRequestHeader(header: $header)
+}

--- a/packages/testsuite/apps/basic/.wundergraph/wundergraph.server.ts
+++ b/packages/testsuite/apps/basic/.wundergraph/wundergraph.server.ts
@@ -1,10 +1,36 @@
 import { configureWunderGraphServer } from '@wundergraph/sdk/server';
 import type { HooksConfig } from './generated/wundergraph.hooks';
 import type { InternalClient } from './generated/wundergraph.internal.client';
+import { buildSchema, GraphQLNonNull, GraphQLObjectType, GraphQLSchema, GraphQLString } from 'graphql/index';
+import { GraphQLExecutionContext } from './generated/wundergraph.server';
 
 export default configureWunderGraphServer<HooksConfig, InternalClient>(() => ({
 	hooks: {
 		queries: {},
 		mutations: {},
 	},
+	graphqlServers: [
+		{
+			apiNamespace: 'embedded',
+			serverName: 'embedded',
+			schema: new GraphQLSchema({
+				query: new GraphQLObjectType<any, GraphQLExecutionContext>({
+					name: 'Query',
+					fields: {
+						clientRequestHeader: {
+							type: GraphQLString,
+							args: {
+								header: {
+									type: new GraphQLNonNull(GraphQLString),
+								},
+							},
+							resolve: async (parent, args, ctx) => {
+								return ctx.wundergraph.clientRequest.headers.get(args.header);
+							},
+						},
+					},
+				}),
+			}),
+		},
+	],
 }));

--- a/packages/testsuite/apps/basic/index.test.ts
+++ b/packages/testsuite/apps/basic/index.test.ts
@@ -58,4 +58,20 @@ describe('Operations', () => {
 		expect(badRequestError?.code).toBe('BadRequest');
 		expect(badRequestError?.statusCode).toBe(400);
 	});
+
+	it('Should return a client request header', async () => {
+		const client = wg.client();
+		client.setExtraHeaders({
+			'X-Test': 'test123',
+		});
+		const { data, error } = await client.query({
+			operationName: 'clientrequest/Header',
+			input: {
+				header: 'X-Test',
+			},
+		});
+
+		expect(error).toBeUndefined();
+		expect(data?.embedded_clientRequestHeader).toBe('test123');
+	});
 });

--- a/pkg/apihandler/apihandler.go
+++ b/pkg/apihandler/apihandler.go
@@ -810,10 +810,7 @@ func (h *GraphQLHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		RenameTypeNames: h.renameTypeNames,
 	})
 	defer h.pool.PutShared(shared)
-
 	shared.Ctx.Variables = requestVariables
-	shared.Ctx.Context = r.Context()
-	shared.Ctx.Request.Header = r.Header
 	shared.Doc.Input.ResetInputString(requestQuery)
 	shared.Parser.Parse(shared.Doc, shared.Report)
 


### PR DESCRIPTION
This fixes a bug where we first assign the client request to the request context and then override the context again, omitting the client request, which is then not properly injected into the transport, resulting in the client request missing in internal GraphQL requests to internally mounted/embedded GraphQL servers.