### PR TITLE
Update post-logout-hook.md for auth0 signout details.

### DIFF
--- a/docs-website/src/pages/docs/auth/cookie-based-auth/auth0/index.md
+++ b/docs-website/src/pages/docs/auth/cookie-based-auth/auth0/index.md
@@ -91,8 +91,25 @@ import { useAuth } from 'components/generated/nextjs';
 export default function Page() {
   const { logout } = useAuth();
 
-  return <button onClick={() => logout({ logoutOpenidConnectProvider: true })}>Logout</button>;
+  return <button onClick={() => logout()}>Logout</button>;
 }
+```
+
+Unfortunately, Auth0 also doesn't provide a way to call a back channel API to log out the user.
+In such cases, you have to use a front channel logout after logging the user out of your WunderGraph application.
+If you omit this step, the user is still logged into the OIDC provider through a cookie.
+
+To fully logout, you should render an iframe with the correct logout flow
+```tsx
+<iframe
+  src={`${auth0Domain}/v2/logout?returnTo=${encodeURIComponent(
+    `${wgApiURL}/auth/cookie/user/logout`,
+  )}&client_id=${auth0ClientId}`}
+  style={{ display: "none" }}
+  onLoad={async () => {
+    window.location.reload();
+  }}
+/>
 ```
 
 ### Customize with Hooks

--- a/docs-website/src/pages/docs/wundergraph-server-ts-reference/post-logout-hook.md
+++ b/docs-website/src/pages/docs/wundergraph-server-ts-reference/post-logout-hook.md
@@ -48,12 +48,12 @@ If you omit this step, the user is still logged into the OIDC provider through a
 For auth0, a quick way to handle it is to render a hidden iframe with the logout url as the src such as the following.
 ```
 <iframe
-  src={`https://${myAuth0Domain}/v2/logout`}
+  src={`${auth0Domain}/v2/logout?returnTo=${encodeURIComponent(
+    `${wgApiURL}/auth/cookie/user/logout`,
+  )}&client_id=${auth0ClientId}`}
   style={{ display: "none" }}
-  onLoad={() => {
-    logout({
-      logoutOpenidConnectProvider: true,
-    });
+  onLoad={async () => {
+    window.location.reload();
   }}
 />
 ```

--- a/docs-website/src/pages/docs/wundergraph-server-ts-reference/post-logout-hook.md
+++ b/docs-website/src/pages/docs/wundergraph-server-ts-reference/post-logout-hook.md
@@ -44,3 +44,16 @@ Some OpenID Connect Providers, like Auth0, do not support the "End Session Endpo
 Unfortunately, Auth0 also doesn't provide a way to call a back channel API to log out the user.
 In such cases, you have to use a front channel logout after logging the user out of your WunderGraph application.
 If you omit this step, the user is still logged into the OIDC provider through a cookie.
+
+For auth0, a quick way to handle it is to render a hidden iframe with the logout url as the src such as the following.
+```
+<iframe
+  src={`https://${myAuth0Domain}/v2/logout`}
+  style={{ display: "none" }}
+  onLoad={() => {
+    logout({
+      logoutOpenidConnectProvider: true,
+    });
+  }}
+/>
+```


### PR DESCRIPTION
## Motivation and Context

I found it a bit difficult to understand how to properly logout auth0 accounts.  There didn't seem to be much in the way of details to how to achieve this.

## Marketing Changelog

Improve auth0 docs on properly logging out users.



I'm not sure if there are other places in the docs I should add this details.  I'm also not sure if this is the best approach or if there's another way to handle it.  We're waiting on the iframe to logout before calling wundergraph logout to be sure we properly logout before getting redirected.