### PR TITLE
feat: support for running the hooks server from the test runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
   "pnpm": {
     "overrides": {
       "@tanstack/query-core": "^4.29.1",
+      "graphql": "^16.6.0",
       "zod": "^3.21.4"
     }
   }

--- a/packages/sdk/src/codegen/index.test.ts
+++ b/packages/sdk/src/codegen/index.test.ts
@@ -106,6 +106,7 @@ export const RunTemplateTest = async (...templates: Template[]) => {
 					},
 				},
 				serverOptions: {
+					present: true,
 					serverUrl: {
 						kind: ConfigurationVariableKind.STATIC_CONFIGURATION_VARIABLE,
 						staticVariableContent: 'http://localhost:9992',

--- a/packages/sdk/src/codegen/templates/typescript/testing.template.ts
+++ b/packages/sdk/src/codegen/templates/typescript/testing.template.ts
@@ -2,6 +2,9 @@
 export const handlebarTemplate = `
 import { ServerOptions, WunderGraphTestServer, WunderGraphMockServer, WunderGraphTestServers } from "@wundergraph/sdk/testing";
 import { createClient, WunderGraphClient } from "./client";
+{{#if hasServer}}
+import configureWunderGraphServer from "../wundergraph.server";
+{{/if}}
 
 /**
  * Encapsulates the WunderGraphTestServers with the generated client types.
@@ -17,6 +20,9 @@ export const createTestServer = (opts?: Partial<ServerOptions<WunderGraphClient>
 	return new WunderGraphTestServer({
 		...opts,
 		createClient: opts?.createClient ?? createClient,
+		{{#if hasServer}}
+		serverConfiguration: configureWunderGraphServer,
+		{{/if}}
 	});
 }
 

--- a/packages/sdk/src/codegen/templates/typescript/testing.ts
+++ b/packages/sdk/src/codegen/templates/typescript/testing.ts
@@ -7,9 +7,11 @@ import templates from '../index';
 
 export class TypeScriptTesting implements Template {
 	constructor() {}
-	generate(_: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
+	generate(generationConfig: CodeGenerationConfig): Promise<TemplateOutputFile[]> {
 		const tmpl = Handlebars.compile(handlebarTemplate);
-		const content = tmpl({});
+		const content = tmpl({
+			hasServer: generationConfig.config.serverOptions?.present ?? false,
+		});
 		return Promise.resolve([
 			{
 				path: 'testing.ts',

--- a/packages/sdk/src/configure/index.ts
+++ b/packages/sdk/src/configure/index.ts
@@ -389,7 +389,7 @@ const resolveConfig = async (
 
 	const resolvedNodeOptions = resolveNodeOptions(config.options);
 	const serverOptions = serverOptionsWithDefaults(config.server?.options);
-	const resolvedServerOptions = resolveServerOptions(serverOptions);
+	const resolvedServerOptions = resolveServerOptions(serverOptions, config.server);
 
 	const publicNodeUrl = trimTrailingSlash(resolveConfigurationVariable(resolvedNodeOptions.publicNodeUrl));
 

--- a/packages/sdk/src/server/types.ts
+++ b/packages/sdk/src/server/types.ts
@@ -35,6 +35,7 @@ export interface MandatoryServerOptions {
 }
 
 export interface ResolvedServerOptions {
+	present: boolean;
 	serverUrl: ConfigurationVariable;
 	listen: ResolvedListenOptions;
 	logger: ResolvedServerLogger;

--- a/packages/sdk/src/server/util.ts
+++ b/packages/sdk/src/server/util.ts
@@ -1,6 +1,6 @@
 import { EnvironmentVariable, mapInputVariable, resolveVariable } from '../configure/variables';
 import { defaultHost, defaultServerPort, isCloud, ListenOptions, LoggerLevel, WgEnv } from '../configure/options';
-import { ResolvedServerOptions, ServerOptions, MandatoryServerOptions } from './types';
+import { ResolvedServerOptions, ServerOptions, MandatoryServerOptions, WunderGraphHooksAndServerConfig } from './types';
 
 export const customGqlServerMountPath = (name: string): string => {
 	return `/gqls/${name}/graphql`;
@@ -39,8 +39,12 @@ export const serverOptionsWithDefaults = (options?: ServerOptions): MandatorySer
 		  };
 };
 
-export const resolveServerOptions = (options: MandatoryServerOptions): ResolvedServerOptions => {
+export const resolveServerOptions = (
+	options: MandatoryServerOptions,
+	server?: WunderGraphHooksAndServerConfig
+): ResolvedServerOptions => {
 	return {
+		present: server !== undefined,
 		serverUrl: mapInputVariable(options.serverUrl),
 		listen: {
 			host: mapInputVariable(options.listen.host),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,6 +2,7 @@ lockfileVersion: 5.4
 
 overrides:
   '@tanstack/query-core': ^4.29.1
+  graphql: ^16.6.0
   zod: ^3.21.4
 
 importers:
@@ -682,7 +683,7 @@ importers:
       '@wundergraph/wunderctl': workspace:*
       execa: 5.1.1
       fastify: ^4.10.2
-      graphql: ^16.3.0
+      graphql: ^16.6.0
       graphql-request: ^6.0.0
       jose: ^4.11.1
       straightforward: ^4.2.2
@@ -771,7 +772,7 @@ importers:
       '@types/node': ^18.16.0
       '@wundergraph/golang-client': workspace:*
       '@wundergraph/sdk': workspace:*
-      graphql: ^16.3.0
+      graphql: ^16.6.0
       pg: ^8.7.3
       stripe: ^11.12.0
       typescript: ^4.9.4
@@ -834,7 +835,7 @@ importers:
       '@types/react': ^18.0.6
       '@wundergraph/nextjs': workspace:*
       '@wundergraph/sdk': workspace:*
-      graphql: ^16.3.0
+      graphql: ^16.6.0
       jose: ^4.11.1
       next: ^13.1.1
       next-auth: ^4.18.3
@@ -878,7 +879,7 @@ importers:
       '@wundergraph/sdk': workspace:*
       '@wundergraph/swr': workspace:*
       concurrently: ^6.0.0
-      graphql: ^16.3.0
+      graphql: ^16.6.0
       next: ^13.1.1
       open-cli: ^7.0.1
       react: ^18.2.0
@@ -971,7 +972,7 @@ importers:
     specifiers:
       '@types/node': ^18.16.0
       '@wundergraph/sdk': workspace:*
-      graphql: ^16.3.0
+      graphql: ^16.6.0
       typescript: ^4.8.2
     dependencies:
       '@types/node': 18.16.0
@@ -986,7 +987,7 @@ importers:
     specifiers:
       '@types/node': ^18.16.0
       '@wundergraph/sdk': workspace:*
-      graphql: ^16.3.0
+      graphql: ^16.6.0
       typescript: ^4.8.2
     dependencies:
       '@types/node': 18.16.0
@@ -1002,7 +1003,7 @@ importers:
       '@wundergraph/sdk': workspace:*
       '@wundergraph/swr': workspace:*
       concurrently: ^6.0.0
-      graphql: ^16.3.0
+      graphql: ^16.6.0
       open-cli: ^7.0.1
       react: ^18.1.0
       react-dom: ^18.1.0
@@ -3013,8 +3014,8 @@ packages:
       '@expo/rudder-sdk-node': 1.1.1
       '@expo/spawn-async': 1.5.0
       '@expo/xcpretty': 4.2.2
-      '@urql/core': 2.3.6_graphql@15.8.0
-      '@urql/exchange-retry': 0.3.0_graphql@15.8.0
+      '@urql/core': 2.3.6_graphql@16.6.0
+      '@urql/exchange-retry': 0.3.0_graphql@16.6.0
       accepts: 1.3.8
       arg: 4.1.0
       better-opn: 3.0.2
@@ -3028,8 +3029,8 @@ packages:
       freeport-async: 2.0.0
       fs-extra: 8.1.0
       getenv: 1.0.0
-      graphql: 15.8.0
-      graphql-tag: 2.12.6_graphql@15.8.0
+      graphql: 16.6.0
+      graphql-tag: 2.12.6_graphql@16.6.0
       https-proxy-agent: 5.0.1
       internal-ip: 4.3.0
       is-root: 2.1.0
@@ -3665,14 +3666,6 @@ packages:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       graphql: 16.6.0
-    dev: false
-
-  /@graphql-typed-document-node/core/3.2.0_graphql@15.8.0:
-    resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
-    peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-    dependencies:
-      graphql: 15.8.0
     dev: false
 
   /@graphql-typed-document-node/core/3.2.0_graphql@16.6.0:
@@ -7426,23 +7419,23 @@ packages:
       eslint-visitor-keys: 3.3.0
     dev: true
 
-  /@urql/core/2.3.6_graphql@15.8.0:
+  /@urql/core/2.3.6_graphql@16.6.0:
     resolution: {integrity: sha512-PUxhtBh7/8167HJK6WqBv6Z0piuiaZHQGYbhwpNL9aIQmLROPEdaUYkY4wh45wPQXcTpnd11l0q3Pw+TI11pdw==}
     peerDependencies:
       graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
     dependencies:
-      '@graphql-typed-document-node/core': 3.2.0_graphql@15.8.0
-      graphql: 15.8.0
+      '@graphql-typed-document-node/core': 3.2.0_graphql@16.6.0
+      graphql: 16.6.0
       wonka: 4.0.15
     dev: false
 
-  /@urql/exchange-retry/0.3.0_graphql@15.8.0:
+  /@urql/exchange-retry/0.3.0_graphql@16.6.0:
     resolution: {integrity: sha512-hHqer2mcdVC0eYnVNbWyi28AlGOPb2vjH3lP3/Bc8Lc8BjhMsDwFMm7WhoP5C1+cfbr/QJ6Er3H/L08wznXxfg==}
     peerDependencies:
       graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
     dependencies:
-      '@urql/core': 2.3.6_graphql@15.8.0
-      graphql: 15.8.0
+      '@urql/core': 2.3.6_graphql@16.6.0
+      graphql: 16.6.0
       wonka: 4.0.15
     dev: false
 
@@ -8607,7 +8600,7 @@ packages:
     dependencies:
       babel-plugin-macros: 2.8.0
       cosmiconfig: 5.2.1
-      graphql: 15.3.0
+      graphql: 16.6.0
     dev: true
 
   /babel-plugin-syntax-trailing-function-commas/7.0.0-beta.0:
@@ -13050,13 +13043,13 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /graphql-tag/2.12.6_graphql@15.8.0:
+  /graphql-tag/2.12.6_graphql@16.6.0:
     resolution: {integrity: sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==}
     engines: {node: '>=10'}
     peerDependencies:
       graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
     dependencies:
-      graphql: 15.8.0
+      graphql: 16.6.0
       tslib: 2.5.0
     dev: false
 
@@ -13066,16 +13059,6 @@ packages:
       graphql: '>=0.8.0'
     dependencies:
       graphql: 16.6.0
-    dev: false
-
-  /graphql/15.3.0:
-    resolution: {integrity: sha512-GTCJtzJmkFLWRfFJuoo9RWWa/FfamUHgiFosxi/X1Ani4AVWbeyBenZTNX6dM+7WSbbFfTo/25eh0LLkwHMw2w==}
-    engines: {node: '>= 10.x'}
-    dev: true
-
-  /graphql/15.8.0:
-    resolution: {integrity: sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==}
-    engines: {node: '>= 10.x'}
     dev: false
 
   /graphql/16.6.0:


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

## Marketing Changelog

<!--
What changes does this PR introduce? Please describe the changes in simple terms that a user can understand
without being familiar with the codebase. Mention @advocates for review and tracking.
-->

#### Checklist

- [ ] run `make test`
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)
