### PR TITLE
docs: fix "therefor" typos 

### DIFF
--- a/docs-website/src/pages/docs/apis/apollo-federation/index.md
+++ b/docs-website/src/pages/docs/apis/apollo-federation/index.md
@@ -9,7 +9,7 @@ Federation helps companies implement GraphQL at scale and allows you to combine 
 It brings a lot of useful features to implement Graphs across multiple teams in a "federated" way, hence the name.
 It was [invented and specified by Apollo](https://www.apollographql.com/docs/federation/federation-spec/).
 
-WunderGraph is extremely fast executing GraphQL Operations and is therefor a great fit for a Federation Gateway.
+WunderGraph is extremely fast executing GraphQL Operations and is therefore a great fit for a Federation Gateway.
 
 ## Add a Apollo Federation DataSource
 

--- a/docs-website/src/pages/docs/databases/prisma.md
+++ b/docs-website/src/pages/docs/databases/prisma.md
@@ -12,7 +12,7 @@ whereas others really just need a quick way to build an API on top of a database
 
 There are a lot of tools out there that turn a database into an API.
 What's special about the combination of WunderGraph and Prisma is that you're building on top of two giants.
-Prisma is a very mature and well maintained project, [it's written in Rust and therefor very performant](https://github.com/prisma/prisma-engines).
+Prisma is a very mature and well maintained project, [it's written in Rust and therefore very performant](https://github.com/prisma/prisma-engines).
 WunderGraph uses Prisma internally to generate a GraphQL Schema from the database and translate GraphQL Operations into efficient SQL statements.
 
 However, Prisma needs a powerful sidekick to turn your database into a production-grade API.


### PR DESCRIPTION
## Motivation and Context

- correct typo in index.md, section apollo-federation.
- correct typo in prisma.md, section databases.

Simply just maintaining docs credibility and ensuring correct spelling and grammar in the documentation.

## Marketing Changelog

#### Checklist

- [x] run `make test`
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [x] documentation is changed or added
- [x] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)
