### PR TITLE
feat: propagate error messages from functions/hooks to API responses

### DIFF
--- a/cli/helpers/server_runner.go
+++ b/cli/helpers/server_runner.go
@@ -38,6 +38,7 @@ func NewHooksServerRunner(log *zap.Logger, cfg *HooksServerRunConfig) *scriptrun
 
 	if cfg.Debug {
 		scriptArgs = append(scriptArgs, "--inspect="+cfg.DebugBindAddress)
+		scriptArgs = append(scriptArgs, "--enable-source-maps")
 	}
 	scriptArgs = append(scriptArgs, cfg.ServerScriptFile)
 

--- a/packages/sdk/src/server/error.ts
+++ b/packages/sdk/src/server/error.ts
@@ -1,0 +1,24 @@
+type ErrorRepresentation = {
+	type: string;
+	message: string;
+	stack?: string;
+};
+
+const errorToJSON = (err: Error): ErrorRepresentation => {
+	return {
+		type: err.constructor.name,
+		message: err.message,
+		stack: err.stack,
+	};
+};
+
+export class ServerError extends Error {
+	constructor(message: string) {
+		super(message);
+		Object.setPrototypeOf(this, ServerError.prototype);
+	}
+
+	toJSON() {
+		return errorToJSON(this);
+	}
+}

--- a/packages/sdk/src/server/plugins/hooks.ts
+++ b/packages/sdk/src/server/plugins/hooks.ts
@@ -20,6 +20,7 @@ import { Attributes } from '../trace/attributes';
 import { attachErrorToSpan } from '../trace/util';
 import { InternalIntergration, InternalHookConfig } from '../../integrations/types';
 import { hookID } from '../util';
+import { ServerError } from '../error';
 
 const maximumRecursionLimit = 16;
 
@@ -417,7 +418,7 @@ const FastifyHooksPlugin: FastifyPluginAsync<FastifyHooksOptions> = async (fasti
 			if (body.cycleCounter > maximumRecursionLimit) {
 				const errorMessage = `maximum recursion limit reached (${maximumRecursionLimit})`;
 				req.log.error(errorMessage);
-				throw new Error(errorMessage);
+				throw new ServerError(errorMessage);
 			}
 			extraHeaders['Wg-Cycle-Counter'] = body.cycleCounter;
 		}

--- a/packages/sdk/src/server/server.ts
+++ b/packages/sdk/src/server/server.ts
@@ -40,6 +40,7 @@ import { CreateServerOptions, TracerConfig } from './types';
 import { loadTraceConfigFromWgConfig } from './trace/config';
 import { TelemetryPluginOptions } from './plugins/telemetry';
 import { createLogger } from './logger';
+import { ServerError } from './error';
 
 export const WunderGraphConfigurationFilename = 'wundergraph.wgconfig';
 
