### PR TITLE
feat: implement removeNullVariables for DB datasources

### DIFF
--- a/pkg/datasources/database/datasource.go
+++ b/pkg/datasources/database/datasource.go
@@ -1098,7 +1098,7 @@ func max(start1 int, start2 int, start3 int, start4 int) int {
 }
 
 func (s *Source) Load(ctx context.Context, input []byte, w io.Writer) (err error) {
-	if err == nil && httpclient.IsInputFlagSet(input, httpclient.UNNULLVARIABLES) {
+	if httpclient.IsInputFlagSet(input, httpclient.UNNULLVARIABLES) {
 		input = s.unNullRequest(input)
 	}
 	// Prisma does not support variables, and it MUST be set to "{}"

--- a/pkg/datasources/database/datasource.go
+++ b/pkg/datasources/database/datasource.go
@@ -28,6 +28,8 @@ import (
 	"github.com/wundergraph/wundergraph/pkg/pool"
 )
 
+const removeNullVariablesDirectiveName = "removeNullVariables"
+
 type Planner struct {
 	visitor                    *plan.Visitor
 	config                     Configuration
@@ -58,6 +60,7 @@ type Planner struct {
 	operationTypeDefinitionRef int
 	isQueryRaw                 bool
 	isQueryRawRow              bool
+	unNullVariables            bool
 }
 
 type inlinedVariable struct {
@@ -159,7 +162,7 @@ func (r *RawJsonVariableRenderer) GetKind() string {
 	return "raw_json"
 }
 
-func (r *RawJsonVariableRenderer) RenderVariable(ctx context.Context, data []byte, out io.Writer) error {
+func (r *RawJsonVariableRenderer) RenderVariable(_ context.Context, data []byte, out io.Writer) error {
 	if !r.parentIsJson {
 		// when the parent is already rendering as a JSON, we don't need to wrap the child in quotes
 		// this happens when using a variable inside the parameters list, e.g.
@@ -177,12 +180,15 @@ func (r *RawJsonVariableRenderer) RenderVariable(ctx context.Context, data []byt
 }
 
 func (p *Planner) ConfigureFetch() plan.FetchConfiguration {
-
 	operation := string(p.printOperation())
 
 	input := fetchInput{
 		Query:     operation,
 		Variables: p.upstreamVariables,
+	}
+
+	if p.unNullVariables {
+		input.Variables = httpclient.SetInputFlag(input.Variables, httpclient.UNNULLVARIABLES)
 	}
 
 	for _, inlinedVariable := range p.inlinedVariables {
@@ -256,6 +262,11 @@ func (p *Planner) ConfigureSubscription() plan.SubscriptionConfiguration {
 }
 
 func (p *Planner) EnterOperationDefinition(ref int) {
+	if p.visitor.Operation.OperationDefinitions[ref].HasDirectives &&
+		p.visitor.Operation.OperationDefinitions[ref].Directives.HasDirectiveByName(p.visitor.Operation, removeNullVariablesDirectiveName) {
+		p.unNullVariables = true
+		p.visitor.Operation.OperationDefinitions[ref].Directives.RemoveDirectiveByName(p.visitor.Operation, removeNullVariablesDirectiveName)
+	}
 	operationType := p.visitor.Operation.OperationDefinitions[ref].OperationType
 	if p.isNested {
 		operationType = ast.OperationTypeQuery
@@ -307,7 +318,7 @@ func (p *Planner) EnterSelectionSet(ref int) {
 	}
 }
 
-func (p *Planner) LeaveSelectionSet(ref int) {
+func (p *Planner) LeaveSelectionSet(_ int) {
 
 	if p.insideJsonField {
 		return
@@ -352,7 +363,7 @@ func (p *Planner) EnterInlineFragment(ref int) {
 	p.nodes = append(p.nodes, ast.Node{Kind: ast.NodeKindInlineFragment, Ref: inlineFragment})
 }
 
-func (p *Planner) LeaveInlineFragment(ref int) {
+func (p *Planner) LeaveInlineFragment(_ int) {
 
 	if p.insideJsonField {
 		return
@@ -489,13 +500,13 @@ func (p *Planner) LeaveField(ref int) {
 	p.nodes = p.nodes[:len(p.nodes)-1]
 }
 
-func (p *Planner) EnterArgument(ref int) {
+func (p *Planner) EnterArgument(_ int) {
 	if p.insideJsonField {
 		return
 	}
 }
 
-func (p *Planner) EnterDocument(operation, definition *ast.Document) {
+func (p *Planner) EnterDocument(_, _ *ast.Document) {
 	if p.upstreamOperation == nil {
 		p.upstreamOperation = ast.NewDocument()
 	} else {
@@ -514,7 +525,7 @@ func (p *Planner) EnterDocument(operation, definition *ast.Document) {
 	p.rootFieldRef = -1
 }
 
-func (p *Planner) LeaveDocument(operation, definition *ast.Document) {
+func (p *Planner) LeaveDocument(_, _ *ast.Document) {
 
 }
 
@@ -1047,8 +1058,6 @@ type Source struct {
 	log    *zap.Logger
 }
 
-// {"query":"{findFirstusers(where: {name: {contains: null}}){name id updatedat}}","variables":{}}
-
 func (s *Source) unNullRequest(request []byte) []byte {
 	if end := bytes.Index(request, []byte(": null")); end != -1 {
 		start1 := bytes.LastIndex(request[:end], []byte("{"))
@@ -1089,8 +1098,11 @@ func max(start1 int, start2 int, start3 int, start4 int) int {
 }
 
 func (s *Source) Load(ctx context.Context, input []byte, w io.Writer) (err error) {
+	variables, _, _, err := jsonparser.Get(input, "variables")
+	if err == nil && httpclient.IsInputFlagSet(variables, httpclient.UNNULLVARIABLES) {
+		input = s.unNullRequest(input)
+	}
 	request, _ := jsonparser.Set(input, []byte("{}"), "variables")
-	request = s.unNullRequest(request)
 	buf := pool.GetBytesBuffer()
 	defer pool.PutBytesBuffer(buf)
 	cancellableCtx, cancel := context.WithTimeout(ctx, time.Second*5)

--- a/pkg/datasources/database/datasource_test.go
+++ b/pkg/datasources/database/datasource_test.go
@@ -160,7 +160,7 @@ func TestDatabaseDataSource(t *testing.T) {
 					Nullable: false,
 					Fetch: &resolve.SingleFetch{
 						BufferId:   0,
-						Input:      `{"query":"{findFirstUser(id: $$0$$){id}}","variables":{"unnull_variables":true}}`,
+						Input:      `{"query":"{findFirstUser(id: $$0$$){id}}","variables":null,"unnull_variables":true}`,
 						DataSource: &Source{},
 						Variables: resolve.NewVariables(
 							&resolve.ContextVariable{

--- a/pkg/datasources/database/datasource_test.go
+++ b/pkg/datasources/database/datasource_test.go
@@ -12,10 +12,10 @@ import (
 
 const (
 	schema = `
-
 		type Query {
 			queryRaw(query: String! parameters: [String]): String
 			queryRawJSON(query: String! parameters: [String]): JSON
+			findFirstUser(id: Int): users
 		}
 
 		type Mutation {
@@ -47,9 +47,18 @@ const (
 			}
 		}
 	`
+
+	operationWithRemoveNullVariablesDirective = `
+	query FindFirstUser($id: Int) @removeNullVariables {
+		findFirstUser(id: $id) {
+			id
+		}
+	}
+	`
 )
 
 func TestDatabaseDataSource(t *testing.T) {
+	idVariableResolver, _ := resolve.NewGraphQLVariableRendererFromJSONRootTypeWithoutValidation(resolve.JsonRootType{Value: jsonparser.Number})
 	providerVariableRenderer, _ := resolve.NewGraphQLVariableRendererFromJSONRootTypeWithoutValidation(resolve.JsonRootType{Value: jsonparser.String})
 	providerIdVariableRenderer, _ := resolve.NewGraphQLVariableRendererFromJSONRootTypeWithoutValidation(resolve.JsonRootType{Value: jsonparser.Number})
 	spVariableRenderer, _ := resolve.NewGraphQLVariableRendererFromJSONRootTypeWithoutValidation(resolve.JsonRootType{Value: jsonparser.String})
@@ -135,6 +144,88 @@ func TestDatabaseDataSource(t *testing.T) {
 					Arguments: []plan.ArgumentConfiguration{
 						{
 							Name:       "data",
+							SourceType: plan.FieldArgumentSource,
+						},
+					},
+				},
+			},
+			DisableResolveFieldPositions: true,
+		},
+	))
+
+	t.Run("findFirstUser", datasourcetesting.RunTest(schema, operationWithRemoveNullVariablesDirective, "",
+		&plan.SynchronousResponsePlan{
+			Response: &resolve.GraphQLResponse{
+				Data: &resolve.Object{
+					Nullable: false,
+					Fetch: &resolve.SingleFetch{
+						BufferId:   0,
+						Input:      `{"query":"{findFirstUser(id: $$0$$){id}}","variables":{"unnull_variables":true}}`,
+						DataSource: &Source{},
+						Variables: resolve.NewVariables(
+							&resolve.ContextVariable{
+								Path:     []string{"id"},
+								Renderer: idVariableResolver,
+							},
+						),
+						DataSourceIdentifier: []byte("database.Source"),
+						DisableDataLoader:    false,
+						DisallowSingleFlight: false,
+						ProcessResponseConfig: resolve.ProcessResponseConfig{
+							ExtractGraphqlResponse:    true,
+							ExtractFederationEntities: false,
+						},
+					},
+					Fields: []*resolve.Field{
+						{
+							BufferID:  0,
+							HasBuffer: true,
+							Name:      []byte("findFirstUser"),
+							Value: &resolve.Object{
+								Nullable: true,
+								Path:     []string{"findFirstUser"},
+								Fields: []*resolve.Field{
+									{
+										Name: []byte("id"),
+										Value: &resolve.Integer{
+											Path: []string{"id"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		plan.Configuration{
+			DataSources: []plan.DataSourceConfiguration{
+				{
+					RootNodes: []plan.TypeField{
+						{
+							TypeName:   "Query",
+							FieldNames: []string{"findFirstUser"},
+						},
+					},
+					ChildNodes: []plan.TypeField{
+						{
+							TypeName:   "users",
+							FieldNames: []string{"id", "avatar", "provider", "providerId", "someprovider"},
+						},
+					},
+					Custom: ConfigJson(Configuration{
+						GraphqlSchema: schema,
+					}),
+					Factory: &Factory{testsSkipEngine: true},
+				},
+			},
+			Fields: []plan.FieldConfiguration{
+				{
+					TypeName:  "Query",
+					FieldName: "findFirstUser",
+					Arguments: []plan.ArgumentConfiguration{
+						{
+							Name:       "id",
 							SourceType: plan.FieldArgumentSource,
 						},
 					},


### PR DESCRIPTION


https://github.com/wundergraph/wundergraph/assets/47415099/16a0e792-047e-4fa1-935e-3f1cd57519e7

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

## Motivation and Context

Add removeNullVariables directive for database data sources

## Marketing Changelog

<!--
What changes does this PR introduce? Please describe the changes in simple terms that a user can understand
without being familiar with the codebase. Mention @advocates for review and tracking.
-->

#### Checklist

- [ ] run `make test`
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)
