### PR TITLE
feat: add default values support for generated operations

### DIFF
--- a/packages/sdk/src/codegen/index.ts
+++ b/packages/sdk/src/codegen/index.ts
@@ -105,10 +105,10 @@ export class CodeGenerator {
 			}
 		});
 		const resolved = await Promise.all(generators);
-		const rawOutFiles: TemplateOutputFile[] = resolved.reduce((previousValue, currentValue) => [
-			...previousValue,
-			...currentValue,
-		], []);
+		const rawOutFiles: TemplateOutputFile[] = resolved.reduce(
+			(previousValue, currentValue) => [...previousValue, ...currentValue],
+			[]
+		);
 		const outFiles = mergeTemplateOutput(rawOutFiles);
 		outFiles.forEach((file) => {
 			const content = `${file.header || ''}${file.content}`;

--- a/packages/sdk/src/codegen/index.ts
+++ b/packages/sdk/src/codegen/index.ts
@@ -108,7 +108,7 @@ export class CodeGenerator {
 		const rawOutFiles: TemplateOutputFile[] = resolved.reduce((previousValue, currentValue) => [
 			...previousValue,
 			...currentValue,
-		]);
+		], []);
 		const outFiles = mergeTemplateOutput(rawOutFiles);
 		outFiles.forEach((file) => {
 			const content = `${file.header || ''}${file.content}`;

--- a/packages/sdk/src/graphql/operations.ts
+++ b/packages/sdk/src/graphql/operations.ts
@@ -887,16 +887,24 @@ export const operationVariablesToJSONSchema = (
 			nonNullType = true;
 		}
 		const name = variable.variable.name.value;
-		schema.properties![name] = typeSchema(
-			schema,
-			schema,
-			graphQLSchema,
-			interpolateVariableDefinitionAsJSON,
-			type,
-			name,
-			nonNullType,
-			customJsonScalars
-		);
+		const defaultValue = variable.defaultValue;
+		const props = {
+			...typeSchema(
+				schema,
+				schema,
+				graphQLSchema,
+				interpolateVariableDefinitionAsJSON,
+				type,
+				name,
+				nonNullType,
+				customJsonScalars
+			),
+		};
+		const defaultValueProp = (defaultValue || ({} as any)).value;
+		if (defaultValueProp) {
+			props.default = defaultValueProp;
+		}
+		schema.properties![name] = props;
 		if (Object.keys(skipFields).length > 0) {
 			applySkipFields(skipFields, schema, schema, name);
 		}

--- a/packages/sdk/src/postman/builder.ts
+++ b/packages/sdk/src/postman/builder.ts
@@ -11,6 +11,7 @@ export interface JSONSchemaParameterPath {
 	path: string[];
 	required: boolean;
 	type: string;
+	value?: any;
 }
 
 const buildItem = (op: GraphQLOperation, operationURL: string, opName: string) => {
@@ -132,7 +133,7 @@ const mutationRequestJson = (url: string, paths: JSONSchemaParameterPath[]): str
 			key: path.path.join('.'),
 			disabled: !path.required,
 			description: `Type ${path.type}, ${path.required ? 'Required' : 'Optional'}`,
-			value: '',
+			value: path.value || '',
 			type: 'text',
 		});
 	}
@@ -155,7 +156,7 @@ const queryRequestJson = (url: string, paths: JSONSchemaParameterPath[]): string
 			{
 				key: path.path.join('.'),
 				disabled: !path.required,
-				value: '',
+				value: path.value || '',
 				description: `Type ${path.type}, ${path.required ? 'Required' : 'Optional'}`,
 			},
 		]);
@@ -164,7 +165,6 @@ const queryRequestJson = (url: string, paths: JSONSchemaParameterPath[]): string
 	return request.toJSON();
 };
 
