### PR TITLE
feat: improve protocol detection when determining callback URLs from auth providers

### DIFF
--- a/pkg/apihandler/apihandler.go
+++ b/pkg/apihandler/apihandler.go
@@ -1742,19 +1742,6 @@ func (r *Builder) configureCookieProvider(router *mux.Router, provider *wgpb.Aut
 	authorizedRedirectUris := loadvariable.Strings(r.api.AuthenticationConfig.CookieBased.AuthorizedRedirectUris)
 	authorizedRedirectUriRegexes := loadvariable.Strings(r.api.AuthenticationConfig.CookieBased.AuthorizedRedirectUriRegexes)
 
-	defaultRedirectProtocol := "http"
-	containsHttps := func(uris []string) bool {
-		for _, value := range uris {
-			if strings.HasPrefix(strings.ToLower((value)), "https://") {
-				return true
-			}
-		}
-		return false
-	}
-	if containsHttps(authorizedRedirectUris) || containsHttps(authorizedRedirectUriRegexes) {
-		defaultRedirectProtocol = "https"
-	}
-
 	router.Use(authentication.RedirectAlreadyAuthenticatedUsers(authorizedRedirectUris, authorizedRedirectUriRegexes))
 	authorizeRouter := router.PathPrefix("/" + authentication.AuthorizePath).Subrouter()
 	authorizeRouter.Use(authentication.ValidateRedirectURIQueryParameter(authorizedRedirectUris, authorizedRedirectUriRegexes))
@@ -1762,12 +1749,11 @@ func (r *Builder) configureCookieProvider(router *mux.Router, provider *wgpb.Aut
 	callbackRouter := router.PathPrefix("/" + authentication.CallbackPath).Subrouter()
 
 	providerConfig := authentication.ProviderConfig{
-		ID:                      provider.Id,
-		InsecureCookies:         r.insecureCookies,
-		ForceRedirectHttps:      r.forceHttpsRedirects,
-		Cookie:                  cookie,
-		AuthTimeout:             authTimeout,
-		DefaultRedirectProtocol: defaultRedirectProtocol,
+		ID:                 provider.Id,
+		InsecureCookies:    r.insecureCookies,
+		ForceRedirectHttps: r.forceHttpsRedirects,
+		Cookie:             cookie,
+		AuthTimeout:        authTimeout,
 	}
 
 	switch provider.Kind {

--- a/pkg/authentication/authentication.go
+++ b/pkg/authentication/authentication.go
@@ -507,20 +507,21 @@ func (v *RedirectURIValidator) GetValidatedRedirectURI(r *http.Request) (redirec
 		}
 		redirectURI = redirectURICookie.Value
 	}
-	if redirectURI == "" {
-		return "", false
-	}
+	return redirectURI, v.IsValid(redirectURI)
+}
+
+func (v *RedirectURIValidator) IsValid(redirectURI string) bool {
 	for i := range v.stringMatchers {
 		if v.stringMatchers[i] == redirectURI {
-			return redirectURI, true
+			return true
 		}
 	}
 	for _, matcher := range v.regexMatchers {
 		if matcher.MatchString(redirectURI) {
-			return redirectURI, true
+			return true
 		}
 	}
-	return redirectURI, false
+	return false
 }
 
 func RedirectAlreadyAuthenticatedUsers(matchString, matchRegex []string) func(handler http.Handler) http.Handler {

--- a/pkg/authentication/oauth2.go
+++ b/pkg/authentication/oauth2.go
@@ -95,7 +95,7 @@ func (h *OAuth2AuthenticationHandler) Authorize(w http.ResponseWriter, r *http.R
 	uriWithoutQuery := strings.Replace(r.RequestURI, "?"+r.URL.RawQuery, "", 1)
 	redirectPath := strings.Replace(uriWithoutQuery, AuthorizePath, CallbackPath, 1)
 
-	scheme := h.config.Provider.RedirectProtocol(r)
+	scheme := h.config.Provider.RedirectProtocol(r, redirectURI)
 
 	callbackURI := fmt.Sprintf("%s://%s%s", scheme, r.Host, redirectPath)
 	oauth2Config := oauth2.Config{
@@ -185,10 +185,8 @@ func (h *OAuth2AuthenticationHandler) Callback(w http.ResponseWriter, r *http.Re
 		}
 	}
 
-	scheme := h.config.Provider.RedirectProtocol(r)
-
 	if redirectURI == "" {
-		redirectURI = fmt.Sprintf("%s://%s%s", scheme, r.Host, "/auth/cookie/user")
+		redirectURI = "/auth/cookie/user"
 	}
 
 	//http.Redirect(w, r, redirect, http.StatusFound)


### PR DESCRIPTION
Since the redirect_uri used after authentication will be an absolute URL
in most cases, we can take advantage of this to autodetect the protocol. The
result is that most users won't ever need to touch this setting, unless the
manually perform the logging in using host-relative URLs.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

## Marketing Changelog

<!--
What changes does this PR introduce? Please describe the changes in simple terms that a user can understand
without being familiar with the codebase. Mention @advocates for review and tracking.
-->

#### Checklist

- [ ] run `make test`
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)
