### PR TITLE
fix(mock-library): ensure to read req body only once

### DIFF
--- a/packages/sdk/src/testing/mock-server.ts
+++ b/packages/sdk/src/testing/mock-server.ts
@@ -95,7 +95,7 @@ export interface InternalMockRequest {
 	/**
 	 * The parsed request body.
 	 */
-	_body?: any;
+	_body?: Buffer;
 }
 
 export interface MockRequest extends Omit<InternalMockRequest, '_body'> {}
@@ -173,19 +173,13 @@ export class WunderGraphMockServer {
 				mockReq._body = await getBody(req);
 				return mockReq._body;
 			};
-			const json = async <Body = any>(): Promise<Body> => {
-				if (mockReq._body) {
-					return JSON.parse(mockReq._body.toString());
-				}
-				mockReq._body = await getBody(req);
-				return JSON.parse(mockReq._body.toString());
-			};
 			const text = async (): Promise<string> => {
-				if (mockReq._body) {
-					return mockReq._body.toString();
-				}
-				mockReq._body = await getBody(req);
-				return mockReq._body.toString();
+				const body = await raw();
+				return body.toString();
+			};
+			const json = async <Body = any>(): Promise<Body> => {
+				const body = await text();
+				return JSON.parse(body);
 			};
 
 			this.requests.set(req, {

--- a/packages/sdk/src/testing/util.ts
+++ b/packages/sdk/src/testing/util.ts
@@ -1,4 +1,3 @@
-import net from 'net';
 import { Request } from '@wundergraph/straightforward';
 import getRawBody from 'raw-body';
 import { access } from 'node:fs/promises';
@@ -10,32 +9,8 @@ export async function freeport(): Promise<number> {
 	});
 }
 