-// TODO: Add "default" values
 // path syntax follows https://github.com/tidwall/sjson#path-syntax
 export function buildPath(
 	path: string[],
@@ -200,6 +200,7 @@ export function buildPath(
 		path,
 		required: false, // ignore it for now because this would make all variants required
 		type: typeof obj.type === 'string' ? obj.type : 'any',
+		value: obj.default,
 	});
 
 	paths.sort(function (a, b) {

--- a/packages/sdk/src/v2openapi/__snapshots__/index.test.ts.snap
+++ b/packages/sdk/src/v2openapi/__snapshots__/index.test.ts.snap
@@ -18581,23 +18581,23 @@ exports[`httpbin: httpbin_fields 1`] = `
 
 exports[`httpbin: httpbin_schema 1`] = `
 "type Query {
-  api_status(code: Int!): JSON
+  api_status(code: Int! = 200): JSON
   api_get: JSON
   api_xml: JSON
   api_ip: JSON
   api_userAgent: JSON
   api_headers: JSON
-  api_delay(seconds: Int!): JSON
-  api_cache(maxAge: Int!): JSON
+  api_delay(seconds: Int! = 2): JSON
+  api_cache(maxAge: Int! = 10): JSON
   api_uuid: JSON
   api_anything: JSON
   api_gzip: JSON
-  api_base64(value: String!): JSON
+  api_base64(value: String! = "aGVsbG8gd29ybGQNCg%3D%3D"): JSON
   api_deflate: JSON
   api_brotli: JSON
   api_responseHeaders: JSON
-  api_bytes(number: String!): JSON
-  api_redirectTo(url: String!): JSON
+  api_bytes(number: String! = "1024"): JSON
+  api_redirectTo(url: String! = "http://example.com"): JSON
   api_stream(number: Int!): JSON
 }
 
@@ -20566,7 +20566,7 @@ exports[`petstore: petstore_fields 1`] = `
 
 exports[`petstore: petstore_schema 1`] = `
 "type Query {
-  api_findPetsByStatus(status: api_findPetsByStatus_status): [api_Pet]
+  api_findPetsByStatus(status: api_findPetsByStatus_status = available): [api_Pet]
   api_findPetsByTags(tags: [String]): [api_Pet]
   api_getPetById(petId: Int!): api_Pet
   api_getInventory: JSON

--- a/packages/sdk/src/v2openapi/index.ts
+++ b/packages/sdk/src/v2openapi/index.ts
@@ -788,9 +788,9 @@ class RESTApiBuilder {
 													value: schema.default,
 												},
 										  }
-										: (astFromValueUntyped(defaultValue) as any)
+										: astFromValueUntyped(defaultValue)
 									: undefined,
-							},
+							} as InputValueDefinitionNode,
 						],
 					};
 					done = true;

--- a/testapps/default/.wundergraph/operations/federated/TopProducts.graphql
+++ b/testapps/default/.wundergraph/operations/federated/TopProducts.graphql
@@ -1,6 +1,6 @@
 # This file is auto generated.
 # Remove/modify this header if you want to customize the operation.
-query federated_topProducts_query($first: Int, $random: Boolean) {
+query federated_topProducts_query($first: Int = 5, $random: Boolean) {
   federated_topProducts(first: $first, random: $random) {
     name
     price


### PR DESCRIPTION
## Motivation and Context


<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

This PR implements feature of respecting the OAS Schema's **default** properties when generating respectful GraphQL operations (during introspection). 

The GQL Specification Nodes contain the default values (for Queries/Mutations)  and they are now taken into consideration and reflected within the gql operations generated during Wundergraph introspection.

This PR fixes #1322.

## Marketing Changelog

<!--
What changes does this PR introduce? Please describe the changes in simple terms that a user can understand
without being familiar with the codebase. Mention @advocates for review and tracking.
-->

If the (OAS/...) Schema Definitions specify operations with query parameters having **default** values specified within the respective Schema definitions, these default values will be reflected as defaults when generating GraphQL Operations during the introspection phase.

#### Checklist

- [x] run `make test`
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)
