### PR TITLE
feat: improve mocking library, support N times and persistent mocks

### DIFF
--- a/docs-website/src/pages/docs/guides/mocking.md
+++ b/docs-website/src/pages/docs/guides/mocking.md
@@ -83,14 +83,19 @@ If you have a demanding test suite, you can create multiple test files and vites
 When you setup a mock with `mock()` and the request matches, the mock server will return the response. If the request does not match, the mock server will return a 404 response and the call to `scope.done()` will fail the test.
 You have also the ability to throw an error inside the response function to fail the mock. This is useful if you want to verify with test assertion that the request is correct. A thrown error is handled as an unmatched request and the next mock will be checked.
 
-The first argument of the `mock` function is a predicate that is used to match the request. The second argument is the function that returns the response.
+The first argument of the `mock` function is an object that accepts the following properties:
+
+- `match` - A function that returns true if the request matches
+- `handler` - A function that returns the response or throws an error
+- `times` - The number of times the mock should be called. Defaults to 1.
+- `persist` - If true, the mock will not be removed after the test. Defaults to false.
 
 ```ts
-const scope = ts.mockServer.mock(
-  async ({ url, method }) => {
+const scope = ts.mockServer.mock({
+  match: ({ url, method }) => {
     return url.path === '/' && method === 'POST';
   },
-  async ({ json }) => {
+  handler: async ({ json }) => {
     const body = await json();
 
     expect(body.variables.code).toEqual('ES');
@@ -115,8 +120,8 @@ const scope = ts.mockServer.mock(
         },
       },
     };
-  }
-);
+  },
+});
 ```
 
 ### Make a request and validate the mock
@@ -140,6 +145,18 @@ scope.done();
 expect(result.error).toBeUndefined();
 expect(result.data).toBeDefined();
 expect(result.data?.countries_countries?.[0].capital).toBe('Madrid');
