### PR TITLE
fix: graphql schema extensions

### DIFF
--- a/packages/sdk/src/definition/database-introspection.ts
+++ b/packages/sdk/src/definition/database-introspection.ts
@@ -48,7 +48,10 @@ const introspectDatabase = async (
 	}
 	const schemaDocumentNode = parse(graphql_schema);
 	const schema = print(schemaDocumentNode);
-	const { RootNodes, ChildNodes, Fields } = configuration(schemaDocumentNode);
+	const { RootNodes, ChildNodes, Fields } = configuration(schemaDocumentNode, {
+		url: '',
+		schemaExtension: introspection.schemaExtension,
+	});
 	const jsonFields = [...jsonTypeFields, ...jsonResponseFields];
 	jsonFields.forEach((field) => {
 		const fieldConfig = Fields.find((f) => f.typeName == field.typeName && f.fieldName == field.fieldName);

--- a/packages/sdk/src/graphql/configuration.test.ts
+++ b/packages/sdk/src/graphql/configuration.test.ts
@@ -627,7 +627,7 @@ describe('configuration', () => {
 		({ schema: tSchema, serviceSDL: tServiceSDL, argumentReplacements: tArgumentReplacements, config }) => {
 			const schema = parse(tSchema);
 			const serviceSDL = tServiceSDL === undefined ? undefined : parse(tServiceSDL);
-			const nodes = configuration(schema, undefined, serviceSDL, tArgumentReplacements);
+			const nodes = configuration(schema, { url: '' }, serviceSDL, tArgumentReplacements);
 			assert.equal(pretty(nodes), pretty(config));
 		}
 	);

--- a/packages/sdk/src/transformations/replaceCustomScalars.ts
+++ b/packages/sdk/src/transformations/replaceCustomScalars.ts
@@ -11,12 +11,9 @@ export const replaceCustomScalars = (
 	schemaSDL: string,
 	introspection: GraphQLIntrospection | OpenAPIIntrospection
 ): ReplaceCustomScalarsResult => {
-	if (introspection.schemaExtension) {
-		schemaSDL = schemaSDL + ' ' + introspection.schemaExtension;
-	} else {
+	if (introspection.replaceCustomScalarTypeFields?.length === 0) {
 		return { schemaSDL, customScalarTypeFields: [] };
 	}
-
 	let insideCustomScalarType = false;
 	let insideCustomScalarField = false;
 	let replaceCustomScalarType: ReplaceCustomScalarTypeFieldConfiguration | undefined;

--- a/packages/testsuite/apps/basic/.wundergraph/operations/schema-extensions/ExtensionWithHook.graphql
+++ b/packages/testsuite/apps/basic/.wundergraph/operations/schema-extensions/ExtensionWithHook.graphql
@@ -1,0 +1,8 @@
+{
+	spacex_capsule(id: "C205") {
+		id
+		type
+		status
+		myCustomField
+	}
+}

--- a/packages/testsuite/apps/basic/.wundergraph/operations/schema-extensions/ExtensionWithoutHook.graphql
+++ b/packages/testsuite/apps/basic/.wundergraph/operations/schema-extensions/ExtensionWithoutHook.graphql
@@ -1,0 +1,8 @@
+{
+	spacex_capsule(id: "C205") {
+		id
+		type
+		status
+		myCustomField
+	}
+}

--- a/packages/testsuite/apps/basic/.wundergraph/wundergraph.config.ts
+++ b/packages/testsuite/apps/basic/.wundergraph/wundergraph.config.ts
@@ -40,9 +40,22 @@ const usersPost = introspect.prisma({
 	},
 });
 
+const spacex = introspect.graphql({
+	apiNamespace: 'spacex',
+	url: 'https://spacex-api.fly.dev/graphql/',
+	schemaExtension: `
+	extend type Capsule {
+		myCustomField: String
+	}
+	`,
+	introspection: {
+		disableCache: true,
+	},
+});
+
 // configureWunderGraph emits the configuration
 configureWunderGraphApplication({
-	apis: [weather, countries, chinook, usersPost, geojson],
+	apis: [weather, countries, chinook, usersPost, geojson, spacex],
 	server,
 	operations,
 	generate,

--- a/packages/testsuite/apps/basic/.wundergraph/wundergraph.server.ts
+++ b/packages/testsuite/apps/basic/.wundergraph/wundergraph.server.ts
@@ -4,7 +4,22 @@ import { GraphQLExecutionContext } from './generated/wundergraph.server';
 
 export default configureWunderGraphServer(() => ({
 	hooks: {
-		queries: {},
+		queries: {
+			Schema_extensionsExtensionWithHook: {
+				mutatingPostResolve: async ({ response }) => {
+					return {
+						...response,
+						data: {
+							...response.data,
+							spacex_capsule: {
+								...response.data?.spacex_capsule,
+								myCustomField: 'resolved by mutatingPostResolve hook',
+							},
+						},
+					};
+				},
+			},
+		},
 		mutations: {},
 	},
 	graphqlServers: [

--- a/packages/testsuite/apps/basic/schema-extensions.test.ts
+++ b/packages/testsuite/apps/basic/schema-extensions.test.ts
@@ -1,0 +1,39 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { createTestServer } from './.wundergraph/generated/testing';
+
+const wg = createTestServer({
+	dir: __dirname,
+});
+
+beforeAll(async () => {
+	await wg.start();
+
+	return async () => {
+		await wg.stop();
+	};
+});
+
+describe('Schema Extensions', () => {
+	it('Should call operation with optional extension field', async () => {
+		const client = wg.client();
+
+		const { data, error } = await client.query({
+			operationName: 'schema-extensions/ExtensionWithoutHook',
+		});
+
+		expect(error).toBeUndefined();
+		expect(data?.spacex_capsule?.id).toBeDefined();
+		expect(data?.spacex_capsule?.myCustomField).toBeNull();
+	});
+	it('Should return optional extension field from mutatingPostResolve hook', async () => {
+		const client = wg.client();
+
+		const { data, error } = await client.query({
+			operationName: 'schema-extensions/ExtensionWithHook',
+		});
+
+		expect(error).toBeUndefined();
+		expect(data?.spacex_capsule?.id).toBeDefined();
+		expect(data?.spacex_capsule?.myCustomField).toEqual('resolved by mutatingPostResolve hook');
+	});
+});

--- a/testapps/default/.wundergraph/operations/schema-extensions/ExtensionWithHook.graphql
+++ b/testapps/default/.wundergraph/operations/schema-extensions/ExtensionWithHook.graphql
@@ -1,0 +1,8 @@
+{
+	spacex_capsule(id: "C205") {
+		id
+		type
+		status
+		myCustomField
+	}
+}

--- a/testapps/default/.wundergraph/operations/schema-extensions/ExtensionWithoutHook.graphql
+++ b/testapps/default/.wundergraph/operations/schema-extensions/ExtensionWithoutHook.graphql
@@ -1,0 +1,8 @@
+{
+	spacex_capsule(id: "C205") {
+		id
+		type
+		status
+		myCustomField
+	}
+}

--- a/testapps/default/.wundergraph/wundergraph.config.ts
+++ b/testapps/default/.wundergraph/wundergraph.config.ts
@@ -54,6 +54,14 @@ const federatedApi = introspect.federation({
 const spacex = introspect.graphql({
 	apiNamespace: 'spacex',
 	url: 'https://spacex-api.fly.dev/graphql/',
+	schemaExtension: `
+	extend type Capsule {
+		myCustomField: String
+	}
+	`,
+	introspection: {
+		disableCache: true,
+	},
 });
 
 const countries = introspect.graphql({

--- a/testapps/default/.wundergraph/wundergraph.server.ts
+++ b/testapps/default/.wundergraph/wundergraph.server.ts
@@ -83,6 +83,21 @@ export default configureWunderGraphServer(() => ({
 					hook.log.info('customResolver hook for Albums');
 				},
 			},
+			Schema_extensionsExtensionWithHook: {
+				mutatingPostResolve: async ({ response }) => {
+					console.log('mutatingPostResolve hook for Schema_extensionsExtensionWithHook');
+					return {
+						...response,
+						data: {
+							...response.data,
+							spacex_capsule: {
+								...response.data?.spacex_capsule,
+								myCustomField: 'resolved by mutatingPostResolve hook',
+							},
+						},
+					};
+				},
+			},
 		},
 		mutations: {
 			SDL: {


### PR DESCRIPTION
## Motivation and Context

This PR enables users to manually extend an introspected GraphQL Schema and resolve it via a mutatingPostResolve hook.

## Marketing Changelog

When dealing with 3rd party GraphQL APIs that are not under your control, you might want to extend the introspected GraphQL schema and add custom logic to resolve a computed field. This is now possible using the `schemaExtension` property on the `introspect.graphql` config, and the `mutatingPostResolve` hook to resolve the field.