### PR TITLE
feat: add support for operations with hyphens in their names

### DIFF
--- a/packages/testsuite/apps/basic/.wundergraph/operations/with-hyphen/call-country-code-with-hyphen-from-ts.ts
+++ b/packages/testsuite/apps/basic/.wundergraph/operations/with-hyphen/call-country-code-with-hyphen-from-ts.ts
@@ -1,0 +1,9 @@
+import { createOperation } from '../../generated/wundergraph.factory';
+
+export default createOperation.query({
+	handler: async ({ operations }) => {
+		return operations.query({
+			operationName: 'with-hyphen/country-code-with-hyphen',
+		});
+	},
+});

--- a/packages/testsuite/apps/basic/.wundergraph/operations/with-hyphen/country-code-with-hyphen.graphql
+++ b/packages/testsuite/apps/basic/.wundergraph/operations/with-hyphen/country-code-with-hyphen.graphql
@@ -1,0 +1,7 @@
+query ($code: String! = "DE") {
+	countries_countries(filter: { code: { eq: $code } }) {
+		code
+		name
+		capital
+	}
+}

--- a/packages/testsuite/apps/basic/index.test.ts
+++ b/packages/testsuite/apps/basic/index.test.ts
@@ -69,4 +69,20 @@ describe('Operations', () => {
 		expect(result.error).toBeUndefined();
 		expect(result.data.greeting).toBeDefined();
 	});
+
+	it('should allow operation names with hyphens', async () => {
+		const result = await wg.client().query({
+			operationName: 'with-hyphen/country-code-with-hyphen',
+		});
+		expect(result.error).toBeUndefined();
+		expect(result.data?.countries_countries?.[0].capital).toBe('Berlin');
+	});
+
+	it('should allow calling operation names with hyphens', async () => {
+		const result = await wg.client().query({
+			operationName: 'with-hyphen/call-country-code-with-hyphen-from-ts',
+		});
+		expect(result.error).toBeUndefined();
+		expect(result.data?.data?.countries_countries?.[0].capital).toBe('Berlin');
+	});
 });

--- a/pkg/loadoperations/loader.go
+++ b/pkg/loadoperations/loader.go
@@ -341,7 +341,7 @@ func isValidOperationName(s string) bool {
 		if i == 0 && !unicode.IsLetter(r) {
 			return false
 		}
-		if !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '/' && r != '_' {
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '/' && r != '_' && r != '-' {
 			return false
 		}
 	}
@@ -349,7 +349,8 @@ func isValidOperationName(s string) bool {
 }
 
 func normalizeOperationName(s string) string {
-	parts := strings.Split(s, "/")
+	cleanedUp := strings.ReplaceAll(s, "-", "_")
+	parts := strings.Split(cleanedUp, "/")
 	caser := cases.Title(language.English, cases.NoLower)
 
 	var out []string


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

## Motivation and Context

Users have asked to be able to use hyphens in their operation names.

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

## Marketing Changelog

We now have an alternative to the boring underscore.
<!--
What changes does this PR introduce? Please describe the changes in simple terms that a user can understand
without being familiar with the codebase. Mention @advocates for review and tracking.
-->

#### Checklist

- [ ] run `make test`
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)
