### PR TITLE
fix: close prometheus metrics when reloading the server

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -77,6 +77,10 @@ type Metrics interface {
 	// Serve starts serving the metrics collected by this Metrics, in a blocking way.
 	// After shutdown, it will return ErrShutdown.
 	Serve() error
-	// Shutdown stops serving the metrics
+	// Close stops serving the metrics immediately and invalidates all previously
+	// create metrics (counters, gauges, etc...)
+	Close() error
+	// Shutdown works like Close(), but it awaits for any clients reading the
+	// metrics to be done
 	Shutdown(ctx context.Context) error
 }

--- a/pkg/metrics/none.go
+++ b/pkg/metrics/none.go
@@ -18,6 +18,7 @@ func (n noMetrics) NewHistogramVec(opts MetricOpts, labelNames ...string) Histog
 }
 func (n noMetrics) NewSummaryVec(opts MetricOpts, labelNames ...string) SummaryVec { return noMetric{} }
 func (n noMetrics) Serve() error                                                   { return nil }
+func (n noMetrics) Close() error                                                   { return nil }
 func (n noMetrics) Shutdown(ctx context.Context) error                             { return nil }
 
 // NewNone returns a metrics provider that does nothing

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -117,14 +117,27 @@ func (m *prometheusMetrics) Serve() error {
 	return err
 }
 
+func (m *prometheusMetrics) Close() error {
+	if err := m.server.Close(); err != nil {
+		return err
+	}
+	m.unregisterCollectors()
+	return nil
+}
+
 func (m *prometheusMetrics) Shutdown(ctx context.Context) error {
 	if err := m.server.Shutdown(ctx); err != nil {
 		return err
 	}
+	m.unregisterCollectors()
+	return nil
+}
+
+func (m *prometheusMetrics) unregisterCollectors() {
 	for _, collector := range m.collectors {
 		m.registerer.Unregister(collector)
 	}
-	return nil
+	m.collectors = nil
 }
 
 // NewPrometheus returns a metrics provider that exposes the metrics via Prometheus

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -271,6 +271,10 @@ func (n *Node) Shutdown(ctx context.Context) error {
 }
 
 func (n *Node) Close() error {
+	if n.metrics != nil {
+		n.metrics.Close()
+		n.metrics = nil
+	}
 	if n.builder != nil {
 		if err := n.builder.Close(); err != nil {
 			return err


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

## Motivation and Context

Closing the metrics server gets rid of an error message that appears after a reload
during development

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

## Marketing Changelog

<!--
What changes does this PR introduce? Please describe the changes in simple terms that a user can understand
without being familiar with the codebase. Mention @advocates for review and tracking.
-->

#### Checklist

- [ ] run `make test`
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)
