### PR TITLE
fix: use Node.js fetch that supports web stream api

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -152,7 +152,6 @@
     "axios": "^0.26.1",
     "axios-retry": "^3.3.1",
     "close-with-grace": "^1.1.0",
-    "cross-fetch": "^3.1.5",
     "debug": "^4.3.4",
     "execa": "5.1.1",
     "fast-json-patch": "^3.1.1",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -180,6 +180,7 @@
     "ts-retry-promise": "^0.7.0",
     "tslib": "^2.5.0",
     "typescript-json-schema": "^0.55.0",
+    "undici": "^5.22.1",
     "write-file-atomic": "^5.0.0",
     "zod": "^3.20.2",
     "zod-to-json-schema": "^3.20.2"

--- a/packages/sdk/src/client/client.ts
+++ b/packages/sdk/src/client/client.ts
@@ -6,9 +6,7 @@ import {
 	Headers,
 	LogoutOptions,
 	MutationRequestOptions,
-	OperationDefinition,
 	OperationRequestOptions,
-	OperationsDefinition,
 	QueryRequestOptions,
 	SubscriptionEventHandler,
 	SubscriptionRequestOptions,
@@ -25,7 +23,6 @@ import {
 	ValidationResponseJSON,
 	ClientOperationErrorCodes,
 } from './errors';
-import { loadFile } from '../codegen/templates/typescript';
 
 // We follow https://docs.wundergraph.com/docs/architecture/wundergraph-rpc-protocol-explained
 

--- a/packages/sdk/src/client/client.ts
+++ b/packages/sdk/src/client/client.ts
@@ -25,6 +25,7 @@ import {
 	ValidationResponseJSON,
 	ClientOperationErrorCodes,
 } from './errors';
+import { loadFile } from '../codegen/templates/typescript';
 
 // We follow https://docs.wundergraph.com/docs/architecture/wundergraph-rpc-protocol-explained
 

--- a/packages/sdk/src/definition/graphql-introspection.test.ts
+++ b/packages/sdk/src/definition/graphql-introspection.test.ts
@@ -1,5 +1,4 @@
 import { introspect } from './index';
-import fetch from 'node-fetch';
 import nock from 'nock';
 import axios from 'axios';
 import { promises as fs } from 'fs';

--- a/packages/sdk/src/server/operations-client.test.ts
+++ b/packages/sdk/src/server/operations-client.test.ts
@@ -1,6 +1,16 @@
 import { OperationsClient } from './operations-client';
 import { createServer } from 'http';
 import { AddressInfo } from 'net';
+import { Agent, setGlobalDispatcher } from 'undici';
+
+// Avoid persistent connections which leads to hanging tests
+// because close event is not emitted
+setGlobalDispatcher(
+	new Agent({
+		keepAliveTimeout: 1,
+		keepAliveMaxTimeout: 1,
+	})
+);
 
 describe('Operations Client', () => {
 	test('Should be able to make a request with default fetch implementation', (done) => {
@@ -26,8 +36,6 @@ describe('Operations Client', () => {
 
 			expect(data).toEqual(mock.data);
 			expect(error).toBeUndefined();
-
-			server.closeAllConnections();
 
 			server.close(done);
 		});
@@ -58,8 +66,6 @@ describe('Operations Client', () => {
 				expect(data).toEqual(mock.data);
 				expect(error).toBeUndefined();
 			}
-
-			server.closeAllConnections();
 
 			server.close(done);
 		});

--- a/packages/sdk/src/server/operations-client.test.ts
+++ b/packages/sdk/src/server/operations-client.test.ts
@@ -30,4 +30,34 @@ describe('Operations Client', () => {
 			done();
 		});
 	});
+
+	test('Should be able to make a subscription request (web-streams)', (done) => {
+		const mock = {
+			data: {
+				id: '1',
+			},
+		};
+
+		const server = createServer((req, res) => {
+			expect(req.url).toEqual('/operations/Events');
+			res.end(JSON.stringify(mock) + '\n\n');
+		});
+
+		server.listen(0, async () => {
+			const client = new OperationsClient({
+				baseURL: `http://localhost:${(server.address() as AddressInfo).port}`,
+				clientRequest: {},
+			});
+			const updates = await client.subscribe({
+				operationName: 'Events',
+			});
+
+			for await (const { data, error } of updates) {
+				expect(data).toEqual(mock.data);
+				expect(error).toBeUndefined();
+			}
+
+			done();
+		});
+	});
 });

--- a/packages/sdk/src/server/operations-client.test.ts
+++ b/packages/sdk/src/server/operations-client.test.ts
@@ -11,6 +11,7 @@ describe('Operations Client', () => {
 		};
 
 		const server = createServer((req, res) => {
+			expect(req.url).toEqual('/operations/Weather');
 			res.end(JSON.stringify(mock));
 		});
 

--- a/packages/sdk/src/server/operations-client.test.ts
+++ b/packages/sdk/src/server/operations-client.test.ts
@@ -1,0 +1,32 @@
+import { OperationsClient } from './operations-client';
+import { createServer } from 'http';
+import { AddressInfo } from 'net';
+
+describe('Operations Client', () => {
+	test('Should be able to make a request with default fetch implementation', (done) => {
+		const mock = {
+			data: {
+				id: '1',
+			},
+		};
+
+		const server = createServer((req, res) => {
+			res.end(JSON.stringify(mock));
+		});
+
+		server.listen(0, async () => {
+			const client = new OperationsClient({
+				baseURL: `http://localhost:${(server.address() as AddressInfo).port}`,
+				clientRequest: {},
+			});
+			const { data, error } = await client.query({
+				operationName: 'Weather',
+			});
+
+			expect(data).toEqual(mock.data);
+			expect(error).toBeUndefined();
+
+			done();
+		});
+	});
+});

--- a/packages/sdk/src/server/operations-client.test.ts
+++ b/packages/sdk/src/server/operations-client.test.ts
@@ -27,7 +27,9 @@ describe('Operations Client', () => {
 			expect(data).toEqual(mock.data);
 			expect(error).toBeUndefined();
 
-			done();
+			server.closeAllConnections();
+
+			server.close(done);
 		});
 	});
 
