### PR TITLE
fix: improve hook server types

### DIFF
--- a/packages/sdk/src/codegen/templates/typescript/hooks.template.ts
+++ b/packages/sdk/src/codegen/templates/typescript/hooks.template.ts
@@ -1,87 +1,27 @@
 //language=handlebars
 export const template = `
 import { {{ modelImports }} } from "./models"
-import type { BaseRequestContext, WunderGraphRequest, WunderGraphResponse, AuthenticationResponse, AuthenticationHookRequest, HooksConfiguration, WsTransportOnConnectionInitResponse, PreUploadHookRequest, PreUploadHookResponse, PostUploadHookRequest, PostUploadHookResponse } from "@wundergraph/sdk/server";
+import type { 
+	BaseRequestContext,
+	WunderGraphRequest,
+	WunderGraphResponse,
+	AuthenticationResponse,
+	AuthenticationHookRequest,
+	HooksConfiguration,
+	WsTransportOnConnectionInitResponse,
+	PreUploadHookRequest,
+	PreUploadHookResponse,
+	PostUploadHookRequest,
+	PostUploadHookResponse,
+	QueryHook,
+	MutationHook,
+	SubscriptionHook
+} from "@wundergraph/sdk/server";
 import type { InternalClient } from "./wundergraph.internal.client"
 import type { User } from "./wundergraph.server"
 import { InternalOperationsClient } from "./wundergraph.internal.operations.client";
 
-// use SKIP to skip the hook and continue the request / response chain without modifying the request / response
-export type SKIP = "skip";
-
-// use CANCEL to skip the hook and cancel the request / response chain
-// this is semantically equal to throwing an error (500)
-export type CANCEL = "cancel";
-
-export type WUNDERGRAPH_OPERATION = {{{operationNamesUnion}}};
-
 export type DATA_SOURCES = {{{dataSourcesUnion}}};
-
-export interface HttpTransportHookRequest extends BaseRequestContext<User, InternalClient> {
-		request: WunderGraphRequest;
-		operation: {
-				name: WUNDERGRAPH_OPERATION;
-				type: 'mutation' | 'query' | 'subscription';
-		}
-}
-export interface HttpTransportHookRequestWithResponse extends BaseRequestContext<User, InternalClient> {
-		response: WunderGraphResponse;
-    operation: {
-        name: string;
-        type: string;
-    }
-}
-export interface WsTransportHookRequest extends BaseRequestContext<User, InternalClient> {
-	  dataSourceId: DATA_SOURCES;
-		request: WunderGraphRequest;
-}
-export interface GlobalHooksConfig<Operations extends string = string, DataSources extends string = string> {
-	httpTransport?: {
-		// onRequest is called right before the request is sent to the origin
-		// it can be used to modify the request
-		// you can return SKIP to skip the hook and continue the request chain without modifying the request
-		// you can return CANCEL to cancel the request chain and return a 500 error
-		onOriginRequest?: {
-			hook: (hook: HttpTransportHookRequest) => Promise<WunderGraphRequest | SKIP | CANCEL>;
-			// calling the httpTransport hooks has a case, because the custom httpTransport hooks have to be called for each request
-			// for this reason, you have to explicitly enable the hook for each Operation
-			enableForOperations?: Operations[];
-			// enableForAllOperations will disregard the enableForOperations property and enable the hook for all operations
-			enableForAllOperations?: boolean;
-		};
-		// onResponse is called right after the response is received from the origin
-		// it can be used to modify the response
-		// you can return SKIP to skip the hook and continue the response chain without modifying the response
-		// you can return CANCEL to cancel the response chain and return a 500 error
-		onOriginResponse?: {
-			hook: (hook: HttpTransportHookRequestWithResponse) => Promise<WunderGraphResponse | SKIP | CANCEL>;
-			// calling the httpTransport hooks has a case, because the custom httpTransport hooks have to be called for each request
-			// for this reason, you have to explicitly enable the hook for each Operation
-			enableForOperations?: Operations[];
-			// enableForAllOperations will disregard the enableForOperations property and enable the hook for all operations
-			enableForAllOperations?: boolean;
-		};
-	};
-	wsTransport?: {
-		// onConnectionInit is used to populate 'connection_init' message payload with custom data
-		// it can be used to authenticate the websocket connection
-		onConnectionInit?: {
-			hook: (hook: WsTransportHookRequest) => Promise<WsTransportOnConnectionInitResponse>;
-			/**
-			 * enableForDataSources will enable the hook for specific data sources.
-			 * you should provide a list of data sources ids
-			 * an id is the identifier of the data source in the wundergraph.config.ts file
-			 * @example
-			 *const chat = introspect.graphql({
-			 *	id: 'chatId',
-			 *	apiNamespace: 'chat',
-			 *	url: 'http://localhost:8085/query',
-			 *});
-			 */
-			enableForDataSources: DataSources[];
-		};
-	};
-}
         
 export type JSONValue =
     | string
@@ -92,75 +32,42 @@ export type JSONValue =
 
 export type JSONObject = { [key: string]: JSONValue };
 										
-export interface HookRequest extends BaseRequestContext<User, InternalClient, InternalOperationsClient> {}
+export interface HookContext extends BaseRequestContext<User, InternalClient, InternalOperationsClient> {}
 
-export interface HookRequestWithResponse<Response> extends HookRequest {
-		response: Response;
-}
+export type HooksConfig = HooksConfiguration<
+	QueryHooks,
+	MutationHooks,
+	SubscriptionHooks,
+	UploadHooks,
+	DATA_SOURCES,
+	HookContext
+>;
 
-export interface HookRequestWithInput<Input> extends HookRequest {
-		input: Input; 
-}
-						
-export interface HooksConfig
-	extends HooksConfiguration<Queries, Mutations, Subscriptions, Uploads, User, InternalClient, GlobalHooksConfig<WUNDERGRAPH_OPERATION, DATA_SOURCES>> {
-	authentication?: {
-		postAuthentication?: (hook: AuthenticationHookRequest<User, InternalClient>) => Promise<void>;
-		mutatingPostAuthentication?: (
-			hook: AuthenticationHookRequest<User, InternalClient>
-		) => Promise<AuthenticationResponse<User>>;
-		revalidate?: (hook: AuthenticationHookRequest<User, InternalClient>) => Promise<AuthenticationResponse<User>>;
-		postLogout?: (hook: AuthenticationHookRequest<User, InternalClient>) => Promise<void>;
-	};
-	queries?: Queries;
-	mutations?: Mutations;
-	subscriptions?: Subscriptions;
-}
-
-export interface Queries {
+export type QueryHooks = {
 {{#if hasQueries}}
-    {{#each queries}}
-        {{operationName}}?: {
-        mockResolve?: (hook: {{#if hasInternalInput}}HookRequestWithInput<Injected{{operationName}}Input>{{else}}HookRequest{{/if}}) => Promise<{{operationName}}Response>;
-        preResolve?: (hook: {{#if hasInternalInput}}HookRequestWithInput<Injected{{operationName}}Input>{{else}}HookRequest{{/if}}) => Promise<void>;
-        {{#if hasInternalInput}} mutatingPreResolve?: (hook: {{#if hasInternalInput}}HookRequestWithInput<Injected{{operationName}}Input>{{else}}HookRequest{{/if}}) => Promise<Injected{{operationName}}Input>;{{/if}}
-        postResolve?: (hook: {{#if hasInternalInput}}HookRequestWithInput<Injected{{operationName}}Input>{{else}}HookRequest{{/if}} & HookRequestWithResponse<{{operationName}}Response>) => Promise<void>;
-        customResolve?: (hook: {{#if hasInternalInput}}HookRequestWithInput<Injected{{operationName}}Input>{{else}}HookRequest{{/if}}) => Promise<void | {{operationName}}Response | null>;
-        mutatingPostResolve?: (hook: {{#if hasInternalInput}}HookRequestWithInput<Injected{{operationName}}Input>{{else}}HookRequest{{/if}} & HookRequestWithResponse<{{operationName}}Response>) => Promise<{{operationName}}Response>;
-        }
-    {{/each}}
+	{{#each queries}}
+		{{operationName}}?: QueryHook<{{#if hasInternalInput}}Injected{{operationName}}Input{{else}}undefined{{/if}}, {{operationName}}Response, HookContext>,
+	{{/each}}
 {{/if}}
 }
 
-export interface Mutations {
+export type MutationHooks ={
 {{#if hasMutations}}
-    {{#each mutations}}
-        {{operationName}}?: {
-        mockResolve?: (hook: {{#if hasInternalInput}}HookRequestWithInput<Injected{{operationName}}Input>{{else}}HookRequest{{/if}}) => Promise<{{operationName}}Response>;
-        preResolve?: (hook: {{#if hasInternalInput}}HookRequestWithInput<Injected{{operationName}}Input>{{else}}HookRequest{{/if}}) => Promise<void>;
-        {{#if hasInternalInput}} mutatingPreResolve?: (hook: {{#if hasInternalInput}}HookRequestWithInput<Injected{{operationName}}Input>{{else}}HookRequest{{/if}}) => Promise<Injected{{operationName}}Input>;{{/if}}
-        postResolve?: (hook: {{#if hasInternalInput}}HookRequestWithInput<Injected{{operationName}}Input>{{else}}HookRequest{{/if}} & HookRequestWithResponse<{{operationName}}Response>) => Promise<void>;
-        customResolve?: (hook: {{#if hasInternalInput}}HookRequestWithInput<Injected{{operationName}}Input>{{else}}HookRequest{{/if}}) => Promise<void | {{operationName}}Response>;
-        mutatingPostResolve?: (hook: {{#if hasInternalInput}}HookRequestWithInput<Injected{{operationName}}Input>{{else}}HookRequest{{/if}} & HookRequestWithResponse<{{operationName}}Response>) => Promise<{{operationName}}Response>;
-        }
-    {{/each}}
+	{{#each mutations}}
+		{{operationName}}?: MutationHook<{{#if hasInternalInput}}Injected{{operationName}}Input{{else}}undefined{{/if}}, {{operationName}}Response, HookContext>,
+	{{/each}}
 {{/if}}
 }
 
-export interface Subscriptions {
+export type SubscriptionHooks = {
 {{#if hasSubscriptions}}
-		{{#each subscriptions}}
-				{{operationName}}?: {
-        preResolve?: (hook: {{#if hasInternalInput}}HookRequestWithInput<Injected{{operationName}}Input>{{else}}HookRequest{{/if}}) => Promise<void>;
-        {{#if hasInternalInput}} mutatingPreResolve?: (hook: {{#if hasInternalInput}}HookRequestWithInput<Injected{{operationName}}Input>{{else}}HookRequest{{/if}}) => Promise<Injected{{operationName}}Input>;{{/if}}
-        postResolve?: (hook: {{#if hasInternalInput}}HookRequestWithInput<Injected{{operationName}}Input>{{else}}HookRequest{{/if}} & HookRequestWithResponse<{{operationName}}Response>) => Promise<void>;
-        mutatingPostResolve?: (hook: {{#if hasInternalInput}}HookRequestWithInput<Injected{{operationName}}Input>{{else}}HookRequest{{/if}} & HookRequestWithResponse<{{operationName}}Response>) => Promise<{{operationName}}Response>;
-        }
-		{{/each}}
+	{{#each subscriptions}}
+		{{operationName}}?: SubscriptionHook<{{#if hasInternalInput}}Injected{{operationName}}Input{{else}}undefined{{/if}}, {{operationName}}Response, HookContext>,
+	{{/each}}
 {{/if}}
 }
 
-export interface Uploads {
+export interface UploadHooks {
     {{#each uploadProviders}}
         {{name}}?: {
             {{#each uploadProfiles}}

--- a/packages/sdk/src/server/index.ts
+++ b/packages/sdk/src/server/index.ts
@@ -19,6 +19,9 @@ export type {
 	WunderGraphResponse,
 	WunderGraphServerConfig,
 	WunderGraphUser,
+	QueryHook,
+	MutationHook,
+	SubscriptionHook,
 } from './types';
 export type {
 	SubscriptionRequestOptions,

--- a/packages/sdk/src/server/server.ts
+++ b/packages/sdk/src/server/server.ts
@@ -73,9 +73,9 @@ if (process.env.START_HOOKS_SERVER === 'true') {
 }
 
 export function configureWunderGraphServer<
-	GeneratedHooksConfig extends HooksConfiguration,
-	GeneratedInternalClient extends InternalClient,
-	GeneratedWebhooksConfig extends WebhooksConfig
+	GeneratedHooksConfig extends HooksConfiguration = HooksConfiguration,
+	GeneratedInternalClient extends InternalClient = InternalClient,
+	GeneratedWebhooksConfig extends WebhooksConfig = WebhooksConfig
 >(configWrapper: () => WunderGraphServerConfig<GeneratedHooksConfig, GeneratedWebhooksConfig>) {
 	return _configureWunderGraphServer<GeneratedHooksConfig, GeneratedWebhooksConfig>(configWrapper());
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

## Motivation and Context

This improves and simplifies the generated hooks server types and make them more strict and extensible.

#### Checklist

- [ ] run `make test`
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)
