### PR TITLE
fix: type error in generated jsonschema.ts file

### DIFF
--- a/packages/sdk/src/codegen/templates/typescript/jsonschema.template.ts
+++ b/packages/sdk/src/codegen/templates/typescript/jsonschema.template.ts
@@ -3,8 +3,8 @@ export const template = `
 // @ts-ignore: no-types available		
 import type {JSONSchema7} from "json-schema";
 
-interface JSONSchema extends JSONSchema7 {
-		'x-graphql-enum-name'?: string;
+type JSONSchema = JSONSchema7 & {
+	'x-graphql-enum-name'?: string;
 }
 
 export interface Queries {

--- a/packages/sdk/src/codegen/templates/typescript/jsonschema.template.ts
+++ b/packages/sdk/src/codegen/templates/typescript/jsonschema.template.ts
@@ -3,17 +3,15 @@ export const template = `
 // @ts-ignore: no-types available		
 import type {JSONSchema7} from "json-schema";
 
-declare module 'json-schema' {
-		export interface JSONSchema7 {
+interface JSONSchema extends JSONSchema7 {
 		'x-graphql-enum-name'?: string;
-	}
 }
 
 export interface Queries {
     {{#each queries}}
     "{{name}}": {
-        input: JSONSchema7;
-        response: JSONSchema7;
+        input: JSONSchema;
+        response: JSONSchema;
 				operationType: string;
 				description: string;
     },
@@ -23,8 +21,8 @@ export interface Queries {
 export interface Mutations {
     {{#each mutations}}
     "{{name}}": {
-        input: JSONSchema7;
-        response: JSONSchema7;
+        input: JSONSchema;
+        response: JSONSchema;
 				operationType: string;
 				description: string;
     },
@@ -34,8 +32,8 @@ export interface Mutations {
 export interface Subscriptions {
     {{#each subscriptions}}
     "{{name}}": {
-        input: JSONSchema7;
-        response: JSONSchema7;
+        input: JSONSchema;
+        response: JSONSchema;
 				operationType: string;
 				description: string;
     },

--- a/packages/sdk/src/codegen/templates/typescript/jsonschema.template.ts
+++ b/packages/sdk/src/codegen/templates/typescript/jsonschema.template.ts
@@ -3,6 +3,12 @@ export const template = `
 // @ts-ignore: no-types available		
 import type {JSONSchema7} from "json-schema";
 
+declare module 'json-schema' {
+		export interface JSONSchema7 {
+		'x-graphql-enum-name'?: string;
+	}
+}
+
 export interface Queries {
     {{#each queries}}
     "{{name}}": {


### PR DESCRIPTION
## Motivation and Context

We extend the json schema type with custom attribute. We need to replicate this in the generated file.

#### Checklist

- [x] run `make test`
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)
