### PR TITLE
fix: wunderctl start --debug

### DIFF
--- a/cli/commands/root.go
+++ b/cli/commands/root.go
@@ -64,7 +64,8 @@ var (
 	// By default it is 5 seconds but for CI and debugging purposes it should be set much lower
 	otelBatchTimeout time.Duration
 
-	rootFlags helpers.RootFlags
+	rootFlags        helpers.RootFlags
+	debugBindAddress string
 
 	red    = color.New(color.FgHiRed)
 	green  = color.New(color.FgHiGreen)
@@ -398,6 +399,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&rootFlags.Log, logLevelFlagName, "l", "info", "Sets the log level")
 	rootCmd.PersistentFlags().StringVarP(&DotEnvFile, "env", "e", ".env", "Allows you to load environment variables from an env file. Defaults to .env in the current directory.")
 	rootCmd.PersistentFlags().BoolVar(&rootFlags.DebugMode, "debug", false, "Enables the debug mode so that all requests and responses will be logged")
+	rootCmd.PersistentFlags().StringVar(&debugBindAddress, "debug-bind-address", "127.0.0.1:9229", "Default host:port to bind to, will only work in conjunction with --debug")
 	rootCmd.PersistentFlags().BoolVar(&rootFlags.Telemetry, "telemetry", !isTelemetryDisabled, "Enables telemetry. Telemetry allows us to accurately gauge WunderGraph feature usage, pain points, and customization across all users.")
 	rootCmd.PersistentFlags().BoolVar(&rootFlags.TelemetryDebugMode, "telemetry-debug", isTelemetryDebugEnabled, "Enables the debug mode for telemetry. Understand what telemetry is being sent to us.")
 	rootCmd.PersistentFlags().BoolVar(&rootFlags.PrettyLogs, prettyLoggingFlagName, false, "Enables pretty logging")

--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -72,6 +72,7 @@ func startHooksServer(ctx context.Context) error {
 		ServerScriptFile:  serverScriptFile,
 		Production:        true,
 		Debug:             rootFlags.DebugMode,
+		DebugBindAddress:  debugBindAddress,
 		Env:               helpers.CliEnv(rootFlags),
 		Log:               rootFlags.Log,
 		Output:            helpers.ScriptRunnerOutputConfig(rootFlags),

--- a/cli/commands/up.go
+++ b/cli/commands/up.go
@@ -47,7 +47,6 @@ var (
 	clearCacheOnStart                       bool
 	enableTUI                               bool
 	logs                                    bool
-	debugBindAddress                        string
 	restartFunc                             func()
 )
 
@@ -708,7 +707,6 @@ func init() {
 	upCmd.PersistentFlags().BoolVar(&disableCache, "no-cache", false, "Disables local caches")
 	upCmd.PersistentFlags().BoolVar(&clearCacheOnStart, "clear-cache", false, "Clears local caches before startup")
 	upCmd.PersistentFlags().BoolVar(&rootFlags.PrettyLogs, prettyLoggingFlagName, true, "Enables pretty logging")
-	upCmd.PersistentFlags().StringVar(&debugBindAddress, "debug-bind-address", "127.0.0.1:9229", "Default host:port to bind to, will only work in conjunction with --debug")
 
 	rootCmd.AddCommand(upCmd)
 }


### PR DESCRIPTION
We always need to pass the debug bind address to the script runner, since
we're using --inspect=, and including the equals sign always requires an address.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

## Marketing Changelog

<!--
What changes does this PR introduce? Please describe the changes in simple terms that a user can understand
without being familiar with the codebase. Mention @advocates for review and tracking.
-->

#### Checklist

- [ ] run `make test`
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)
