### PR TITLE
feat: use GitHub API instead of tarballs when downloading examples

### DIFF
--- a/packages/create-wundergraph-app/src/helpers/download.ts
+++ b/packages/create-wundergraph-app/src/helpers/download.ts
@@ -27,6 +27,130 @@ export const downloadTar = async (url: string) => {
 	}
 };
 
+type FSFile = {
+	contents: string;
+};
+
+type FSDir = {
+	contents: null;
+	children: FSEntry[];
+};
+
+type FSEntry = {
+	name: string;
+} & (FSFile | FSDir);
+
+const downloadRepoDirectory = async (
+	repoOwner: string,
+	repoName: string,
+	repoDirPath: string,
+	ref: string
+): Promise<FSEntry[]> => {
+	const options = {
+		...getGitHubRequestOptions(),
+		followRedirect: true,
+	};
+	const resp = await got
+		.get(`https://api.github.com/repos/${repoOwner}/${repoName}/contents/${repoDirPath}?ref=${ref}`, options)
+		.catch((e: any) => {
+			throw e;
+		});
+	const remoteEntries = JSON.parse(resp.body) as { name: string; type: string; download_url: string | null }[];
+	const entries: FSEntry[] = [];
+	const tasks: (() => Promise<void>)[] = [];
+	for (const entry of remoteEntries) {
+		switch (entry.type) {
+			case 'dir':
+				tasks.push(async () => {
+					const name = entry.name;
+					const sub = await downloadRepoDirectory(repoOwner, repoName, repoDirPath + '/' + name, ref);
+					entries.push({
+						name: name,
+						contents: null,
+						children: sub,
+					});
+				});
+				break;
+			case 'file':
+				const name = entry.name;
+				const download_url = entry.download_url!;
+				tasks.push(async () => {
+					const resp = await got.get(download_url, options).catch((e: any) => {
+						throw new Error(`error downloading ${download_url}: ${e}`);
+					});
+					entries.push({
+						name: name,
+						contents: resp.body,
+					});
+				});
+				break;
+			default:
+				throw new Error(`unknown entry type ${entry.type}`);
+		}
+	}
+	await Promise.all(tasks.map((t) => t()));
+	return entries;
+};
+
+const writeFiles = async (root: string, files: FSEntry[]) => {
+	const tasks: (() => Promise<void>)[] = [];
+	for (const file of files) {
+		const name = join(root, file.name);
+		if (typeof file.contents === 'string') {
+			tasks.push(async () => {
+				await fsp.writeFile(name, file.contents, { encoding: 'utf-8' });
+				// XXX: GitHub API doesn't provide the file permissions, so we
+				// have to make an educated guess
+				if (name.endsWith('.sh')) {
+					await fsp.chmod(name, 0o755);
+				}
+			});
+		} else {
+			tasks.push(async () => {
+				await fsp.mkdir(name, { recursive: true });
+				await writeFiles(name, file.children);
+			});
+		}
+	}
+	await Promise.all(tasks.map((t) => t()));
+};
+
+const downloadAndExtractRepoWithApi = async (
+	root: string,
+	repoOwnerName: string,
+	repoName: string,
+	filePath: string,
+	ref: string
+) => {
+	const files = await downloadRepoDirectory(repoOwnerName, repoName, filePath ?? '', ref);
+	await writeFiles(root, files);
+};
+
+export const downloadAndExtractRepoWithTarball = async (
+	root: string,
+	repoOwnerName: string,
+	repoName: string,
+	ref: string,
+	filePath?: string,
+	isInit?: boolean
+) => {
+	const tempFile = await downloadTar(`https://github.com/${repoOwnerName}/${repoName}/archive/${ref}.tar.gz`);
+	await tar.x({
+		file: tempFile,
+		cwd: root,
+		strip: filePath ? filePath.split('/').length + 1 : 1,
+		filter: (p) => {
+			const rel = p.split('/').slice(1).join('/');
+			if (isInit) {
+				return rel.startsWith(`${filePath ? `${filePath}/.wundergraph` : ''}`);
+			} else {
+				return rel.startsWith(`${filePath ? `${filePath}/` : ''}`);
+			}
+		},
+	});
+	await fsp.unlink(tempFile);
+};
+
 export const downloadAndExtractRepo = async ({
 	root,
 	repoName,
@@ -42,26 +166,19 @@ export const downloadAndExtractRepo = async ({
 	filePath?: string;
 	isInit?: boolean;
 }) => {
+	const spinner = ora('Loading..').start();
 	try {
-		const spinner = ora('Loading..').start();
-		const tempFile = await downloadTar(`https://github.com/${repoOwnerName}/${repoName}/archive/${ref}.tar.gz`);
-		await tar.x({
-			file: tempFile,
-			cwd: root,
-			strip: filePath ? filePath.split('/').length + 1 : 1,
-			filter: (p) => {
-				const rel = p.split('/').slice(1).join('/');
-				if (isInit) {
-					return rel.startsWith(`${filePath ? `${filePath}/.wundergraph` : ''}`);
-				} else {
-					return rel.startsWith(`${filePath ? `${filePath}/` : ''}`);
-				}
-			},
-		});
-		await fsp.unlink(tempFile);
-		spinner.succeed(chalk.green('Successfully cloned the repository'));
-	} catch (e) {
-		console.error(chalk.red('Failed to clone the repository'));
+		try {
+			await downloadAndExtractRepoWithApi(root, repoOwnerName, repoName, filePath ?? '', ref);
+		} catch (e: any) {
+			if (e.code !== 'ERR_NON_2XX_3XX_RESPONSE') {
+				throw e;
+			}
+			await downloadAndExtractRepoWithTarball(root, repoOwnerName, repoName, ref, filePath, isInit);
+		}
+	} catch (e: any) {
+		console.error(chalk.red(`Failed to clone the repository: ${e}`));
 		process.exit(1);
 	}
+	spinner.succeed(chalk.green('Successfully cloned the repository'));
 };


### PR DESCRIPTION
This brings the set up time for a new project down from ~60s to ~2s.
Since the API has rather low limits, we still keep the old tarball
download method around and we use it as a fallback if downloading via
API fails due to API limits.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

## Marketing Changelog

<!--
What changes does this PR introduce? Please describe the changes in simple terms that a user can understand
without being familiar with the codebase. Mention @advocates for review and tracking.
-->

#### Checklist

- [ ] run `make test`
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)
