### PR TITLE
docs: fix incorrect examples of uploadProfiles definitions

### DIFF
--- a/docs-website/src/pages/docs/storage/aws-s3/index.md
+++ b/docs-website/src/pages/docs/storage/aws-s3/index.md
@@ -19,17 +19,15 @@ const aws = {
   bucketLocation: 'eu-central-1',
   bucketName: 'wundergraph-test',
   useSSL: true, // you should always enable SSL for cloud storage providers!
-  uploadProfiles: [
-    {
-      avatar: {
-        requireAuthentication: false, // optional, defaults to true
-        maxAllowedUploadSizeBytes: 1024 * 1024 * 10, // 10 MB, optional, defaults to 25 MB
-        maxAllowedFiles: 1, // limit the number of files to 1, leave undefined for unlimited files
-        allowedMimeTypes: ['image/png', 'image/jpeg'], // wildcard is supported, e.g. 'image/*', leave empty/undefined to allow all
-        allowedFileExtensions: ['png', 'jpg'], // leave empty/undefined to allow all
-      },
+  uploadProfiles: {
+    avatar: {
+      requireAuthentication: false, // optional, defaults to true
+      maxAllowedUploadSizeBytes: 1024 * 1024 * 10, // 10 MB, optional, defaults to 25 MB
+      maxAllowedFiles: 1, // limit the number of files to 1, leave undefined for unlimited files
+      allowedMimeTypes: ['image/png', 'image/jpeg'], // wildcard is supported, e.g. 'image/*', leave empty/undefined to allow all
+      allowedFileExtensions: ['png', 'jpg'], // leave empty/undefined to allow all
     },
-  ],
+  },
 };
 
 configureWunderGraphApplication({

--- a/docs-website/src/pages/docs/storage/minio/index.md
+++ b/docs-website/src/pages/docs/storage/minio/index.md
@@ -18,17 +18,15 @@ const aws = {
   secretAccessKey: '12345678', // access secret to upload files to the S3 bucket
   bucketName: 'uploads', // the bucket name to which you're uploading files
   useSSL: false, // disable SSL if you're running e.g. Minio on your local machine
-  uploadProfiles: [
-    {
-      avatar: {
-        requireAuthentication: false, // optional, defaults to true
-        maxAllowedUploadSizeBytes: 1024 * 1024 * 10, // 10 MB, optional, defaults to 25 MB
-        maxAllowedFiles: 1, // limit the number of files to 1, leave undefined for unlimited files
-        allowedMimeTypes: ['image/png', 'image/jpeg'], // wildcard is supported, e.g. 'image/*', leave empty/undefined to allow all
-        allowedFileExtensions: ['png', 'jpg'], // leave empty/undefined to allow all
-      },
+  uploadProfiles: {
+    avatar: {
+      requireAuthentication: false, // optional, defaults to true
+      maxAllowedUploadSizeBytes: 1024 * 1024 * 10, // 10 MB, optional, defaults to 25 MB
+      maxAllowedFiles: 1, // limit the number of files to 1, leave undefined for unlimited files
+      allowedMimeTypes: ['image/png', 'image/jpeg'], // wildcard is supported, e.g. 'image/*', leave empty/undefined to allow all
+      allowedFileExtensions: ['png', 'jpg'], // leave empty/undefined to allow all
     },
-  ],
+  },
 };
 
 configureWunderGraphApplication({


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

## Marketing Changelog

<!--
What changes does this PR introduce? Please describe the changes in simple terms that a user can understand
without being familiar with the codebase. Mention @advocates for review and tracking.
-->

#### Checklist

- [ ] run `make test`
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)
