### PR TITLE
chore: add publish client guide

### DIFF
--- a/docs-website/config/navigation.tsx
+++ b/docs-website/config/navigation.tsx
@@ -425,6 +425,10 @@ const navigation = [
 						title: 'Using HTTP proxies',
 						href: '/docs/guides/using-http-proxies',
 					},
+					{
+						title: 'Publish generated client to NPM',
+						href: '/docs/guides/publish-generated-client-to-npm',
+					},
 				],
 			},
 		],

--- a/docs-website/src/pages/docs/guides/publish_generated-client-to-npm.md
+++ b/docs-website/src/pages/docs/guides/publish_generated-client-to-npm.md
@@ -1,0 +1,128 @@
+---
+title: Publish the generated client to NPM
+pageTitle: WunderGraph - Publish the generated client to NPM
+description: This guide shows how to publish the generated client to NPM
+---
+
+This guide shows you how to bundle the generated client code for distribution to NPM.
+
+## Prerequisites
+
+This guide assumes you already have an existing WunderGraph project inside a monorepo. If you don't have a WunderGraph project yet, you can follow the [Getting Started](/docs/getting-started) guide to create a new project.
+
+There's an example repository available on [GitHub](https://github.com/wundergraph/publish-client).
+
+## Setup
+
+The first thing we need to do is to create a new client package inside the monorepo.
+
+Create a new `client` folder inside your `packages` folder (or any other folder you prefer, that is configured as a workspace) and add a `package.json` file with the following content:
+
+```json
+{
+  "name": "@my-org/client",
+  "version": "1.0.0",
+  "description": "WunderGraph client",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsup"
+  },
+  "dependencies": {
+    "@wundergraph/sdk": "^0.149.1"
+  },
+  "devDependencies": {
+    "tsup": "^6.7.0",
+    "zod": "^3.21.4"
+  }
+}
+```
+
+Zod is required to build TypeScript operation endpoints for the client.
+
+Next we need a `tsconfig.json` file in the `client` folder:
+
+```json
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "commonjs",
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["zod"]
+  },
+  "include": ["../../gateway/.wundergraph/**/*.ts"]
+}
+```
+
+The `include` path points to the the `.wundergraph` folder, where the generated client code is located. It's also required to add the `zod` type to the `types` array of the `compilerOptions`.
+
+The last thing we need to do is to add a `tsup.config.ts` file to the `client` folder:
+
+```ts
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['../../gateway/.wundergraph/generated/client.ts'],
+  splitting: false,
+  bundle: true,
+  clean: true,
+  dts: true,
+  outDir: 'dist',
+  format: ['cjs', 'esm'],
+});
+```
+
+- `entry` points to the generated client code in our gateway.
+- `splitting` is disabled because we want to bundle everything into a single file.
+- `bundle` is enabled to bundle all imports except dependencies into a single file, this is required so TypeScript operations types are included in the bundle.
+- `clean` is enabled to remove the `dist` folder before building.
+- `dts` is enabled to generate type definitions.
+- `outDir` is set to `dist` to output the bundled code into the `dist` folder
+- `format` is set to `cjs` and `esm` to generate CommonJS and ES Modules. Currently the WunderGraph SDK only supports CommonJS, but we plan to support ES Modules in the future.
+
+Now we're almost set, the last thing to do is add a new build script to the workspace root `package.json` that will run the WunderGraph code generation and build the client:
+
+```json
+{
+  "scripts": {
+    "generate": "pnpm run --filter gateway generate",
+    "build": "WG_PUBLIC_NODE_URL=https://api.my.org pnpm generate && pnpm build:client",
+    "build:client": "pnpm run --filter @my-org/client build",
+    "publish:client": "pnpm run --filter @my-org/client publish"
+  }
+}
+```
+
+The `WG_PUBLIC_NODE_URL` is the URL of the WunderGraph gateway that will be used to generate the client code. It defaults to `http://localhost:9991` if not set. You can also set it in a `.env` file. You should configure it to point to the production gateway URL in your CI/CD pipeline.
+
+Now we're ready to build the client:
+
+```bash
+pnpm build
+```
+
+After building the client, it's ready to be published to NPM, Google Packages or a private package registry.
+
+## Learn More
+
+- [Client reference](https://docs.wundergraph.com/docs/clients-reference/typescript-client)
+- [TSUP](https://tsup.egoist.dev/)
+
+## Deploy to WunderGraph Cloud
+
+[![Deploy to WunderGraph](https://wundergraph.com/button)](https://cloud.wundergraph.com/new/clone?templateName=simple)
+
+## Got Questions?
+
+Join us on [Discord](https://wundergraph.com/discord)!

--- a/docs-website/src/pages/docs/guides/publish_generated-client-to-npm.md
+++ b/docs-website/src/pages/docs/guides/publish_generated-client-to-npm.md
@@ -118,6 +118,7 @@ After building the client, it's ready to be published to NPM, Google Packages or
 
 - [Client reference](https://docs.wundergraph.com/docs/clients-reference/typescript-client)
 - [TSUP](https://tsup.egoist.dev/)
+- [Example repository](https://github.com/wundergraph/publish-client).
 
 ## Deploy to WunderGraph Cloud
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

## Motivation and Context

A new guide that shows how to bundle the generated client for distribution to NPM

## Marketing Changelog

<!--
What changes does this PR introduce? Please describe the changes in simple terms that a user can understand
without being familiar with the codebase. Mention @advocates for review and tracking.
-->

#### Checklist

- [ ] run `make test`
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)