@@ -57,7 +59,9 @@ describe('Operations Client', () => {
 				expect(error).toBeUndefined();
 			}
 
-			done();
+			server.closeAllConnections();
+
+			server.close(done);
 		});
 	});
 });

--- a/packages/sdk/src/server/operations-client.ts
+++ b/packages/sdk/src/server/operations-client.ts
@@ -1,4 +1,3 @@
-import fetch from 'cross-fetch';
 import {
 	Client,
 	ClientConfig,
@@ -60,10 +59,9 @@ export class OperationsClient<
 	protected readonly clientRequest: any;
 
 	constructor(options: OperationsClientConfig) {
-		const { clientRequest, customFetch = fetch, ...rest } = options;
+		const { clientRequest, ...rest } = options;
 		super({
 			...rest,
-			customFetch,
 		});
 
 		this.clientRequest = clientRequest;
@@ -158,7 +156,9 @@ export class OperationsClient<
 		return sub as any;
 	};
 
-	protected async fetchSubscription<Data = any, Error = any>(subscription: SubscriptionRequestOptions) {
+	protected async fetchSubscription<Data = any, Error = any>(
+		subscription: SubscriptionRequestOptions
+	): Promise<Response> {
 		const searchParams = this.searchParams();
 		const params: any = { input: subscription.input, __wg: { clientRequest: this.clientRequest } };
 
@@ -167,7 +167,7 @@ export class OperationsClient<
 		}
 
 		const url = this.addUrlParams(this.operationUrl(subscription.operationName), searchParams);
-		return await this.fetchJson(url, {
+		return this.fetchJson(url, {
 			method: 'POST',
 			body: this.stringifyInput(params),
 			signal: subscription.abortSignal,

--- a/packages/sdk/src/server/operations-client.ts
+++ b/packages/sdk/src/server/operations-client.ts
@@ -71,6 +71,7 @@ export class OperationsClient<
 		const { clientRequest, customFetch = fetch, ...rest } = options;
 
 		super({
+			// fetch compatible but not the exact same type
 			customFetch: customFetch as any,
 			...rest,
 		});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -446,7 +446,6 @@ importers:
       axios-retry: ^3.3.1
       chai: ^4.3.4
       close-with-grace: ^1.1.0
-      cross-fetch: ^3.1.5
       debug: ^4.3.4
       execa: 5.1.1
       fast-json-patch: ^3.1.1
@@ -505,7 +504,6 @@ importers:
       axios: 0.26.1_debug@4.3.4
       axios-retry: 3.3.1
       close-with-grace: 1.1.0
-      cross-fetch: 3.1.5
       debug: 4.3.4
       execa: 5.1.1
       fast-json-patch: 3.1.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -481,6 +481,7 @@ importers:
       type-fest: ^3.5.2
       typescript: ^4.8.2
       typescript-json-schema: ^0.55.0
+      undici: ^5.22.1
       write-file-atomic: ^5.0.0
       zod: ^3.21.4
       zod-to-json-schema: ^3.20.2
@@ -532,6 +533,7 @@ importers:
       ts-retry-promise: 0.7.0
       tslib: 2.5.0
       typescript-json-schema: 0.55.0
+      undici: 5.22.1
       write-file-atomic: 5.0.0
       zod: 3.21.4
       zod-to-json-schema: 3.20.2_zod@3.21.4
@@ -23766,6 +23768,13 @@ packages:
   /undici/5.11.0:
     resolution: {integrity: sha512-oWjWJHzFet0Ow4YZBkyiJwiK5vWqEYoH7BINzJAJOLedZ++JpAlCbUktW2GQ2DS2FpKmxD/JMtWUUWl1BtghGw==}
     engines: {node: '>=12.18'}
+    dependencies:
+      busboy: 1.6.0
+    dev: false
+
+  /undici/5.22.1:
+    resolution: {integrity: sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==}
+    engines: {node: '>=14.0'}
     dependencies:
       busboy: 1.6.0
     dev: false


### PR DESCRIPTION
The cross-fetch package does not provide a web-streams compatible API required by the base client implementation. This cause `response.body.getReader is not a function` when starting a subscription with the operations client. We can provide different implementations for the Web and Server or use a web-stream compatible fetch on the server as well. I choose the second option.

This PR switched to `undici` as default fetch implementation on the server. It has support for Node.js 16+. As soon as Node.js 16 is out of maintenance, we can remove the package because, starting with Node.js 18, the exact fetch implementation is exposed as global.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

## Marketing Changelog

<!--
What changes does this PR introduce? Please describe the changes in simple terms that a user can understand
without being familiar with the codebase. Mention @advocates for review and tracking.
-->

#### Checklist

- [ ] run `make test`
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)
