### PR TITLE
feat(sdk): add custom fetch options

### DIFF
--- a/packages/sdk/src/client/client.ts
+++ b/packages/sdk/src/client/client.ts
@@ -121,6 +121,7 @@ export class Client {
 
 	private async fetch(input: RequestInfo, init: RequestInit = {}): Promise<globalThis.Response> {
 		const fetchImpl = this.options.customFetch || globalThis.fetch;
+		const customFetchOptions = this.options.customFetchOptions || {};
 
 		init.headers = {
 			...this.baseHeaders,
@@ -138,9 +139,8 @@ export class Client {
 
 		try {
 			const resp = await fetchImpl(input, {
-				credentials: 'include',
-				mode: 'cors',
 				...init,
+				...customFetchOptions,
 			});
 			return resp;
 		} finally {

--- a/packages/sdk/src/client/client.ts
+++ b/packages/sdk/src/client/client.ts
@@ -121,7 +121,7 @@ export class Client {
 
 	private async fetch(input: RequestInfo, init: RequestInit = {}): Promise<globalThis.Response> {
 		const fetchImpl = this.options.customFetch || globalThis.fetch;
-		const customFetchOptions = this.options.customFetchOptions || {};
+		const customFetchOptions = this.options.customFetchOptions || { credentials: 'include', mode: 'cors' };
 
 		init.headers = {
 			...this.baseHeaders,

--- a/packages/sdk/src/client/types.ts
+++ b/packages/sdk/src/client/types.ts
@@ -56,6 +56,7 @@ export interface ClientConfig {
 	baseURL: string;
 	sdkVersion?: string;
 	customFetch?: (input: RequestInfo, init?: RequestInit) => Promise<globalThis.Response>;
+	customFetchOptions?: RequestInit;
 	extraHeaders?: Headers;
 	operationMetadata?: OperationMetadata;
 	/**


### PR DESCRIPTION
# Add custom fetch options

## Motivation and Context

The wundergraph client is incompatible with cloudflare workers/pages. Some runtime like workers [don't support](https://github.com/cloudflare/workerd/blob/902b65ace3c5c0f5ae4b432fae976f28ddaec1ec/src/workerd/api/http.h#L510-L517) some of the fetch options that are injected by the wundergraph client and that can't be overwritten by a customFetch.

This can be tested easily in the cloudflare workers [playground](https://cloudflareworkers.com/#76e201bbfa9a01b3fc7cc29e97096465:about:blank)

This PR adds a way to pass custom fetch options to the wundergraph client to give more flexibility.

## Marketing Changelog

Add custom fetch options. 
This makes the wundergraph client compatible with cloudflare workers/pages.

#### Checklist

- [x] run `make test`
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)
