### PR TITLE
feat: unify logging level colors across the SDK

### DIFF
--- a/packages/sdk/src/logger/index.ts
+++ b/packages/sdk/src/logger/index.ts
@@ -56,7 +56,7 @@ const initLogger = (destination: DestinationStream): pino.Logger => {
 	};
 
 	if (enablePretty) {
-		const stream = pretty({
+		const config = {
 			colorize: true,
 			colorizeObjects: false,
 			translateTime: 'HH:MM:ss TT', // https://www.npmjs.com/package/dateformat
@@ -67,7 +67,11 @@ const initLogger = (destination: DestinationStream): pino.Logger => {
 			destination: destination,
 			messageFormat: '{msg}',
 			singleLine: true,
-		});
+		};
+		// XXX: This is supported by pino-pretty but not listed in its types
+		// See https://github.com/pinojs/pino-pretty/blob/e510233be8c0b6068e9e279fc1ecc66e5dde08e7/index.js#L71
+		(config as any).customColors = '20:magenta,30:blue,40:yellow,50:red,message:whiteBright';
+		const stream = pretty(config);
 
 		return pino(options, stream);
 	}


### PR DESCRIPTION
Make the colors used by pino match the colors used by zap

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

## Motivation and Context

Using the same colors for both logging systems produces more visual consistency when
looking at the log messages

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

## Marketing Changelog

<!--
What changes does this PR introduce? Please describe the changes in simple terms that a user can understand
without being familiar with the codebase. Mention @advocates for review and tracking.
-->

#### Checklist

- [ ] run `make test`
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)
