### PR TITLE
fix: when caching a plan, take operationName into account

### DIFF
--- a/pkg/apihandler/apihandler.go
+++ b/pkg/apihandler/apihandler.go
@@ -852,6 +852,11 @@ type SubscriptionResolver interface {
 	ResolveGraphQLSubscription(ctx *resolve.Context, subscription *resolve.GraphQLSubscription, writer resolve.FlushWriter) (err error)
 }
 
+type GraphQLResolver interface {
+	QueryResolver
+	SubscriptionResolver
+}
+
 type liveQueryConfig struct {
 	enabled                bool
 	pollingIntervalSeconds int64

--- a/pkg/apihandler/apihandler_test.go
+++ b/pkg/apihandler/apihandler_test.go
@@ -3,6 +3,7 @@ package apihandler
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -43,6 +44,10 @@ func (f *FakeResolver) ResolveGraphQLResponse(ctx *resolve.Context, response *re
 	f.invocations++
 	_, err = writer.Write(f.resolve(ctx, response, data))
 	return
+}
+
+func (f *FakeResolver) ResolveGraphQLSubscription(ctx *resolve.Context, subscription *resolve.GraphQLSubscription, writer resolve.FlushWriter) error {
+	return errors.New("unimplemented")
 }
 
 type FakeSubscriptionResolver struct {

--- a/pkg/apihandler/graphql_test.go
+++ b/pkg/apihandler/graphql_test.go
@@ -1,0 +1,88 @@
+package apihandler
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dgraph-io/ristretto"
+	"github.com/gavv/httpexpect/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/wundergraph/graphql-go-tools/pkg/astparser"
+	"github.com/wundergraph/graphql-go-tools/pkg/asttransform"
+	"github.com/wundergraph/graphql-go-tools/pkg/engine/resolve"
+	"github.com/wundergraph/wundergraph/pkg/pool"
+	"go.uber.org/zap"
+	"golang.org/x/sync/singleflight"
+)
+
+const (
+	graphqlTestSchema = `
+	type Query {
+		q1: String!
+		q2: String!
+	}`
+)
+
+func graphqlTestQueryWithOperationName(operationName string) string {
+	return fmt.Sprintf(`
+	{
+		"query":"query a { q1 } query b { q2 }",
+		"operationName":"%s"
+	}`, operationName)
+}
+
+func TestGraphQLHandler_PlanCaching(t *testing.T) {
+	// Test that plan caching doesn't incorrectly return a cached plan
+	// for a different operationName
+	definition, report := astparser.ParseGraphqlDocumentString(graphqlTestSchema)
+	if report.HasErrors() {
+		t.Fatal(report.Error())
+	}
+
+	err := asttransform.MergeDefinitionWithBaseSchema(&definition)
+	assert.NoError(t, err)
+
+	resolver := &FakeResolver{
+		resolve: func(ctx *resolve.Context, response *resolve.GraphQLResponse, data []byte) []byte {
+			// Return the queried field
+			object := response.Data.(*resolve.Object)
+			name := object.Fields[0].Name
+			return []byte(fmt.Sprintf(`{"data":{"%s":"%s"}}`, name, name))
+		},
+	}
+
+	planCache, err := ristretto.NewCache(&ristretto.Config{
+		MaxCost:     1024 * 4,      // keep 4k execution plans in the cache
+		NumCounters: 1024 * 4 * 10, // 4k * 10
+		BufferItems: 64,            // number of keys per Get buffer.
+	})
+	assert.NoError(t, err)
+
+	handler := &GraphQLHandler{
+		definition: &definition,
+		resolver:   resolver,
+		planCache:  planCache,
+		sf:         &singleflight.Group{},
+		log:        zap.NewNop(),
+		pool:       pool.New(),
+	}
+
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	e := httpexpect.WithConfig(httpexpect.Config{
+		BaseURL:  srv.URL,
+		Reporter: httpexpect.NewAssertReporter(t),
+	})
+
+	e.POST("/graphql").
+		WithBytes([]byte(graphqlTestQueryWithOperationName("a"))).WithHeader("Content-Type", "application/json").
+		Expect().Status(http.StatusOK).Body().Equal(`{"data":{"q1":"q1"}}`)
+
+	e.POST("/graphql").
+		WithBytes([]byte(graphqlTestQueryWithOperationName("b"))).WithHeader("Content-Type", "application/json").
+		Expect().Status(http.StatusOK).Body().Equal(`{"data":{"q2":"q2"}}`)
+
+}

--- a/pkg/apihandler/graphql_test.go
+++ b/pkg/apihandler/graphql_test.go
@@ -9,12 +9,14 @@ import (
 	"github.com/dgraph-io/ristretto"
 	"github.com/gavv/httpexpect/v2"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"golang.org/x/sync/singleflight"
+
 	"github.com/wundergraph/graphql-go-tools/pkg/astparser"
 	"github.com/wundergraph/graphql-go-tools/pkg/asttransform"
 	"github.com/wundergraph/graphql-go-tools/pkg/engine/resolve"
+
 	"github.com/wundergraph/wundergraph/pkg/pool"
-	"go.uber.org/zap"
-	"golang.org/x/sync/singleflight"
 )
 
 const (


### PR DESCRIPTION
Otherwise we might pick a cached plan for a different operationName

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

## Motivation and Context

Identified when determining operation types sent to GraphQL handler

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

## Marketing Changelog

<!--
What changes does this PR introduce? Please describe the changes in simple terms that a user can understand
without being familiar with the codebase. Mention @advocates for review and tracking.
-->

#### Checklist

- [ ] run `make test`
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)
