### PR TITLE
fix: server logger missing cloud env bindings

### DIFF
--- a/packages/sdk/src/logger/index.ts
+++ b/packages/sdk/src/logger/index.ts
@@ -58,9 +58,20 @@ const initLogger = (destination: DestinationStream): pino.Logger => {
 
 const logger = initLogger(process.stdout);
 
+let cloudBindings: Record<string, any> = {};
+if (process.env.WG_CLOUD_ENVIRONMENT_ID) {
+	cloudBindings.environmentID = process.env.WG_CLOUD_ENVIRONMENT_ID;
+}
+if (process.env.WG_CLOUD_PROJECT_ID) {
+	cloudBindings.projectID = process.env.WG_CLOUD_PROJECT_ID;
+}
+if (process.env.WG_CLOUD_DEPLOYMENT_ID) {
+	cloudBindings.deploymentID = process.env.WG_CLOUD_DEPLOYMENT_ID;
+}
+
 export const Logger = logger.child({ component: '@wundergraph/sdk' });
 export const ServerLogger = logger.child(
-	{ component: '@wundergraph/server' },
+	{ component: '@wundergraph/server', ...cloudBindings },
 	{ level: process.env.WG_DEBUG_MODE === 'true' ? PinoLogLevel.Debug : PinoLogLevel.Info }
 );
 

--- a/packages/sdk/src/logger/index.ts
+++ b/packages/sdk/src/logger/index.ts
@@ -58,7 +58,7 @@ const initLogger = (destination: DestinationStream): pino.Logger => {
 
 const logger = initLogger(process.stdout);
 
-let cloudBindings: Record<string, any> = {};
+const cloudBindings: Record<string, any> = {};
 if (process.env.WG_CLOUD_ENVIRONMENT_ID) {
 	cloudBindings.environmentID = process.env.WG_CLOUD_ENVIRONMENT_ID;
 }


### PR DESCRIPTION
#### Checklist

- [x] run `make test`
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)
