### PR TITLE
fix: detect all request timeouts correctly

### DIFF
--- a/packages/testsuite/apps/openapi/.wundergraph/wundergraph.config.ts
+++ b/packages/testsuite/apps/openapi/.wundergraph/wundergraph.config.ts
@@ -9,7 +9,7 @@ const notes = introspect.openApiV2({
 		kind: 'file',
 		filePath: './api.yaml',
 	},
-	baseURL: 'http://localhost:8090/',
+	baseURL: new EnvironmentVariable('OPENAPI_URL', 'http://localhost:8090/'),
 });
 
 // configureWunderGraph emits the configuration

--- a/packages/testsuite/apps/openapi/openapi.test.ts
+++ b/packages/testsuite/apps/openapi/openapi.test.ts
@@ -112,7 +112,7 @@ describe('Test error responses', () => {
 	test('handle undeclared 404', async () => await expectHttpStatusCodeInMutation(404));
 	test('handle undeclared 500', async () => await expectHttpStatusCodeInMutation(500));
 
-	test.only('return timeout as 504', async () => {
+	test('return timeout as 504', async () => {
 		const wg = createTestServer({
 			dir: __dirname,
 			env: {

--- a/packages/testsuite/apps/openapi/openapi.test.ts
+++ b/packages/testsuite/apps/openapi/openapi.test.ts
@@ -111,4 +111,27 @@ describe('Test error responses', () => {
 	test('handle undeclared 400', async () => await expectHttpStatusCodeInMutation(400));
 	test('handle undeclared 404', async () => await expectHttpStatusCodeInMutation(404));
 	test('handle undeclared 500', async () => await expectHttpStatusCodeInMutation(500));
+
+	test.only('return timeout as 504', async () => {
+		const wg = createTestServer({
+			dir: __dirname,
+			env: {
+				// This timeouts instead of failing to connect
+				OPENAPI_URL: 'http://1.2.3.4:8080',
+			},
+		});
+		await wg.start();
+
+		const result = await wg.client().query({
+			operationName: 'NoteByID',
+			input: {
+				id: 1,
+			},
+		});
+
+		expect(result.error).toBeDefined();
+		expect(result.error?.statusCode).toBe(504);
+
+		await wg.stop();
+	});
 });

--- a/pkg/apihandler/apihandler.go
+++ b/pkg/apihandler/apihandler.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"os"
@@ -2505,7 +2506,9 @@ func handleOperationErr(log *zap.Logger, err error, w http.ResponseWriter, error
 		w.WriteHeader(499)
 		return true
 	}
-	if errors.Is(err, context.DeadlineExceeded) {
+	// This detects all timeout errors, including context.DeadlineExceeded
+	var ne net.Error
+	if errors.As(err, &ne) && ne.Timeout() {
 		// request timeout exceeded
 		log.Error("request timeout exceeded",
 			zap.String("operationName", operation.Name),


### PR DESCRIPTION
Return 504 when an upstream produces a timeout

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

## Marketing Changelog

<!--
What changes does this PR introduce? Please describe the changes in simple terms that a user can understand
without being familiar with the codebase. Mention @advocates for review and tracking.
-->

#### Checklist

- [ ] run `make test`
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)
