### PR TITLE
feat: add support for caching in function handlers

### DIFF
--- a/packages/sdk/src/configure/index.ts
+++ b/packages/sdk/src/configure/index.ts
@@ -1598,6 +1598,11 @@ const applyNodeJsOperationOverrides = (
 			pollingIntervalSeconds: overrides.liveQuery.pollingIntervalSeconds,
 		};
 	}
+	if (overrides.cache) {
+		operation.CacheConfig = {
+			...overrides.cache,
+		};
+	}
 	if (overrides.requireAuthentication) {
 		operation.AuthenticationConfig = {
 			required: overrides.requireAuthentication,

--- a/packages/sdk/src/configure/operations.ts
+++ b/packages/sdk/src/configure/operations.ts
@@ -12,17 +12,20 @@ export interface BaseOperationConfiguration {
 	};
 }
 
+export interface QueryCacheConfiguration {
+	enable: boolean;
+	public: boolean;
+	maxAge: number;
+	staleWhileRevalidate: number;
+}
+
+export interface LiveQueryConfiguration {
+	enable: boolean;
+	pollingIntervalSeconds: number;
+}
 export interface QueryConfiguration extends BaseOperationConfiguration {
-	caching: {
-		enable: boolean;
-		public: boolean;
-		maxAge: number;
-		staleWhileRevalidate: number;
-	};
-	liveQuery: {
-		enable: boolean;
-		pollingIntervalSeconds: number;
-	};
+	caching: QueryCacheConfiguration;
+	liveQuery: LiveQueryConfiguration;
 }
 
 export interface MutationConfiguration extends BaseOperationConfiguration {}

--- a/packages/sdk/src/operations/index.ts
+++ b/packages/sdk/src/operations/index.ts
@@ -3,12 +3,13 @@ export { z } from 'zod';
 export type {
 	ExtractInput,
 	ExtractResponse,
-	LiveQueryConfig,
+	LiveQueryConfiguration,
 	SubscriptionHandler,
 	BaseOperationConfiguration,
 	HandlerContext,
 	NodeJSOperation,
 	OperationTypes,
+	QueryCacheConfiguration,
 } from './operations';
 export type {
 	GraphQLError,

--- a/packages/testsuite/apps/basic/.wundergraph/operations/functions/greeting.ts
+++ b/packages/testsuite/apps/basic/.wundergraph/operations/functions/greeting.ts
@@ -7,4 +7,9 @@ export default createOperation.query({
 	handler: async ({ input }) => {
 		return 'Hello I am ' + input.name;
 	},
+	cache: {
+		public: true,
+		maxAge: 60,
+		staleWhileRevalidate: 120,
+	},
 });

--- a/packages/testsuite/apps/basic/apicache.test.ts
+++ b/packages/testsuite/apps/basic/apicache.test.ts
@@ -1,0 +1,40 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { createTestServer } from './.wundergraph/generated/testing';
+
+const wg = createTestServer({
+	dir: __dirname,
+});
+
+beforeAll(async () => {
+	await wg.start();
+
+	return async () => {
+		await wg.stop();
+	};
+});
+
+const operationUrl = (operationPath: string) => {
+	return wg.url(`/operations/${operationPath}`);
+};
+
+const fetchOperationUrl = (operationPath: string) => {
+	return fetch(operationUrl(operationPath));
+};
+
+describe('API Cache', () => {
+	it('should not have cache headers in handlers without cache', async () => {
+		const resp = await fetchOperationUrl('functions/simple');
+		expect(resp.status).toBe(200);
+		expect(resp.headers.get('cache-control')).toBeNull();
+	});
+
+	it('should have cache headers in handlers cache', async () => {
+		const resp = await fetchOperationUrl('functions/greeting?name=Pepe');
+		expect(resp.status).toBe(200);
+		const cacheControl = resp.headers.get('cache-control');
+		expect(cacheControl).not.toBeNull();
+		expect(cacheControl).toMatch(/public/);
+		expect(cacheControl).toMatch(/max-age=60/);
+		expect(cacheControl).toMatch(/stale-while-revalidate=120/);
+	});
+});

--- a/pkg/apihandler/apihandler_test.go
+++ b/pkg/apihandler/apihandler_test.go
@@ -938,13 +938,12 @@ func TestQueryHandler_Caching(t *testing.T) {
 			Response: &resolve.GraphQLResponse{},
 		},
 		pool: pool.New(),
-		cacheConfig: cacheConfig{
-			enable:               true,
-			maxAge:               2,
-			public:               true,
-			staleWhileRevalidate: 0,
-		},
-		cache:                  cache,
+		cache: newCacheHandler(cache, &wgpb.OperationCacheConfig{
+			Enable:               true,
+			MaxAge:               2,
+			Public:               true,
+			StaleWhileRevalidate: 0,
+		}, ""),
 		operation:              operation,
 		rbacEnforcer:           &authentication.RBACEnforcer{},
 		stringInterpolator:     interpolateNothing,
@@ -973,7 +972,7 @@ func TestQueryHandler_Caching(t *testing.T) {
 	res.Headers().ValueEqual(WgCacheHeader, []string{"MISS"})
 	res.Body().Equal(`{"data":{"me":{"name":"Jens"}}}`)
 
-	handler.cacheConfig.public = false
+	handler.cache.config.Public = false
 
 	time.Sleep(time.Second)
 

--- a/pkg/apihandler/cache.go
+++ b/pkg/apihandler/cache.go
@@ -1,0 +1,175 @@
+package apihandler
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/cespare/xxhash"
+	"github.com/wundergraph/wundergraph/pkg/apicache"
+	"github.com/wundergraph/wundergraph/pkg/wgpb"
+)
+
+type cacheConfig struct {
+	Enable               bool
+	MaxAge               int64
+	Public               bool
+	StaleWhileRevalidate int64
+}
+
+// cacheHandler holds the cache configuration and data structures for an operation handler.
+// To create a cacheHandler, use newCacheHandler()
+type cacheHandler struct {
+	config cacheConfig
+	cache  apicache.Cache
+	// configHash is the hash of the full application configuration. We use it as part
+	// of the cache keys to ensure any changes to the config invalidate the cache
+	configHash []byte
+}
+
+// newCacheHandler returns a new cacheHandler from an apicache.Cache, an wgpb.OperationCacheConfig representing
+// the cache configuration for an operation and the API configuration hash (typically from Api.ApiConfigHash)
+func newCacheHandler(cache apicache.Cache, config *wgpb.OperationCacheConfig, configHash string) *cacheHandler {
+	return &cacheHandler{
+		config: cacheConfig{
+			Enable:               config.Enable,
+			MaxAge:               config.MaxAge,
+			Public:               config.Public,
+			StaleWhileRevalidate: config.StaleWhileRevalidate,
+		},
+		cache:      cache,
+		configHash: []byte(configHash),
+	}
+}
+
+// RequestHandler returns a handler for a single operation request, deriving the key from the
+// cacheHandler's configHash and the request URI. The requestCacheHandler will be enabled or
+// disabled based on the cacheHandler's config. A disabled requestCacheHandler will not append
+// Cache-Control/Age headers, will never lookup items in its cache and won't store them either.
+//
+// See also requestCacheHandler.
+func (c *cacheHandler) RequestHandler(r *http.Request, w http.ResponseWriter) *requestCacheHandler {
+	return &requestCacheHandler{
+		handler: c,
+		r:       r,
+		w:       w,
+		key:     string(c.configHash) + r.RequestURI,
+	}
+}
+
+// requestCacheHandler holds the cache related data for a given API requests. You should create
+// a requestCacheHandler early in the request, try to serve cached data via Serve and, if that fails,
+// regenerate the data and call SetHeaders() to provide the appropriate headers followed by
+// Store() to store the data.
+//
+// requestCacheHandler methods are all nil-safe, in the sense that calling them with a nil receiver
+// will result in a no-op. This voids moving some checks from the handlers into requestCacheHandler's
+// method, making the operation handling logic more straightforward.
+type requestCacheHandler struct {
+	handler *cacheHandler
+	r       *http.Request
+	w       http.ResponseWriter
+	key     string
+	isStale bool
+}
+
+func (c *requestCacheHandler) isEnabled() bool {
+	return c != nil && c.handler.config.Enable
+}
+
+// ETag returns a en ETag derived from the config hash and the received data
+func (c *requestCacheHandler) ETag(data []byte) string {
+	hash := xxhash.New()
+	_, _ = hash.Write(c.handler.configHash)
+	_, _ = hash.Write(data)
+	return fmt.Sprintf("W/\"%d\"", hash.Sum64())
+}
+
+// SetETag generates an ETag via ETag(), then sets it as the ETag header and
+// returns the ETag value.
+func (c *requestCacheHandler) SetETag(data []byte) string {
+	etag := c.ETag(data)
+	c.w.Header()["ETag"] = []string{etag}
+	return etag
+}
+
+// SetHeaders adds Cache-Control and Age headers to the response using Header().Set() in the
+// requestCacheHandler' http.ResponseWriter iff the cache is enabled. Otherwise it's a no-op.
+func (c *requestCacheHandler) SetHeaders(age int64) {
+	if !c.isEnabled() {
+		return
+	}
+	config := &c.handler.config
+
+	publicOrPrivate := "private"
+	if config.Public {
+		publicOrPrivate = "public"
+	}
+	c.w.Header().Set("Cache-Control", fmt.Sprintf("%s, max-age=%d, stale-while-revalidate=%d", publicOrPrivate, config.MaxAge, config.StaleWhileRevalidate))
+	c.w.Header().Set("Age", fmt.Sprintf("%d", age))
+}
+
+// Serve tries to serve the requestCacheHandler's http.Request from the cache,
+// return true iff the request was entirely served and no further data should
+// be written. If there's no cache hit, it adds the X-Wg-Cache: MISS header
+// and returns false. If the cache is disabled, this is a no-op.
+func (c *requestCacheHandler) Serve(ctx context.Context) (bool, error) {
+	if !c.isEnabled() {
+		return false, nil
+	}
+	item, hit := c.handler.cache.Get(ctx, c.key)
+	if hit {
+
+		c.w.Header().Set(WgCacheHeader, "HIT")
+
+		etag := c.SetETag(item.Data)
+		age := item.Age()
+		c.SetHeaders(item.Age())
+		c.isStale = age > c.handler.config.MaxAge
+
+		ifNoneMatch := c.r.Header.Get("If-None-Match")
+		if ifNoneMatch == etag {
+			c.w.WriteHeader(http.StatusNotModified)
+			return true, nil
+		}
+
+		c.w.WriteHeader(http.StatusOK)
+		if _, err := c.w.Write(item.Data); err != nil {
+			return true, err
+		}
+		return true, nil
+	} else {
+		c.w.Header().Set(WgCacheHeader, "MISS")
+	}
+	return false, nil
+}
+
+// Store stores the given data under the cache key used for this handler, using the
+// TTL as determined by the configuration. If the cache is disabled, this is a no-op.
+func (c *requestCacheHandler) Store(data []byte) {
+	if !c.isEnabled() {
+		return
+	}
+	cacheData := make([]byte, len(data))
+	copy(cacheData, data)
+
+	config := &c.handler.config
+	ttl := time.Second * time.Duration(config.MaxAge+config.StaleWhileRevalidate)
+	c.handler.cache.SetWithTTL(c.key, cacheData, ttl)
+}
+
+// IfStale should be called after the whole request has been served. If the request
+// was served from the cache is now stale, it calls the received generator() function
+// to regenerate the cache and refresh the cache (using Store()). See also (OnStale())
+func (c *requestCacheHandler) IfStale(generator func() ([]byte, error)) error {
+	if !c.isEnabled() || !c.isStale {
+		return nil
+	}
+	data, err := generator()
+	if err != nil {
+		return err
+	}
+	c.Store(data)
+	return nil
+}


### PR DESCRIPTION
- Add a cache argument to functions for creating TS operations
- Refactor cache support from QueryHandler into separate types
- Use these new types to support caches from FunctionHandler
- Add test for checking the response headers

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

## Motivation and Context

GraphQL based functions had configurable cache behaviour. This adds the same features
to TS based operations.

## Marketing Changelog

Added server side support for typescript operations
<!--
What changes does this PR introduce? Please describe the changes in simple terms that a user can understand
without being familiar with the codebase. Mention @advocates for review and tracking.
-->

#### Checklist

- [ ] run `make test`
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)