-export function getJSONBody<Body = any>(req: Request): Promise<Body> {
-	return new Promise((resolve, reject) => {
-		getRawBody(req, (err, body) => {
-			if (err) {
-				reject(err);
-			} else {
-				resolve(JSON.parse(body.toString()));
-			}
-		});
-	});
-}
-
 export function getBody(req: Request): Promise<Buffer> {
 	return getRawBody(req);
-}
-
-export function getTextBody(req: Request): Promise<string> {
-	return new Promise((resolve, reject) => {
-		getRawBody(req, (err, body) => {
-			if (err) {
-				reject(err);
-			} else {
-				resolve(body.toString());
-			}
-		});
-	});
 }
 
 export async function fileExists(path: string) {

--- a/packages/testsuite/apps/mock/.wundergraph/operations/CountryWeather.graphql
+++ b/packages/testsuite/apps/mock/.wundergraph/operations/CountryWeather.graphql
@@ -1,0 +1,20 @@
+query ($countryCode: String!, $capital: String! @internal) {
+	country: countries_countries(filter: { code: { eq: $countryCode } }) {
+		code
+		name
+		capital @export(as: "capital")
+		weather: _join @transform(get: "weather_getCityByName.weather") {
+			weather_getCityByName(name: $capital) {
+				weather {
+					temperature {
+						max
+					}
+					summary {
+						title
+						description
+					}
+				}
+			}
+		}
+	}
+}

--- a/packages/testsuite/apps/mock/.wundergraph/wundergraph.config.ts
+++ b/packages/testsuite/apps/mock/.wundergraph/wundergraph.config.ts
@@ -8,13 +8,22 @@ import {
 import server from './wundergraph.server';
 import operations from './wundergraph.operations';
 
+const weather = introspect.graphql({
+	id: 'weather',
+	apiNamespace: 'weather',
+	url: new EnvironmentVariable('WEATHER_URL', 'https://weather-api.wundergraph.com/'),
+	introspection: {
+		pollingIntervalSeconds: 5,
+	},
+});
+
 const countries = introspect.graphql({
 	apiNamespace: 'countries',
 	url: new EnvironmentVariable('COUNTRIES_URL', 'https://countries.trevorblades.com/'),
 });
 
 configureWunderGraphApplication({
-	apis: [countries],
+	apis: [countries, weather],
 	server,
 	operations,
 	generate: configureWunderGraphGeneration({

--- a/packages/testsuite/apps/mock/test/api-joins.test.ts
+++ b/packages/testsuite/apps/mock/test/api-joins.test.ts
@@ -33,13 +33,12 @@ describe('Mock Api join', () => {
 		 * We join from the country to the weather API with the capital.
 		 */
 		const scopeCountry = ts.mockServer.mock<Record<string, any>>({
-			match: ({ url, method }) => {
-				return url.path === '/' && method === 'POST';
-			},
-			handler: async ({ json }) => {
+			match: async ({ json }) => {
 				const body = await json();
 				expect(body.variables.countryCode).toEqual('DE');
-
+				return true;
+			},
+			handler: async ({}) => {
 				return {
 					body: { data: { country: [{ code: 'DE', name: 'Germany', capital: 'Berlin' }] } },
 				};
@@ -47,13 +46,12 @@ describe('Mock Api join', () => {
 		});
 
 		const scopeWeather = ts.mockServer.mock<Record<string, any>>({
-			match: async ({ url, method }) => {
-				return url.path === '/' && method === 'POST';
-			},
-			handler: async ({ json }) => {
+			match: async ({ json }) => {
 				const body = await json();
 				expect(body.variables.capital).toEqual('Berlin');
-
+				return true;
+			},
+			handler: async ({ json }) => {
 				return {
 					body: {
 						data: {

--- a/packages/testsuite/apps/mock/test/api-joins.test.ts
+++ b/packages/testsuite/apps/mock/test/api-joins.test.ts
@@ -1,0 +1,99 @@
+import { expect, beforeAll, describe, it } from 'vitest';
+import { join } from 'path';
+import { TestServers, createTestAndMockServer } from '../.wundergraph/generated/testing';
+import { TestContext } from '../types';
+
+let ts: TestServers;
+
+beforeAll(async (ctx) => {
+	ts = createTestAndMockServer({
+		// The directory where your wundergraph directory is located
+		dir: join(__dirname, '..'),
+		// Enable debug mode to see the real API request
+		// This simplifies mock creation
+		// debug: true,
+	});
+
+	return ts.start({
+		// Environment variables replaced by the test mock server URL
+		mockURLEnvs: [
+			// dynamic environment variable
+			'OS_NODE_URL',
+			// datasource environment variables
+			'WEATHER_URL',
+			'COUNTRIES_URL',
+		],
+	});
+});
+
+describe('Mock Api join', () => {
+	it<TestContext>('Should be able to mock the country and weather join', async () => {
+		/**
+		 * The order is important for a join.
+		 * We join from the country to the weather API with the capital.
+		 */
+		const scopeCountry = ts.mockServer.mock<Record<string, any>>({
+			match: ({ url, method }) => {
+				return url.path === '/' && method === 'POST';
+			},
+			handler: async ({ json }) => {
+				const body = await json();
+				expect(body.variables.countryCode).toEqual('DE');
+
+				return {
+					body: { data: { country: [{ code: 'DE', name: 'Germany', capital: 'Berlin' }] } },
+				};
+			},
+		});
+
+		const scopeWeather = ts.mockServer.mock<Record<string, any>>({
+			match: async ({ url, method }) => {
+				return url.path === '/' && method === 'POST';
+			},
+			handler: async ({ json }) => {
+				const body = await json();
+				expect(body.variables.capital).toEqual('Berlin');
+
+				return {
+					body: {
+						data: {
+							weather_getCityByName: {
+								weather: { temperature: { max: 297.13 }, summary: { title: 'Clear', description: 'clear sky' } },
+							},
+						},
+					},
+				};
+			},
+		});
+
+		const result = await ts.testServer.client().query({
+			operationName: 'CountryWeather',
+			input: {
+				countryCode: 'DE',
+			},
+		});
+
+		scopeWeather.done();
+		scopeCountry.done();
+
+		expect(result.error).toBeUndefined();
+		expect(result.data).toStrictEqual({
+			country: [
+				{
+					code: 'DE',
+					name: 'Germany',
+					capital: 'Berlin',
+					weather: {
+						temperature: {
+							max: 297.13,
+						},
+						summary: {
+							title: 'Clear',
+							description: 'clear sky',
+						},
+					},
+				},
+			],
+		});
+	});
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

## Motivation and Context

This PR provides an example of how to mock our `join` directive which issues multiple request to external API's. During this, I found an issue. We allow to read the request body multiple times when multiple mock handlers call `json`, `raw` or `text`.

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

## Marketing Changelog

<!--
What changes does this PR introduce? Please describe the changes in simple terms that a user can understand
without being familiar with the codebase. Mention @advocates for review and tracking.
-->

#### Checklist

- [ ] run `make test`
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)
