### PR TITLE
fix: use the right context.Context when reusing a resolve.Context in GetSharedFromRequest()

### DIFF
--- a/packages/testsuite/apps/orm/.wundergraph/operations/clientRequestContentLength.ts
+++ b/packages/testsuite/apps/orm/.wundergraph/operations/clientRequestContentLength.ts
@@ -2,7 +2,10 @@ import { createOperation } from '../generated/wundergraph.factory';
 
 export default createOperation.query({
 	handler: async ({ graph }) => {
-		const length = await graph.from('echo').query('clientRequestContentLength').exec();
+		const length = await graph
+			.from('echo')
+			.query('clientRequestContentLength')
+			.exec();
 		return {
 			length,
 		};

--- a/packages/testsuite/apps/orm/.wundergraph/operations/clientRequestContentLength.ts
+++ b/packages/testsuite/apps/orm/.wundergraph/operations/clientRequestContentLength.ts
@@ -1,0 +1,10 @@
+import { createOperation } from '../generated/wundergraph.factory';
+
+export default createOperation.query({
+	handler: async ({ graph }) => {
+		const length = await graph.from('echo').query('clientRequestContentLength').exec();
+		return {
+			length,
+		};
+	},
+});

--- a/packages/testsuite/apps/orm/.wundergraph/operations/clientRequestContentLength.ts
+++ b/packages/testsuite/apps/orm/.wundergraph/operations/clientRequestContentLength.ts
@@ -2,10 +2,7 @@ import { createOperation } from '../generated/wundergraph.factory';
 
 export default createOperation.query({
 	handler: async ({ graph }) => {
-		const length = await graph
-			.from('echo')
-			.query('clientRequestContentLength')
-			.exec();
+		const length = await graph.from('echo').query('clientRequestContentLength').exec();
 		return {
 			length,
 		};

--- a/packages/testsuite/apps/orm/.wundergraph/wundergraph.server.ts
+++ b/packages/testsuite/apps/orm/.wundergraph/wundergraph.server.ts
@@ -1,8 +1,28 @@
 import { configureWunderGraphServer } from '@wundergraph/sdk/server';
+import { GraphQLObjectType, GraphQLSchema, GraphQLString } from 'graphql';
 
 export default configureWunderGraphServer(() => ({
 	hooks: {
 		queries: {},
 		mutations: {},
 	},
+	graphqlServers: [
+		{
+			serverName: 'echo',
+			apiNamespace: 'echo',
+			schema: new GraphQLSchema({
+				query: new GraphQLObjectType({
+					name: 'RootQueryType',
+					fields: {
+						clientRequestContentLength: {
+							type: GraphQLString,
+							resolve(obj, args, context, info) {
+								return context.wundergraph.clientRequest.headers.get('Content-Length');
+							},
+						},
+					},
+				}),
+			}),
+		},
+	],
 }));

--- a/packages/testsuite/apps/orm/orm.test.ts
+++ b/packages/testsuite/apps/orm/orm.test.ts
@@ -34,4 +34,17 @@ describe('The WunderGraph ORM', () => {
 		const data = await resp.json();
 		expect(data.name).toBe('Germany');
 	});
+
+	it('it should pass a clientRequest to the internal GraphQL server', async () => {
+		const client = wg.client();
+		// This needs to be run in a loop because we need to reuse a resolve.Context
+		// to trigger the bug
+		for (let ii = 0; ii < 100; ii++) {
+			const { data, error } = await client.query({
+				operationName: 'clientRequestContentLength',
+			});
+			expect(error).toBeUndefined();
+			expect(parseInt(data?.length ?? '', 10)).toBeGreaterThan(0);
+		}
+	});
 });

--- a/pkg/pool/pool.go
+++ b/pkg/pool/pool.go
@@ -122,7 +122,7 @@ func (p *Pool) GetSharedFromRequest(ctx context.Context, r *http.Request, planCo
 	if shared != nil {
 		s := shared.(*Shared)
 		s.Planner.SetConfig(planConfig)
-		s.Ctx = s.Ctx.WithContext(ctx)
+		s.Ctx = s.Ctx.WithContext(c)
 		s.Ctx.Request.Header = r.Header
 		s.Ctx.RenameTypeNames = cfg.RenameTypeNames
 		return s


### PR DESCRIPTION
Passes the right clientRequest to internal graphql requests

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

## Marketing Changelog

<!--
What changes does this PR introduce? Please describe the changes in simple terms that a user can understand
without being familiar with the codebase. Mention @advocates for review and tracking.
-->

#### Checklist

- [ ] run `make test`
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)