+```
+
+If an assertion fails or any error is thrown inside those handlers, the test will fail and the error will be rethrown when calling `scope.done()`. This ensure that the `Test runner` can handle the error correctly e.g. by printing a stack trace or showing a diff.
+
+```bash
+AssertionError: expected 'ES' to deeply equal 'DE'
+Caused by: No interceptor matched for request POST http://0.0.0.0:36331/
+Expected :DE
+Actual   :ES
+<Click to see difference>
+
+    at Object.handler (/c/app/countries.test.ts:29:33)
 ```
 
 For a full example please check the example in the [WunderGraph repository](https://github.com/wundergraph/wundergraph/tree/main/packages/testsuite/apps/mock/test/mock-datasource.test.ts)

--- a/packages/sdk/src/testing/index.ts
+++ b/packages/sdk/src/testing/index.ts
@@ -1,6 +1,7 @@
-export type { ServerOptions } from './test-server';
+export type { ServerOptions, ServerStartOptions } from './test-server';
 export type { TestServersStartOptions } from './test-servers';
 
 export { WunderGraphMockServer } from './mock-server';
 export { WunderGraphTestServer } from './test-server';
 export { WunderGraphTestServers } from './test-servers';
+export { Scope } from './scope';

--- a/packages/sdk/src/testing/mock-server.test.ts
+++ b/packages/sdk/src/testing/mock-server.test.ts
@@ -11,11 +11,11 @@ describe('Mock server', () => {
 	});
 
 	test('Should be able to mock an endpoint', async () => {
-		const scope = server.mock(
-			async ({ url, method }) => {
+		const scope = server.mock({
+			match: async ({ url, method }) => {
 				return url.path === '/test?a=b' && method === 'GET';
 			},
-			async () => {
+			handler: async () => {
 				return {
 					status: 200,
 					headers: {
@@ -27,8 +27,8 @@ describe('Mock server', () => {
 						},
 					},
 				};
-			}
-		);
+			},
+		});
 
 		const resp = await fetch(`${server.url()}/test?a=b`);
 		const data = await resp.json();
@@ -44,12 +44,12 @@ describe('Mock server', () => {
 		});
 	});
 
-	test('Should be able to mock the same request multiple times', async () => {
-		let scope = server.mock(
-			async ({ url, method }) => {
+	test('Should be able to mock the same request multiple times with different responses', async () => {
+		let scope = server.mock({
+			match: async ({ url, method }) => {
 				return url.path === '/test' && method === 'GET';
 			},
-			async () => {
+			handler: async () => {
 				return {
 					body: {
 						getUser: {
@@ -57,8 +57,8 @@ describe('Mock server', () => {
 						},
 					},
 				};
-			}
-		);
+			},
+		});
 
 		let resp = await fetch(`${server.url()}/test`);
 		let data = await resp.json();
@@ -72,11 +72,11 @@ describe('Mock server', () => {
 			},
 		});
 
-		scope = server.mock(
-			async ({ url, method }) => {
+		scope = server.mock({
+			match: async ({ url, method }) => {
 				return url.path === '/test' && method === 'GET';
 			},
-			async () => {
+			handler: async () => {
 				return {
 					body: {
 						getUser: {
@@ -84,8 +84,8 @@ describe('Mock server', () => {
 						},
 					},
 				};
-			}
-		);
+			},
+		});
 
 		resp = await fetch(`${server.url()}/test`);
 		data = await resp.json();
@@ -100,12 +100,13 @@ describe('Mock server', () => {
 		});
 	});
 
-	test('Should throw an error when mock interceptor could not be found', async () => {
-		const scope = server.mock(
-			async ({ url, method }) => {
-				return url.path === '/does_not_exist';
+	test('Should be able to persist mocks', async () => {
+		let scope = server.mock({
+			persist: true,
+			match: async ({ url, method }) => {
+				return url.path === '/test' && method === 'GET';
 			},
-			async () => {
+			handler: async () => {
 				return {
 					body: {
 						getUser: {
@@ -113,27 +114,119 @@ describe('Mock server', () => {
 						},
 					},
 				};
-			}
-		);
+			},
+		});
+
+		let resp = await fetch(`${server.url()}/test`);
+		let data = await resp.json();
+
+		expect(resp.status).toBe(200);
+		expect(data).toEqual({
+			getUser: {
+				id: '123',
+			},
+		});
+
+		resp = await fetch(`${server.url()}/test`);
+		data = await resp.json();
+
+		expect(resp.status).toBe(200);
+		expect(data).toEqual({
+			getUser: {
+				id: '123',
+			},
+		});
+
+		resp = await fetch(`${server.url()}/test`);
+		data = await resp.json();
+
+		scope.done();
+
+		expect(resp.status).toBe(200);
+		expect(data).toEqual({
+			getUser: {
+				id: '123',
+			},
+		});
+	});
+
+	test('Should be able to use mock for N requests', async () => {
+		let scope = server.mock({
+			times: 2,
+			match: async ({ url, method }) => {
+				return url.path === '/test' && method === 'GET';
+			},
+			handler: async () => {
+				return {
+					body: {
+						getUser: {
+							id: '123',
+						},
+					},
+				};
+			},
+		});
+
+		let resp = await fetch(`${server.url()}/test`);
+		let data = await resp.json();
+
+		expect(() => scope.done()).toThrow('Mock is not done. Expect 1 more call.');
+
+		expect(resp.status).toBe(200);
+		expect(data).toEqual({
+			getUser: {
+				id: '123',
+			},
+		});
+
+		resp = await fetch(`${server.url()}/test`);
+		data = await resp.json();
+
+		scope.done();
+
+		expect(resp.status).toBe(200);
+
+		expect(data).toEqual({
+			getUser: {
+				id: '123',
+			},
+		});
+	});
+
+	test('Should throw an error when mock could not be found', async () => {
+		const scope = server.mock({
+			match: async ({ url, method }) => {
+				return url.path === '/does_not_exist';
+			},
+			handler: async () => {
+				return {
+					body: {
+						getUser: {
+							id: '123',
+						},
+					},
+				};
+			},
+		});
 
 		const resp = await fetch(`${server.url()}/test`);
 
-		expect(() => scope.done()).toThrow('No interceptor matched for request GET /test');
+		expect(() => scope.done()).toThrow('No mock matched for request GET /test');
 
 		expect(resp.status).toBe(404);
 		expect(scope.isDone).toBe(false);
 		expect(scope.error).toBeDefined();
 	});
 
-	test('Should return 404 and throw with original error when handler does not match with any interceptor / handler', async () => {
-		let scope = server.mock(
-			async ({ url, method }) => {
+	test('Should return 404 and throw with original error when handler does not match with any mock / handler', async () => {
+		let scope = server.mock({
+			match: ({ url, method }) => {
 				return url.path === '/test' && method === 'GET';
 			},
-			async () => {
+			handler: () => {
 				throw new Error('Request does not match');
-			}
-		);
+			},
+		});
 
 		let resp = await fetch(`${server.url()}/test`);
 
@@ -142,17 +235,15 @@ describe('Mock server', () => {
 		expect(scope.error).toBeDefined();
 		// @ts-expect-error
 		expect(scope.error.cause).toBeDefined();
-		expect(() => scope.done()).toThrow(
-			'Request does not match\n' + 'Caused by: No interceptor matched for request GET /test'
-		);
+		expect(() => scope.done()).toThrow('Request does not match\n' + 'Caused by: No mock matched for request GET /test');
 
-		// Let's test if the interceptor was reset
+		// Let's test if the mock was reset
 
-		scope = server.mock(
-			async ({ url, method }) => {
+		scope = server.mock({
+			match: ({ url, method }) => {
 				return url.path === '/test' && method === 'GET';
 			},
-			async () => {
+			handler: () => {
 				return {
 					body: {
 						getUser: {
@@ -160,8 +251,8 @@ describe('Mock server', () => {
 						},
 					},
 				};
-			}
-		);
+			},
+		});
 
 		resp = await fetch(`${server.url()}/test`);
 
@@ -177,15 +268,15 @@ describe('Mock server', () => {
 		});
 	});
 
-	test('Should return 404 and throw with original error when handler does not match with any interceptor / match', async () => {
-		let scope = server.mock(
-			async ({ url, method }) => {
+	test('Should return 404 and throw with original error when handler does not match with any mock / match', async () => {
+		let scope = server.mock({
+			match: ({ url, method }) => {
 				throw new Error('Request does not match');
 			},
-			async () => {
+			handler: () => {
 				return {};
-			}
-		);
+			},
+		});
 
 		let resp = await fetch(`${server.url()}/test`);
 
@@ -194,17 +285,15 @@ describe('Mock server', () => {
 		expect(scope.error).toBeDefined();
 		// @ts-expect-error
 		expect(scope.error.cause).toBeDefined();
-		expect(() => scope.done()).toThrow(
-			'Request does not match\n' + 'Caused by: No interceptor matched for request GET /test'
-		);
+		expect(() => scope.done()).toThrow('Request does not match\n' + 'Caused by: No mock matched for request GET /test');
 
-		// Let's test if the interceptor was reset
+		// Let's test if the mock was reset
 
-		scope = server.mock(
-			async ({ url, method }) => {
+		scope = server.mock({
+			match: ({ url, method }) => {
 				return url.path === '/test' && method === 'GET';
 			},
-			async () => {
+			handler: () => {
 				return {
 					body: {
 						getUser: {
@@ -212,8 +301,8 @@ describe('Mock server', () => {
 						},
 					},
 				};
-			}
-		);
+			},
+		});
 
 		resp = await fetch(`${server.url()}/test`);
 
@@ -229,15 +318,15 @@ describe('Mock server', () => {
 		});
 	});
 
-	test('Should return 404 and throw with not found error when handler does not match with any interceptor', async () => {
-		let scope = server.mock(
-			async ({ url, method }) => {
+	test('Should return 404 and throw with not found error when handler does not match with any mock', async () => {
+		let scope = server.mock({
+			match: ({ url, method }) => {
 				return url.path === '/no_match' && method === 'GET';
 			},
-			async () => {
+			handler: () => {
 				return {};
-			}
-		);
+			},
+		});
 
 		let resp = await fetch(`${server.url()}/test`);
 
@@ -246,15 +335,15 @@ describe('Mock server', () => {
 		expect(scope.error).toBeDefined();
 		// @ts-expect-error
 		expect(scope.error.cause).toBeUndefined();
-		expect(() => scope.done()).toThrow('No interceptor matched for request GET /test');
+		expect(() => scope.done()).toThrow('No mock matched for request GET /test');
 
-		// Let's test if the interceptor was reset
+		// Let's test if the mock was reset
 
-		scope = server.mock(
-			async ({ url, method }) => {
+		scope = server.mock({
+			match: ({ url, method }) => {
 				return url.path === '/test' && method === 'GET';
 			},
-			async () => {
+			handler: () => {
 				return {
 					body: {
 						getUser: {
@@ -262,8 +351,8 @@ describe('Mock server', () => {
 						},
 					},
 				};
-			}
-		);
+			},
+		});
 
 		resp = await fetch(`${server.url()}/test`);
 
@@ -275,15 +364,15 @@ describe('Mock server', () => {
 	});
 
 	test('Should be possible to consume the payload twice', async () => {
-		const scope = server.mock(
-			async ({ url, method, json }) => {
+		const scope = server.mock({
+			match: async ({ url, method, json }) => {
 				const body = await json();
 
 				expect(body).toEqual({ a: 'b' });
 
 				return url.path === '/test?a=b' && method === 'POST';
 			},
-			async ({ json }) => {
+			handler: async ({ json }) => {
 				const body = await json();
 
 				expect(body).toEqual({ a: 'b' });
@@ -295,8 +384,8 @@ describe('Mock server', () => {
 					},
 					body,
 				};
-			}
-		);
+			},
+		});
 
 		const resp = await fetch(`${server.url()}/test?a=b`, {
 			method: 'POST',

--- a/packages/sdk/src/testing/scope.ts
+++ b/packages/sdk/src/testing/scope.ts
@@ -1,0 +1,63 @@
+interface ScopeOptions {
+	counter?: number;
+	persist?: boolean;
+}
+
+export class Scope {
+	/**
+	 * The error thrown by the matcher or handler.
+	 */
+	public error?: Error;
+
+	/**
+	 * Counter stores the pending times that the current mock should be active.
+	 */
+	public counter: number;
+
+	/**
+	 *  Persisted stores if the current mock should be always active.
+	 */
+	private readonly persisted: boolean = false;
+
+	/**
+	 * Pending stores the number of pending calls.
+	 */
+	public pending: number = 0;
+
+	constructor(options?: ScopeOptions) {
+		this.counter = options?.counter ?? 1;
+		this.persisted = options?.persist ?? false;
+	}
+
+	/**
+	 * Is true, if the scope is persisted.
+	 */
+	get isPersisted() {
+		return this.persisted;
+	}
+
+	/**
+	 * Is true, no outstanding calls are left.
+	 */
+	get isDone() {
+		if (this.persisted) {
+			return this.pending === 0;
+		}
+		return this.counter === 0;
+	}
+
+	/**
+	 * Throw an error if the scope is not done or an error was thrown.
+	 */
+	done(): void {
+		if (this.error) {
+			throw this.error;
+		}
+		if (!this.isDone) {
+			if (this.persisted) {
+				throw new Error(`Mock is not done. Processing ${this.pending > 1 ? 'calls' : 'call'}: ${this.pending}`);
+			}
+			throw new Error(`Mock is not done. Expect ${this.counter} more ${this.counter > 1 ? 'calls' : 'call'}.`);
+		}
+	}
+}

--- a/packages/testsuite/apps/mock/test/mock-datasource.test.ts
+++ b/packages/testsuite/apps/mock/test/mock-datasource.test.ts
@@ -20,11 +20,11 @@ beforeAll(async () => {
 describe('Mock http datasource', () => {
 	it('Should mock countries origin API', async () => {
 		// Mock the countries origin API
-		const scope = ts.mockServer.mock(
-			({ url, method }) => {
+		const scope = ts.mockServer.mock({
+			match: ({ url, method }) => {
 				return url.path === '/' && method === 'POST';
 			},
-			async ({ json }) => {
+			handler: async ({ json }) => {
 				const body = await json();
 				expect(body.variables.code).toEqual('ES');
 				expect(body.query).toEqual(
@@ -48,8 +48,8 @@ describe('Mock http datasource', () => {
 						},
 					},
 				};
-			}
-		);
+			},
+		});
 
 		const result = await ts.testServer.client().query({
 			operationName: 'CountryByCode',
@@ -66,16 +66,16 @@ describe('Mock http datasource', () => {
 	});
 
 	it('Should not be called because does not match', async () => {
-		const scope = ts.mockServer.mock(
-			async ({ url }) => {
+		const scope = ts.mockServer.mock({
+			match: ({ url }) => {
 				throw new Error(`Unexpected call to ${url}`);
 			},
-			async (req) => {
+			handler: (req) => {
 				expect.fail('This should not be called');
 
 				return {};
-			}
-		);
+			},
+		});
 
 		const result = await ts.testServer.client().query({
 			operationName: 'CountryByCode',


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

This PR simplifies the `.mock` interface to a single object and introduces two new features:

- `match` - A function that returns true if the request matches
- `handler` - A function that returns the response or throws an error
- **`times`** - The number of times the mock should be called. Defaults to 1.
- **`persist`** - If true, the mock will not be removed after the test. Defaults to false.

- Perssitent

```ts
let scope = server.mock({
  times: 2,
  persist: true,
  match: async ({ url, method }) => {
    return url.path === "/test" && method === "GET";
  },
  handler: async () => {
    return {
      body: {
        getUser: {
          id: "123",
        },
      },
    };
  },
});

```

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

## Marketing Changelog

<!--
What changes does this PR introduce? Please describe the changes in simple terms that a user can understand
without being familiar with the codebase. Mention @advocates for review and tracking.
-->

#### Checklist

- [ ] run `make test`
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)
