### PR TITLE
fix: variable corruption

### DIFF
--- a/pkg/apihandler/apihandler.go
+++ b/pkg/apihandler/apihandler.go
@@ -860,7 +860,8 @@ func (h *GraphQLHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if len(prepared.variables) != 0 {
 		// we have to merge query variables into extracted variables to been able to override default values
-		shared.Ctx.Variables = MergeJsonRightIntoLeft(prepared.variables, shared.Ctx.Variables)
+		// we make a copy of the extracted variables to not override h.extractedVariables
+		shared.Ctx.Variables = MergeJsonRightIntoLeft([]byte(string(prepared.variables)), shared.Ctx.Variables)
 	}
 
 	switch p := prepared.preparedPlan.(type) {
@@ -1308,7 +1309,8 @@ func (h *QueryHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx.Variables = h.jsonStringInterpolator.Interpolate(ctx.Variables)
 
 	if len(h.extractedVariables) != 0 {
-		ctx.Variables = MergeJsonRightIntoLeft(h.extractedVariables, ctx.Variables)
+		// we make a copy of the extracted variables to not override h.extractedVariables
+		ctx.Variables = MergeJsonRightIntoLeft([]byte(string(h.extractedVariables)), ctx.Variables)
 	}
 
 	ctx.Variables, err = postProcessVariables(h.operation, r, ctx.Variables)
@@ -1652,7 +1654,8 @@ func (h *MutationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx.Variables = h.jsonStringInterpolator.Interpolate(ctx.Variables)
 
 	if len(h.extractedVariables) != 0 {
-		ctx.Variables = MergeJsonRightIntoLeft(h.extractedVariables, ctx.Variables)
+		// we make a copy of the extracted variables to not override h.extractedVariables
+		ctx.Variables = MergeJsonRightIntoLeft([]byte(string(h.extractedVariables)), ctx.Variables)
 	}
 
 	ctx.Variables, err = postProcessVariables(h.operation, r, ctx.Variables)
@@ -1740,7 +1743,8 @@ func (h *SubscriptionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	ctx.Variables = h.jsonStringInterpolator.Interpolate(ctx.Variables)
 
 	if len(h.extractedVariables) != 0 {
-		ctx.Variables = MergeJsonRightIntoLeft(h.extractedVariables, ctx.Variables)
+		// we make a copy of the extracted variables to not override h.extractedVariables
+		ctx.Variables = MergeJsonRightIntoLeft([]byte(string(h.extractedVariables)), ctx.Variables)
 	}
 
 	ctx.Variables, err = postProcessVariables(h.operation, r, ctx.Variables)

--- a/pkg/apihandler/internalapihandler.go
+++ b/pkg/apihandler/internalapihandler.go
@@ -366,7 +366,8 @@ func (h *InternalApiHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx.Variables = compactBuf.Bytes()
 
 	if len(h.extractedVariables) != 0 {
-		ctx.Variables = MergeJsonRightIntoLeft(ctx.Variables, h.extractedVariables)
+		// we make a copy of the extracted variables to not override h.extractedVariables
+		ctx.Variables = MergeJsonRightIntoLeft([]byte(string(h.extractedVariables)), ctx.Variables)
 	}
 
 	ctx.Variables = injectVariables(h.operation, r, ctx.Variables)
@@ -450,7 +451,8 @@ func (h *InternalSubscriptionApiHandler) ServeHTTP(w http.ResponseWriter, r *htt
 	ctx.Variables = compactBuf.Bytes()
 
 	if len(h.extractedVariables) != 0 {
-		ctx.Variables = MergeJsonRightIntoLeft(ctx.Variables, h.extractedVariables)
+		// we make a copy of the extracted variables to not override h.extractedVariables
+		ctx.Variables = MergeJsonRightIntoLeft([]byte(string(h.extractedVariables)), ctx.Variables)
 	}
 
 	ctx.Variables = injectVariables(h.operation, r, ctx.Variables)


### PR DESCRIPTION
Copy prepared variables before merging user-defined variables to avoid corruption.

In very rare cases, it's possible that we're overriding the shared variables object in a way that will result in corruption. To avoid this, we're creating a copy first.