@@ -328,7 +329,7 @@ export const createServer = async ({
 		if (serverConfig.context?.request?.create) {
 			const result = await serverConfig.context.request.create(globalContext);
 			if (result === undefined) {
-				throw new Error('could not instantiate request context');
+				throw new ServerError('could not instantiate request context');
 			}
 			return result;
 		}
@@ -550,7 +551,7 @@ export const createServer = async ({
 		  })
 		: ({
 				from() {
-					throw new Error(
+					throw new ServerError(
 						`ORM is not enabled for your application. Set "experimental.orm" to "true" in your \`wundergraph.config.ts\` to enable.`
 					);
 				},

--- a/packages/testsuite/apps/hooks/.wundergraph/wundergraph.server.ts
+++ b/packages/testsuite/apps/hooks/.wundergraph/wundergraph.server.ts
@@ -1,20 +1,20 @@
 import { GraphQLObjectType, GraphQLSchema, GraphQLString, GraphQLInt, GraphQLFloat, GraphQLBoolean } from 'graphql';
 
 import { configureWunderGraphServer } from '@wundergraph/sdk/server';
+import { ResponseError } from '@wundergraph/sdk/client';
 
 export default configureWunderGraphServer(() => ({
 	hooks: {
 		queries: {
 			Infinite: {
 				preResolve: async (hook) => {
-					const result = await hook.internalClient.queries.Infinite({
-						input: hook.input,
-					});
-
-					const result2 = await hook.operations.query({
+					const result = await hook.operations.query({
 						operationName: 'Infinite',
 						input: hook.input,
 					});
+					if (result.error) {
+						throw result.error;
+					}
 				},
 			},
 			PreResolveFailure: {

--- a/pkg/apihandler/apihandler.go
+++ b/pkg/apihandler/apihandler.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/http/httputil"
 	"os"
@@ -498,6 +497,7 @@ func (r *Builder) registerOperation(operation *wgpb.Operation) error {
 			renameTypeNames:        r.renameTypeNames,
 			queryParamsAllowList:   queryParamsAllowList,
 			hooksPipeline:          hooksPipeline,
+			errorHandler:           newErrorHandler(operation, r.devMode),
 		}
 
 		if operation.LiveQueryConfig != nil && operation.LiveQueryConfig.Enable {
@@ -545,6 +545,7 @@ func (r *Builder) registerOperation(operation *wgpb.Operation) error {
 			postResolveTransformer: postResolveTransformer,
 			renameTypeNames:        r.renameTypeNames,
 			hooksPipeline:          hooksPipeline,
+			errorHandler:           newErrorHandler(operation, r.devMode),
 		}
 		copy(handler.extractedVariables, shared.Doc.Input.Variables)
 		route = r.router.Methods(http.MethodPost, http.MethodOptions).Path(apiPath)
@@ -583,6 +584,7 @@ func (r *Builder) registerOperation(operation *wgpb.Operation) error {
 			renameTypeNames:        r.renameTypeNames,
 			queryParamsAllowList:   queryParamsAllowList,
 			hooksPipeline:          hooksPipeline,
+			errorHandler:           newErrorHandler(operation, r.devMode),
 		}
 		copy(handler.extractedVariables, shared.Doc.Input.Variables)
 		route = r.router.Methods(http.MethodGet, http.MethodOptions).Path(apiPath)
@@ -880,6 +882,7 @@ type QueryHandler struct {
 	renameTypeNames        []resolve.RenameTypeName
 	queryParamsAllowList   []string
 	hooksPipeline          *hooks.SynchronousOperationPipeline
+	errorHandler           *errorHandler
 }
 
 func (h *QueryHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -935,10 +938,8 @@ func (h *QueryHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resolveCtx.Variables, err = postProcessVariables(h.operation, r, resolveCtx.Variables)
-	if err != nil {
-		if done := handleOperationErr(requestLogger, err, w, "postProcessVariables failed", h.operation); done {
-			return
-		}
+	if h.errorHandler.Done(w, err, "postProcessVariables failed", requestLogger) {
+		return
 	}
 
 	flusher, flusherOk := w.(http.Flusher)
@@ -960,7 +961,7 @@ func (h *QueryHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp, err := h.hooksPipeline.Run(resolveCtx, w, r, buf)
-	if done := handleOperationErr(requestLogger, err, w, "hooks pipeline failed", h.operation); done {
+	if h.errorHandler.Done(w, err, "hooks pipeline failed", requestLogger) {
 		return
 	}
 
@@ -976,7 +977,7 @@ func (h *QueryHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	_, err = w.Write(resp.Data)
-	if done := handleOperationErr(requestLogger, err, w, "writing response failed", h.operation); done {
+	if h.errorHandler.Done(w, err, "writing response failed", requestLogger) {
 		return
 	}
 }
@@ -1135,6 +1136,7 @@ type MutationHandler struct {
 	postResolveTransformer *postresolvetransform.Transformer
 	renameTypeNames        []resolve.RenameTypeName
 	hooksPipeline          *hooks.SynchronousOperationPipeline
+	errorHandler           *errorHandler
 }
 
 func (h *MutationHandler) parseFormVariables(r *http.Request) []byte {
@@ -1218,17 +1220,15 @@ func (h *MutationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ctx.Variables, err = postProcessVariables(h.operation, r, ctx.Variables)
-	if err != nil {
-		if done := handleOperationErr(requestLogger, err, w, "postProcessVariables failed", h.operation); done {
-			return
-		}
+	if h.errorHandler.Done(w, err, "postProcessVariables failed", requestLogger) {
+		return
 	}
 
 	buf := pool.GetBytesBuffer()
 	defer pool.PutBytesBuffer(buf)
 
 	resp, err := h.hooksPipeline.Run(ctx, w, r, buf)
-	if done := handleOperationErr(requestLogger, err, w, "hooks pipeline failed", h.operation); done {
+	if h.errorHandler.Done(w, err, "hooks pipeline failed", requestLogger) {
 		return
 	}
 
@@ -1242,7 +1242,7 @@ func (h *MutationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	reader := bytes.NewReader(resp.Data)
 	_, err = reader.WriteTo(w)
-	if done := handleOperationErr(requestLogger, err, w, "writing response failed", h.operation); done {
+	if h.errorHandler.Done(w, err, "writing response failed", requestLogger) {
 		return
 	}
 }
@@ -1263,6 +1263,7 @@ type SubscriptionHandler struct {
 	renameTypeNames        []resolve.RenameTypeName
 	queryParamsAllowList   []string
 	hooksPipeline          *hooks.SubscriptionOperationPipeline
+	errorHandler           *errorHandler
 }
 
 func (h *SubscriptionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -1321,10 +1322,8 @@ func (h *SubscriptionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	}
 
 	ctx.Variables, err = postProcessVariables(h.operation, r, ctx.Variables)
-	if err != nil {
-		if done := handleOperationErr(requestLogger, err, w, "postProcessVariables failed", h.operation); done {
-			return
-		}
+	if h.errorHandler.Done(w, err, "postProcessVariables failed", requestLogger) {
+		return
 	}
 
 	ctx, flushWriter, ok := getHooksFlushWriter(ctx, r, w, h.hooksPipeline, h.log)
@@ -1739,7 +1738,8 @@ func (r *Builder) registerNodejsOperation(operation *wgpb.Operation, apiPath str
 			enabled:                operation.LiveQueryConfig.Enable,
 			pollingIntervalSeconds: operation.LiveQueryConfig.PollingIntervalSeconds,
 		},
-		internal: false,
+		internal:     false,
+		errorHandler: newErrorHandler(operation, r.devMode),
 	}
 
 	if operation.AuthenticationConfig != nil && operation.AuthenticationConfig.AuthRequired {
@@ -1769,6 +1769,7 @@ type FunctionsHandler struct {
 	stringInterpolator   *interpolate.StringInterpolator
 	liveQuery            liveQueryConfig
 	internal             bool
+	errorHandler         *errorHandler
 }
 
 func (h *FunctionsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -1863,7 +1864,7 @@ func (h *FunctionsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	isLive := h.liveQuery.enabled && r.URL.Query().Has(WgLiveParam)
 
 	input, err := hooks.EncodeData(r, buf, ctx.Variables, nil)
-	if done := handleOperationErr(requestLogger, err, w, "encoding hook data failed", h.operation); done {
+	if h.errorHandler.Done(w, err, "encoding hook data failed", requestLogger) {
 		return
 	}
 
@@ -2069,45 +2070,6 @@ func getFlushWriter(ctx *resolve.Context, variables []byte, r *http.Request, w h
 	}
 
 	return ctx, flushWriter, true
-}
-
-func handleOperationErr(log *zap.Logger, err error, w http.ResponseWriter, errorMessage string, operation *wgpb.Operation) (done bool) {
-	if err == nil {
-		return false
-	}
-	if errors.Is(err, context.Canceled) {
-		// client closed connection
-		w.WriteHeader(499)
-		return true
-	}
-	// This detects all timeout errors, including context.DeadlineExceeded
-	var ne net.Error
-	if errors.As(err, &ne) && ne.Timeout() {
-		// request timeout exceeded
-		log.Warn("request timeout exceeded",
-			zap.String("operationName", operation.Name),
-			zap.String("operationType", operation.OperationType.String()),
-		)
-		w.WriteHeader(http.StatusGatewayTimeout)
-		_, _ = io.WriteString(w, http.StatusText(http.StatusGatewayTimeout))
-		return true
-	}
-	var validationError *inputvariables.ValidationError
-	if errors.As(err, &validationError) {
-		w.WriteHeader(http.StatusBadRequest)
-		enc := json.NewEncoder(w)
-		if err := enc.Encode(&validationError); err != nil {
-			log.Error("error encoding validation error", zap.Error(err))
-		}
-		return true
-	}
-	log.Error(errorMessage,
-		zap.String("operationName", operation.Name),
-		zap.String("operationType", operation.OperationType.String()),
-		zap.Error(err),
-	)
-	http.Error(w, fmt.Sprintf("%s: %s", errorMessage, err.Error()), http.StatusInternalServerError)
-	return true
 }
 
 func validateInputVariables(ctx context.Context, log *zap.Logger, variables []byte, validator *inputvariables.Validator, w http.ResponseWriter) bool {

--- a/pkg/apihandler/errorhandler.go
+++ b/pkg/apihandler/errorhandler.go
@@ -1,0 +1,117 @@
+package apihandler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strconv"
+
+	"github.com/wundergraph/wundergraph/pkg/hooks"
+	"github.com/wundergraph/wundergraph/pkg/inputvariables"
+	"github.com/wundergraph/wundergraph/pkg/wgpb"
+	"go.uber.org/zap"
+)
+
+type errorHandler struct {
+	operation *wgpb.Operation
+	devMode   bool
+}
+
+func newErrorHandler(operation *wgpb.Operation, devMode bool) *errorHandler {
+	return &errorHandler{
+		operation: operation,
+		devMode:   devMode,
+	}
+}
+
+func (h *errorHandler) hookResponseError(w http.ResponseWriter, hookErr *hooks.HookResponseError) {
+	type gqlError struct {
+		Message string `json:"message"`
+	}
+
+	type gqlHookResponseErrorExtension struct {
+		Code       string `json:"code,omitempty"`
+		StatusCode int    `json:"statusCode,omitempty"`
+		Stack      string `json:"stack,omitempty"`
+	}
+	type gqlErrorExtensions struct {
+		Hooks []gqlHookResponseErrorExtension `json:"hooks"`
+	}
+	type gqlErrorResponse struct {
+		Errors     []gqlError          `json:"errors"`
+		Extensions *gqlErrorExtensions `json:"extensions,omitempty"`
+	}
+	// Only print stack traces on development mode
+	stack := ""
+	if h.devMode {
+		stack = hookErr.Stack
+	}
+	resp := &gqlErrorResponse{
+		Errors: []gqlError{
+			{
+				Message: hookErr.Message,
+			},
+		},
+		Extensions: &gqlErrorExtensions{
+			Hooks: []gqlHookResponseErrorExtension{
+				{
+					Code:       hookErr.Code,
+					StatusCode: hookErr.StatusCode,
+					Stack:      stack,
+				},
+			},
+		},
+	}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("error encoding error response: %v", err), http.StatusInternalServerError)
+		return
+	}
+	hdr := w.Header()
+	hdr.Set("Content-Type", "application/json")
+	hdr.Set("Content-Length", strconv.Itoa(len(data)))
+	_, _ = w.Write(data)
+}
+
+func (h *errorHandler) Done(w http.ResponseWriter, err error, errorMessage string, log *zap.Logger) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) {
+		// client closed connection
+		w.WriteHeader(499)
+		return true
+	}
+	log = log.With(zap.String("operationName", h.operation.Name),
+		zap.String("operationType", h.operation.OperationType.String()))
+	// This detects all timeout errors, including context.DeadlineExceeded
+	var ne net.Error
+	if errors.As(err, &ne) && ne.Timeout() {
+		// request timeout exceeded
+		log.Warn("request timeout exceeded")
+		w.WriteHeader(http.StatusGatewayTimeout)
+		_, _ = io.WriteString(w, http.StatusText(http.StatusGatewayTimeout))
+		return true
+	}
+	var validationError *inputvariables.ValidationError
+	if errors.As(err, &validationError) {
+		w.WriteHeader(http.StatusBadRequest)
+		enc := json.NewEncoder(w)
+		if err := enc.Encode(&validationError); err != nil {
+			log.Error("error encoding validation error", zap.Error(err))
+		}
+		return true
+	}
+	var hookResponseError *hooks.HookResponseError
+	if errors.As(err, &hookResponseError) && hookResponseError.Message != "" {
+		h.hookResponseError(w, hookResponseError)
+		return true
+	}
+	log.Error(errorMessage, zap.Error(err))
+	http.Error(w, fmt.Sprintf("%s: %s", errorMessage, err.Error()), http.StatusInternalServerError)
+	return true
+}

--- a/pkg/hooks/authentication.go
+++ b/pkg/hooks/authentication.go
@@ -142,9 +142,9 @@ func runMutatingAuthenticationHook(ctx context.Context, hook MiddlewareHook, cli
 		log.Error("hook failed", zap.Error(err))
 		return nil, err
 	}
-	if out.Error != "" {
-		log.Error("returned an error", zap.String("error", out.Error))
-		return nil, AuthenticationDeniedError(out.Error)
+	if err := out.ResponseError(); err != nil {
+		log.Error("returned an error", zap.Error(err))
+		return nil, AuthenticationDeniedError(err.Error())
 	}
 	var res mutatingPostAuthenticationResponse
 	if err := json.Unmarshal(out.Response, &res); err != nil {

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -594,6 +594,7 @@ func (n *Node) startServer(nodeConfig *WunderNodeConfig) error {
 		Metrics:             n.metrics,
 		InsecureCookies:     n.options.insecureCookies,
 		Log:                 n.log,
+		DevMode:             n.options.devMode,
 	}
 	internalBuilder := apihandler.NewInternalBuilder(internalBuilderConfig)
 


### PR DESCRIPTION
When a function or a hook throws an error, propagate it through the stack
until it's output by the API as an error. This allows clients to retrieve
the very same error message that was produced in the backend.

If the error is not one of the types we control, just log it to the terminal's
output without returning it through the API, since that could expose internal
implementation details.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

## Marketing Changelog

<!--
What changes does this PR introduce? Please describe the changes in simple terms that a user can understand
without being familiar with the codebase. Mention @advocates for review and tracking.
-->

#### Checklist

- [ ] run `make test`
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)
