### PR TITLE
fix: polling for federation sources, allow individual configuration

### DIFF
--- a/packages/sdk/src/configure/index.ts
+++ b/packages/sdk/src/configure/index.ts
@@ -437,6 +437,14 @@ const resolveConfig = async (
 	const generators = await Promise.all(config.apis);
 	const resolvedApis = await Promise.all(generators.map((generator) => generator(apiIntrospectionOptions)));
 
+	if (WG_DATA_SOURCE_POLLING_MODE) {
+		// To avoid having to deal with different return types, exit here when running in
+		// WG_DATA_SOURCE_POLLING_MODE. If there are any APIs with polling enabled this point
+		// will never be reached because we'll keep waiting while resolving the APIs while the
+		// polling runs at regular intervals.
+		process.exit(0);
+	}
+
 	const resolved = await resolveApplication(
 		roles,
 		customClaims,
@@ -738,17 +746,6 @@ export const configureWunderGraphApplication = <
 >(
 	config: WunderGraphConfigApplicationConfig<TCustomClaim, TPublicClaim>
 ) => {
-	if (WG_DATA_SOURCE_POLLING_MODE) {
-		// if the DataSourcePolling environment variable is set to 'true',
-		// we don't run the regular config build process which would generate the whole config
-		// instead, we only resolve all Promises of the API Introspection
-		// This will keep polling the (configured) DataSources until `wunderctl up` stops the polling process
-		// If a change is detected in the DataSource, the cache is updated,
-		// which will trigger a re-run of the config build process
-		Promise.all(config.apis).catch();
-		return;
-	}
-
 	const wgDirAbs = process.env.WG_DIR_ABS;
 	if (!wgDirAbs) {
 		throw new Error('environment variable WG_DIR_ABS is empty');

--- a/packages/sdk/src/definition/federation-introspection.ts
+++ b/packages/sdk/src/definition/federation-introspection.ts
@@ -111,9 +111,9 @@ export const introspectFederation = async (introspection: GraphQLFederationIntro
 
 			const graphQLIntrospections: GraphQLIntrospection[] = introspection.upstreams.map((upstream) => ({
 				...upstream,
-				isFederation: true,
 				apiNamespace: introspection.apiNamespace,
 				id: upstream.id ?? introspection.id,
+				isFederation: true,
 			}));
 
 			const apis = await Promise.all(graphQLIntrospections.map((i) => introspectGraphql(i, options)));

--- a/packages/sdk/src/definition/index.ts
+++ b/packages/sdk/src/definition/index.ts
@@ -256,7 +256,7 @@ export interface GraphQLIntrospection extends GraphQLUpstream, GraphQLIntrospect
 export interface GraphQLFederationUpstream extends Omit<Omit<GraphQLUpstream, 'introspection'>, 'apiNamespace'> {
 	name?: string;
 	loadSchemaFromString?: GraphQLIntrospectionOptions['loadSchemaFromString'];
-	introspection?: GraphqlIntrospectionHeaders;
+	introspection?: IntrospectionFetchOptions & GraphqlIntrospectionHeaders;
 }
 
 export interface GraphQLFederationIntrospection extends IntrospectionConfiguration {
@@ -289,6 +289,11 @@ export interface PrismaIntrospection extends IntrospectionConfiguration {
 	replaceCustomScalarTypeFields?: ReplaceCustomScalarTypeFieldConfiguration[];
 }
 
+export interface IntrospectionFetchOptions {
+	disableCache?: boolean;
+	pollingIntervalSeconds?: number;
+}
+
 export interface IntrospectionConfiguration {
 	// id is the unique identifier for the data source
 	id?: string;
@@ -301,10 +306,7 @@ export interface IntrospectionConfiguration {
 	 * @defaultValue Use the default timeout for this node.
 	 */
 	requestTimeoutSeconds?: number;
-	introspection?: {
-		disableCache?: boolean;
-		pollingIntervalSeconds?: number;
-	};
+	introspection?: IntrospectionFetchOptions;
 }
 
 export interface HTTPUpstream extends IntrospectionConfiguration {
@@ -365,7 +367,7 @@ export interface GraphQLUpstream extends HTTPUpstream {
 	path?: InputVariable;
 	subscriptionsURL?: InputVariable;
 	subscriptionsUseSSE?: boolean;
-	introspection?: HTTPUpstream['introspection'] & GraphqlIntrospectionHeaders;
+	introspection?: IntrospectionFetchOptions & GraphqlIntrospectionHeaders;
 }
 
 export interface OpenAPIIntrospectionFile {

--- a/packages/sdk/src/localcache/index.ts
+++ b/packages/sdk/src/localcache/index.ts
@@ -157,10 +157,19 @@ export class LocalCacheBucket {
 		}
 	}
 
-	async set(key: any, data: string, opts?: CacheSetOptions): Promise<void> {
+	/**
+	 * set stores the given into data into the cache associated with the provided key
+	 * and overwriting previous entries under the same key
+	 *
+	 * @param key cache key to store the data under
+	 * @param data data to store
+	 * @param opts options for storing the data
+	 * @returns true if the value could be stored, false otherwise
+	 */
+	async set(key: any, data: string, opts?: CacheSetOptions): Promise<boolean> {
 		const filePath = this.keyPath(key);
 		if (!filePath) {
-			return;
+			return false;
 		}
 		const ttlSeconds = opts?.ttlSeconds ?? 0;
 		const expiration = ttlSeconds !== 0 ? Date.now() / 1000 + ttlSeconds : 0;
@@ -171,7 +180,9 @@ export class LocalCacheBucket {
 			await this.write(filePath, buf);
 		} catch (e: any) {
 			logger.error(`error storing cache entry at ${filePath}: ${e}`);
+			return false;
 		}
+		return true;
 	}
 
 	async getJSON(key: any, opts?: CacheGetOptions): Promise<any> {
@@ -186,15 +197,25 @@ export class LocalCacheBucket {
 		return undefined;
 	}
 
-	async setJSON(key: any, data: any, opts?: CacheSetOptions): Promise<void> {
+	/**
+	 * setJSON encodes the given data with JSON, then stores the given into data into the cache
+	 * associated with the provided key and overwriting previous entries under the same key
+	 *
+	 * @param key cache key to store the data under
+	 * @param data data to store
+	 * @param opts options for storing the data
+	 * @returns true if the value could be stored, false otherwise
+	 */
+
+	async setJSON(key: any, data: any, opts?: CacheSetOptions): Promise<boolean> {
 		let encoded: string;
 		try {
 			encoded = JSON.stringify(data);
 		} catch (e: any) {
 			logger.error(`error storing encoding cached data: ${e}`);
-			return;
+			return false;
 		}
 
-		await this.set(key, encoded, opts);
+		return await this.set(key, encoded, opts);
 	}
 }

--- a/packages/testsuite/apps/basic/polling.test.ts
+++ b/packages/testsuite/apps/basic/polling.test.ts
@@ -1,0 +1,23 @@
+import path from 'path';
+
+import execa from 'execa';
+import { expect, describe, it } from 'vitest';
+
+describe('Test polling', () => {
+	it('should not exit if there are any APIs with polling', async () => {
+		const wgDir = path.join('apps', 'basic', '.wundergraph');
+		const proc = execa('node', ['generated/bundle/config.cjs'], {
+			env: {
+				WUNDERGRAPH_CACHE_DIR: path.join(wgDir, 'tempcache'),
+				WG_DATA_SOURCE_POLLING_MODE: 'true',
+				WG_DIR_ABS: wgDir,
+			},
+			cwd: wgDir,
+			stdio: 'inherit',
+		});
+		// Wait 3 seconds and see if the process exited
+		await new Promise((r) => setTimeout(r, 3000));
+		expect(proc.exitCode).toBeNull();
+		proc.kill();
+	});
+});


### PR DESCRIPTION
Each upstream can now set its own settings for the poll interval.
Also, add a test to ensure that introspection keeps running in the background

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

## Marketing Changelog

<!--
What changes does this PR introduce? Please describe the changes in simple terms that a user can understand
without being familiar with the codebase. Mention @advocates for review and tracking.
-->

#### Checklist

- [ ] run `make test`
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)
