### PR TITLE
feat: allow revalidate hook to alter the user object, then save it back

### DIFF
--- a/pkg/apihandler/apihandler.go
+++ b/pkg/apihandler/apihandler.go
@@ -1625,7 +1625,7 @@ func (r *Builder) authenticationHooks() authentication.Hooks {
 
 func (r *Builder) registerAuth() error {
 
-	config, err := loadUserConfiguration(r.api, r.middlewareClient, r.log)
+	config, err := loadUserConfiguration(r.api, r.middlewareClient, r.insecureCookies, r.log)
 	if err != nil {
 		return err
 	}

--- a/pkg/apihandler/authentication.go
+++ b/pkg/apihandler/authentication.go
@@ -21,7 +21,7 @@ func authenticationHooks(api *Api, client *hooks.Client, log *zap.Logger) authen
 	})
 }
 
-func loadUserConfiguration(api *Api, client *hooks.Client, log *zap.Logger) (authentication.LoadUserConfig, error) {
+func loadUserConfiguration(api *Api, client *hooks.Client, insecureCookies bool, log *zap.Logger) (authentication.LoadUserConfig, error) {
 	var hashKey, blockKey, csrfSecret []byte
 
 	if h := loadvariable.String(api.AuthenticationConfig.CookieBased.HashKey); h != "" {
@@ -56,10 +56,11 @@ func loadUserConfiguration(api *Api, client *hooks.Client, log *zap.Logger) (aut
 	authHooks := authenticationHooks(api, client, log)
 
 	return authentication.LoadUserConfig{
-		Log:           log,
-		Cookie:        cookie,
-		CSRFSecret:    csrfSecret,
-		JwksProviders: jwksProviders,
-		Hooks:         authHooks,
+		Log:             log,
+		Cookie:          cookie,
+		InsecureCookies: insecureCookies,
+		CSRFSecret:      csrfSecret,
+		JwksProviders:   jwksProviders,
+		Hooks:           authHooks,
 	}, nil
 }

--- a/pkg/apihandler/internalapihandler.go
+++ b/pkg/apihandler/internalapihandler.go
@@ -161,7 +161,7 @@ func (i *InternalBuilder) BuildAndMountInternalApiHandler(ctx context.Context, r
 }
 
 func (i *InternalBuilder) registerAuth() error {
-	config, err := loadUserConfiguration(i.api, i.middlewareClient, i.log)
+	config, err := loadUserConfiguration(i.api, i.middlewareClient, i.insecureCookies, i.log)
 	if err != nil {
 		return err
 	}

--- a/pkg/authentication/authentication.go
+++ b/pkg/authentication/authentication.go
@@ -44,7 +44,8 @@ func init() {
 
 type UserLoader struct {
 	log             *zap.Logger
-	s               *securecookie.SecureCookie
+	cookie          *securecookie.SecureCookie
+	insecureCookies bool
 	cache           *ristretto.Cache
 	client          *http.Client
 	userLoadConfigs []*UserLoadConfig
@@ -298,7 +299,7 @@ func (u *User) HasExpired() bool {
 	return false
 }
 
-func (u *User) Save(s *securecookie.SecureCookie, w http.ResponseWriter, r *http.Request, domain string, insecureCookies bool) error {
+func (u *User) Save(s *securecookie.SecureCookie, w http.ResponseWriter, r *http.Request, insecureCookies bool) error {
 
 	rawIdToken := u.RawIDToken
 
@@ -321,11 +322,13 @@ func (u *User) Save(s *securecookie.SecureCookie, w http.ResponseWriter, r *http
 		return err
 	}
 
+	cookieDomain := removeSubdomain(sanitizeDomain(r.Host))
+
 	cookie := &http.Cookie{
 		Name:     userCookieName,
 		Value:    encoded,
 		Path:     "/",
-		Domain:   removeSubdomain(sanitizeDomain(domain)),
+		Domain:   cookieDomain,
 		MaxAge:   authenticationCookieMaxAge,
 		Secure:   !insecureCookies,
 		HttpOnly: true,
@@ -343,7 +346,7 @@ func (u *User) Save(s *securecookie.SecureCookie, w http.ResponseWriter, r *http
 		Name:     idCookieName,
 		Value:    encoded,
 		Path:     "/",
-		Domain:   removeSubdomain(sanitizeDomain(domain)),
+		Domain:   cookieDomain,
 		MaxAge:   authenticationCookieMaxAge,
 		Secure:   !insecureCookies,
 		HttpOnly: true,
@@ -355,7 +358,7 @@ func (u *User) Save(s *securecookie.SecureCookie, w http.ResponseWriter, r *http
 	return nil
 }
 
-func (u *User) Load(loader *UserLoader, r *http.Request) error {
+func (u *User) Load(loader *UserLoader, w http.ResponseWriter, r *http.Request) error {
 	if err := u.loadUser(loader, r); err != nil {
 		return err
 	}
@@ -370,6 +373,9 @@ func (u *User) Load(loader *UserLoader, r *http.Request) error {
 			return errors.New("user has expired")
 		}
 		*u = *revalidated
+		if u.FromCookie {
+			return u.Save(loader.cookie, w, r, loader.insecureCookies)
+		}
 	}
 	return nil
 }
@@ -420,7 +426,7 @@ func (u *User) loadUser(loader *UserLoader, r *http.Request) error {
 	if err != nil {
 		return err
 	}
-	err = loader.s.Decode(userCookieName, cookie.Value, u)
+	err = loader.cookie.Decode(userCookieName, cookie.Value, u)
 	if err == nil {
 		u.FromCookie = true
 	}
@@ -428,7 +434,7 @@ func (u *User) loadUser(loader *UserLoader, r *http.Request) error {
 	if err != nil {
 		return err
 	}
-	err = loader.s.Decode(idCookieName, cookie.Value, &u.RawIDToken)
+	err = loader.cookie.Decode(idCookieName, cookie.Value, &u.RawIDToken)
 	u.IdToken = tryParseJWT(u.RawIDToken)
 	return err
 }
@@ -656,11 +662,12 @@ func (e *RBACEnforcer) containsOne(slice []string, one string) bool {
 }
 
 type LoadUserConfig struct {
-	Log           *zap.Logger
-	Cookie        *securecookie.SecureCookie
-	CSRFSecret    []byte
-	JwksProviders []*wgpb.JwksAuthProvider
-	Hooks         Hooks
+	Log             *zap.Logger
+	Cookie          *securecookie.SecureCookie
+	InsecureCookies bool
+	CSRFSecret      []byte
+	JwksProviders   []*wgpb.JwksAuthProvider
+	Hooks           Hooks
 }
 
 func NewLoadUserMw(config LoadUserConfig) func(handler http.Handler) http.Handler {
@@ -742,7 +749,8 @@ func NewLoadUserMw(config LoadUserConfig) func(handler http.Handler) http.Handle
 	loader := &UserLoader{
 		log:             config.Log,
 		userLoadConfigs: jwkConfigs,
-		s:               config.Cookie,
+		cookie:          config.Cookie,
+		insecureCookies: config.InsecureCookies,
 		cache:           cache,
 		client: &http.Client{
 			Timeout: time.Second * 10,
@@ -753,7 +761,7 @@ func NewLoadUserMw(config LoadUserConfig) func(handler http.Handler) http.Handle
 	return func(handler http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			var user User
-			err := user.Load(loader, r)
+			err := user.Load(loader, w, r)
 			if err == nil {
 				r = r.WithContext(context.WithValue(r.Context(), "user", &user))
 			}
@@ -800,7 +808,7 @@ func (u *UserHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		err = user.Save(u.Cookie, w, r, u.Host, u.InsecureCookies)
+		err = user.Save(u.Cookie, w, r, u.InsecureCookies)
 		if err != nil {
 			u.Log.Error("RevalidateAuthentication could not save cookie", zap.Error(err))
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/pkg/authentication/oauth2.go
+++ b/pkg/authentication/oauth2.go
@@ -277,7 +277,7 @@ func (h *OAuth2AuthenticationHandler) authenticate(w http.ResponseWriter, r *htt
 		}
 	}
 
-	if err := user.Save(h.config.Provider.Cookie, w, r, r.Host, h.config.Provider.InsecureCookies); err != nil {
+	if err := user.Save(h.config.Provider.Cookie, w, r, h.config.Provider.InsecureCookies); err != nil {
 		return nil, &authError{
 			Code: authErrorCodeSavedFailed,
 			Err:  fmt.Errorf("could not encode user data: %w", err),

--- a/pkg/hooks/authentication.go
+++ b/pkg/hooks/authentication.go
@@ -98,8 +98,12 @@ func (h *AuthenticationHooks) RevalidateAuthentication(ctx context.Context, user
 	if err != nil {
 		return nil, err
 	}
-	result.AccessToken = user.AccessToken
-	result.IdToken = user.IdToken
+	if len(result.AccessToken) == 0 {
+		result.AccessToken = user.AccessToken
+	}
+	if len(result.IdToken) == 0 {
+		result.IdToken = user.IdToken
+	}
 	return result, nil
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

## Marketing Changelog

<!--
What changes does this PR introduce? Please describe the changes in simple terms that a user can understand
without being familiar with the codebase. Mention @advocates for review and tracking.
-->

#### Checklist

- [ ] run `make test`
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)
