### PR TITLE
fix: jsonschema template

### DIFF
--- a/packages/sdk/src/codegen/templates/typescript/jsonschema.template.ts
+++ b/packages/sdk/src/codegen/templates/typescript/jsonschema.template.ts
@@ -3,15 +3,18 @@ export const template = `
 // @ts-ignore: no-types available		
 import type {JSONSchema7} from "json-schema";
 
-type JSONSchema = JSONSchema7 & {
-	'x-graphql-enum-name'?: string;
+// @ts-ignore: module unavailable
+declare module 'json-schema' {
+	export interface JSONSchema7 {
+		'x-graphql-enum-name'?: string;
+	}
 }
 
 export interface Queries {
     {{#each queries}}
     "{{name}}": {
-        input: JSONSchema;
-        response: JSONSchema;
+        input: JSONSchema7;
+        response: JSONSchema7;
 				operationType: string;
 				description: string;
     },
@@ -21,8 +24,8 @@ export interface Queries {
 export interface Mutations {
     {{#each mutations}}
     "{{name}}": {
-        input: JSONSchema;
-        response: JSONSchema;
+        input: JSONSchema7;
+        response: JSONSchema7;
 				operationType: string;
 				description: string;
     },
@@ -32,8 +35,8 @@ export interface Mutations {
 export interface Subscriptions {
     {{#each subscriptions}}
     "{{name}}": {
-        input: JSONSchema;
-        response: JSONSchema;
+        input: JSONSchema7;
+        response: JSONSchema7;
 				operationType: string;
 				description: string;
     },


### PR DESCRIPTION
declare module instead of type in jsonschema.ts

Also Unless we set shamefully hoist, the module is not detected with pnpm. So we just ts-ignore it in that case. Other package managers have no issue. This is done to bypass pnpm with testapps.

#### Checklist

- [x] run `make test`
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)
