### PR TITLE
fix: don't interfere with terminal after running wunderctl up

### DIFF
--- a/cli/commands/up.go
+++ b/cli/commands/up.go
@@ -199,6 +199,7 @@ var upCmd = &cobra.Command{
 				log.Warn("could not enable console UI", zap.Error(err))
 			} else {
 				go consoleUI.Run()
+				defer consoleUI.Close()
 			}
 		}
 

--- a/pkg/apihandler/apihandler_test.go
+++ b/pkg/apihandler/apihandler_test.go
@@ -593,12 +593,13 @@ func TestFunctionsHandler_Live(t *testing.T) {
 	validateNothing, err := inputvariables.NewValidator(inputSchema, true)
 	assert.NoError(t, err)
 
-	hookServerRequestCount := 0
+	var hookServerRequestCount atomic.Int64
 
 	fakeHookServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"response":{"data":{"me":{"name":"Jens","bio":"Founder & CEO of WunderGraph","counter":` + strconv.Itoa(hookServerRequestCount) + `}}}}`))
-		hookServerRequestCount++
+		count := int(hookServerRequestCount.Load())
+		_, _ = w.Write([]byte(`{"response":{"data":{"me":{"name":"Jens","bio":"Founder & CEO of WunderGraph","counter":` + strconv.Itoa(count) + `}}}}`))
+		hookServerRequestCount.Add(1)
 	}))
 
 	defer fakeHookServer.Close()

--- a/pkg/apihandler/apihandler_test.go
+++ b/pkg/apihandler/apihandler_test.go
@@ -650,7 +650,7 @@ func TestFunctionsHandler_Live(t *testing.T) {
 	data, err := ioutil.ReadAll(res.Body)
 	assert.Equal(t, context.DeadlineExceeded, err)
 	assert.Equal(t, "{\"data\":{\"me\":{\"name\":\"Jens\",\"bio\":\"Founder & CEO of WunderGraph\",\"counter\":0}}}\n\n{\"data\":{\"me\":{\"name\":\"Jens\",\"bio\":\"Founder & CEO of WunderGraph\",\"counter\":1}}}\n\n{\"data\":{\"me\":{\"name\":\"Jens\",\"bio\":\"Founder & CEO of WunderGraph\",\"counter\":2}}}\n\n", string(data))
-	assert.Equal(t, 3, hookServerRequestCount)
+	assert.Equal(t, 3, int(hookServerRequestCount.Load()))
 }
 
 func TestFunctionsHandler_Live_JSONPatch(t *testing.T) {

--- a/pkg/cui/cui.go
+++ b/pkg/cui/cui.go
@@ -61,8 +61,10 @@ func (u *UI) Open() error {
 
 // Close closes the keyboard handle
 func (u *UI) Close() {
-	u.enabled = false
-	_ = keyboard.Close()
+	if u.enabled {
+		u.enabled = false
+		_ = keyboard.Close()
+	}
 }
 
 func (u *UI) quit() {


### PR DESCRIPTION
Even if we're exiting, we need to call keyboard.Close() to restore
the terminal state

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

## Marketing Changelog

<!--
What changes does this PR introduce? Please describe the changes in simple terms that a user can understand
without being familiar with the codebase. Mention @advocates for review and tracking.
-->

#### Checklist

- [ ] run `make test`
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)
