### PR TITLE
fix: string email_verified fields from sign in with apple

### DIFF
--- a/pkg/authentication/authentication.go
+++ b/pkg/authentication/authentication.go
@@ -78,6 +78,16 @@ func (u *UserLoader) parseClaims(r io.Reader) (*Claims, error) {
 	if err := json.Unmarshal(data, &claims); err != nil {
 		return nil, err
 	}
+
+	switch v := claims.EmailVerifiedRaw.(type) {
+	case bool:
+		claims.EmailVerified = v
+	case string:
+		claims.EmailVerified = (v == "true")
+	default:
+		return nil, fmt.Errorf("email_verified field is neither a bool nor a string")
+	}
+
 	if err := json.Unmarshal(data, &claims.Raw); err != nil {
 		return nil, err
 	}

--- a/pkg/authentication/oidc.go
+++ b/pkg/authentication/oidc.go
@@ -124,7 +124,8 @@ type Claims struct {
 	Picture           string                 `json:"picture"`
 	Website           string                 `json:"website"`
 	Email             string                 `json:"email"`
-	EmailVerified     bool                   `json:"email_verified"`
+	EmailVerified     bool                   `json:"-"`
+	EmailVerifiedRaw  interface{}            `json:"email_verified"`
 	Gender            string                 `json:"gender"`
 	BirthDate         string                 `json:"birthdate"`
 	ZoneInfo          string                 `json:"zoneinfo"`


### PR DESCRIPTION
Neither token nor cookie based providers work with sign in with apple via Auth0. The reason is that apple provides the email_verified field as a string. This breaks the parser which expects a boolean value. I fixed the token based flow here.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

## Marketing Changelog

<!--
What changes does this PR introduce? Please describe the changes in simple terms that a user can understand
without being familiar with the codebase. Mention @advocates for review and tracking.
-->

#### Checklist

- [x] run `make test`
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)
