### PR TITLE
fix: handle anyOf and types with unrepresentable names in OAS

### DIFF
--- a/packages/sdk/src/openapibuilder/index.test.ts
+++ b/packages/sdk/src/openapibuilder/index.test.ts
@@ -2,7 +2,7 @@ import { JSONSchema7 } from 'json-schema';
 
 import { OperationExecutionEngine, OperationType } from '@wundergraph/protobuf';
 import { GraphQLOperation } from '../graphql/operations';
-import { OpenApiBuilder } from './index';
+import { OpenApiBuilder, isValidOpenApiSchemaName } from './index';
 
 const emptySchema = {
 	type: 'object',
@@ -251,7 +251,8 @@ describe('OpenAPI builder', () => {
 		expect(firstRef).toMatch(/#\/components\/schemas\/.*/);
 
 		const refName = firstRef?.substring('#/components/schemas/'.length);
-		expect(refName).toMatch(/^[a-zA-Z0-9._-]+$/);
+		expect(refName).toBeDefined();
+		expect(isValidOpenApiSchemaName(refName!)).toBeTruthy();
 		expect(result.components?.schemas?.[refName!]).toBeDefined();
 	});
 

--- a/packages/sdk/src/openapibuilder/index.test.ts
+++ b/packages/sdk/src/openapibuilder/index.test.ts
@@ -1,3 +1,5 @@
+import { JSONSchema7 } from 'json-schema';
+
 import { OperationExecutionEngine, OperationType } from '@wundergraph/protobuf';
 import { GraphQLOperation } from '../graphql/operations';
 import { OpenApiBuilder } from './index';
@@ -52,6 +54,15 @@ const operations = [
 	},
 ] as GraphQLOperation[];
 
+const build = (operations: GraphQLOperation[]) => {
+	const builder = new OpenApiBuilder({
+		title: 'WunderGraph',
+		version: '0',
+		baseURL: 'http://localhost:9991',
+	});
+	return builder.build(operations);
+};
+
 describe('OpenAPI builder', () => {
 	test('no operations', async () => {
 		const apiTitle = 'WunderGraph';
@@ -70,11 +81,6 @@ describe('OpenAPI builder', () => {
 	});
 
 	test('operation properties', async () => {
-		const builder = new OpenApiBuilder({
-			title: 'WunderGraph',
-			version: '1.0',
-			baseURL: 'http://localhost:9991',
-		});
 		const operations = [
 			{
 				Name: 'Query',
@@ -126,7 +132,7 @@ describe('OpenAPI builder', () => {
 				},
 			},
 		] as unknown as GraphQLOperation[];
-		const result = builder.build(operations);
+		const result = build(operations);
 
 		const querySpec = result.paths['/QueryPath'];
 		expect(querySpec).toBeDefined();
@@ -164,12 +170,7 @@ describe('OpenAPI builder', () => {
 				Internal: true,
 			},
 		] as unknown as GraphQLOperation[];
-		const builder = new OpenApiBuilder({
-			title: 'WunderGraph',
-			version: '0',
-			baseURL: 'http://localhost:9991',
-		});
-		const result = builder.build(operations);
+		const result = build(operations);
 		expect(Object.keys(result.paths).length).toBe(1);
 		expect(result.paths['/QueryPath']).toBeDefined();
 		expect(result.paths['/InternalQueryPath']).toBeUndefined();
@@ -194,12 +195,8 @@ describe('OpenAPI builder', () => {
 				OperationType: OperationType.SUBSCRIPTION,
 			},
 		] as unknown as GraphQLOperation[];
-		const builder = new OpenApiBuilder({
-			title: 'WunderGraph',
-			version: '0',
-			baseURL: 'http://localhost:9991',
-		});
-		const result = builder.build(operations);
+
+		const result = build(operations);
 		expect(Object.keys(result.paths).length).toBe(3);
 		const query = result.paths['/QueryPath'].get;
 		expect(query?.['x-wundergraph-operation-type']).toBe('query');
@@ -210,6 +207,52 @@ describe('OpenAPI builder', () => {
 		const subscription = result.paths['/SubscriptionPath'].get;
 		expect(subscription?.['x-wundergraph-operation-type']).toBe('subscription');
 		expect(subscription?.['x-wundergraph-requires-authentication']).toBe(false);
+	});
+
+	test('rewrite references and generate valid names inside anyOf', () => {
+		const operations = [
+			{
+				Name: 'Weather',
+				PathName: 'weather/get',
+				OperationType: OperationType.QUERY,
+				ExecutionEngine: OperationExecutionEngine.ENGINE_GRAPHQL,
+				VariablesSchema: emptySchema,
+				ResponseSchema: {
+					type: 'object',
+					properties: {
+						weather: {
+							anyOf: [
+								{
+									$ref: '#/definitions/{readonlysummary:{readonlytitle:string|null;readonlydescription:string|null;readonlyicon:string|null;}|null;}',
+								},
+								{
+									type: 'null',
+								},
+							],
+						},
+					},
+					required: ['weather'],
+					definitions: {
+						'{readonlysummary:{readonlytitle:string|null;readonlydescription:string|null;readonlyicon:string|null;}|null;}':
+							{
+								type: 'string',
+							},
+					},
+				},
+			},
+		] as unknown as GraphQLOperation[];
+
+		const result = build(operations);
+		const operation = result.paths['/weather/get'].get;
+		const responseSchema = operation?.responses?.['200']?.content?.['application/json']?.schema;
+		const weather = responseSchema?.properties?.['weather'];
+		const firstAnyOf = (weather as JSONSchema7).anyOf?.[0];
+		const firstRef = (firstAnyOf as JSONSchema7).$ref;
+		expect(firstRef).toMatch(/#\/components\/schemas\/.*/);
+
+		const refName = firstRef?.substring('#/components/schemas/'.length);
+		expect(refName).toMatch(/^[a-zA-Z0-9._-]+$/);
+		expect(result.components?.schemas?.[refName!]).toBeDefined();
 	});
 
 	test('OpenAPI Builder', async () => {

--- a/packages/sdk/src/openapibuilder/index.ts
+++ b/packages/sdk/src/openapibuilder/index.ts
@@ -115,6 +115,18 @@ export interface OpenApiBuilderOptions {
 	description?: string;
 }
 
+/**
+ * isValidOpenApiSchemaName returns true iff the name is valid
+ * to be used as a schema name inside an OAS.
+ *
+ * @param name Schema name
+ * @returns True if the name is valid, false otherwise
+ */
+export const isValidOpenApiSchemaName = (name: string) => {
+	// name must match this regular expression to be a valid schema name in OAS
+	return name && name.match(/^[a-zA-Z0-9._-]+$/);
+};
+
 // OpenApiBuilder generates an OpenAPI specification for querying the provided operations.
 // Each operation should have proper VariablesSchema and ResponseSchema. Query and Subscription
 // operations produce GET requests with querystring parameters, while Mutation operations produce
@@ -206,12 +218,9 @@ export class OpenApiBuilder {
 	}
 
 	private validComponentsSchemaName(name: string) {
-		// name must match this regular expression to be a valid schema name in OAS
-		if (name.match(/^[a-zA-Z0-9._-]+$/)) {
-			return name;
-		}
-		// Hash the name to make it a valid identifier
-		return objectHash(name);
+		// If the name is not valid, we use its hash, which will always generate
+		// a valid name in a deterministic way
+		return isValidOpenApiSchemaName(name) ? name : objectHash(name);
 	}
 
 	private rewriteSchemaRefs(spec: OpenApiSpec, schema: JSONSchema7Definition) {


### PR DESCRIPTION
- When rewriting type references, descend into object.anyOf
- When rewriting type references types that might have invalid names
in OAS (like anonymous types which use its representation) by hashing
their definition and generating a valid name.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

## Motivation and Context

ORM generates anonymous types that were not correctly handled by the OpenAPI generator
<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

## Marketing Changelog

OpenAPI generation now works with the ORM
<!--
What changes does this PR introduce? Please describe the changes in simple terms that a user can understand
without being familiar with the codebase. Mention @advocates for review and tracking.
-->

#### Checklist

- [ ] run `make test`
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)
