### PR TITLE
fix: add globalfetch configuration option to server

### DIFF
--- a/packages/sdk/src/server/plugins/omnigraphOAS.ts
+++ b/packages/sdk/src/server/plugins/omnigraphOAS.ts
@@ -21,10 +21,11 @@ export interface OpenApiServerConfig {
 	schema: string;
 	mountPath: string;
 	upstreamURL?: string;
+	globalFetch?: typeof fetch;
 }
 
 const FastifyOASGraphQLPlugin: FastifyPluginAsync<OpenApiServerConfig> = async (fastify, config) => {
-	const schema = executableSchema(config.schema, fastify.log, config.upstreamURL);
+	const schema = executableSchema(config.schema, fastify.log, config.upstreamURL, config.globalFetch);
 
 	fastify.route({
 		method: ['GET', 'POST'],
@@ -60,7 +61,8 @@ const FastifyOASGraphQLPlugin: FastifyPluginAsync<OpenApiServerConfig> = async (
 const executableSchema = (
 	schemaStr: string,
 	logger: FastifyBaseLogger,
-	upstreamURL: string | undefined
+	upstreamURL: string | undefined,
+	globalFetch: typeof fetch = fetch
 ): GraphQLSchema => {
 	const schema = buildSchema(schemaStr, {
 		assumeValidSDL: true,
@@ -74,7 +76,7 @@ const executableSchema = (
 		schema,
 		logger: logWrapper,
 		pubsub,
-		globalFetch: loggedFetch(logger.child({ type: 'OpenAPI' }), fetch),
+		globalFetch: loggedFetch(logger.child({ type: 'OpenAPI' }), globalFetch),
 	};
 	if (upstreamURL !== '') {
 		opts['endpoint'] = upstreamURL;

--- a/packages/sdk/src/server/plugins/omnigraphSOAP.ts
+++ b/packages/sdk/src/server/plugins/omnigraphSOAP.ts
@@ -11,32 +11,34 @@ export interface SoapServerConfig {
 	serverName: string;
 	schema: string;
 	mountPath: string;
+	globalFetch: typeof fetch;
 }
 
 // fetchWithHeaders - wraps fetch function to pass headers from context to fetch options
-const fetchWithHeaders = (url: string, options?: RequestInit, context?: any, info?: GraphQLResolveInfo) => {
-	/*
-	 * temporary workaround to pass headers to fetch
-	 * current drawback is that it will pass all headers from the wundernode request to the wundergraph server
-	 * */
+const fetchWithHeaders =
+	(fetchFn: MeshFetch) => (url: string, options?: RequestInit, context?: any, info?: GraphQLResolveInfo) => {
+		/*
+		 * temporary workaround to pass headers to fetch
+		 * current drawback is that it will pass all headers from the wundernode request to the wundergraph server
+		 * */
 
-	const headers = {
-		...context?.headers,
-		...options?.headers,
+		const headers = {
+			...context?.headers,
+			...options?.headers,
+		};
+
+		// workaround to deal with https://github.com/node-fetch/node-fetch/discussions/1678
+		delete headers.host;
+		delete headers.referer;
+
+		const opts = {
+			...options,
+			headers,
+			agent: new Agent({ family: 4 }),
+		};
+
+		return fetchFn(url, opts, context, info);
 	};
-
-	// workaround to deal with https://github.com/node-fetch/node-fetch/discussions/1678
-	delete headers.host;
-	delete headers.referer;
-
-	const opts = {
-		...options,
-		headers,
-		agent: new Agent({ family: 4 }),
-	};
-
-	return (fetch as MeshFetch)(url, opts, context, info);
-};
 
 const FastifySoapGraphQLPlugin: FastifyPluginAsync<SoapServerConfig> = async (fastify, config) => {
 	const schema = buildSchema(config.schema, {
@@ -45,9 +47,9 @@ const FastifySoapGraphQLPlugin: FastifyPluginAsync<SoapServerConfig> = async (fa
 	});
 
 	const fetchLogger = fastify.log.child({ type: 'SOAP' });
-	const fetchFn = fetchWithHeaders as (input: RequestInfo | URL, init?: RequestInit | undefined) => Promise<Response>;
+	const fetchFn = fetchWithHeaders(config.globalFetch);
 	// prepare queries executor from schema with soap directives
-	const executor = createExecutorFromSchemaAST(schema, loggedFetch(fetchLogger, fetchFn));
+	const executor = createExecutorFromSchemaAST(schema, loggedFetch(fetchLogger, fetchFn as typeof fetch));
 
 	fastify.route({
 		method: ['GET', 'POST'],

--- a/packages/sdk/src/server/server.ts
+++ b/packages/sdk/src/server/server.ts
@@ -1,5 +1,5 @@
 import closeWithGrace from 'close-with-grace';
-import { Headers } from '@whatwg-node/fetch';
+import { Headers, fetch } from '@whatwg-node/fetch';
 import process from 'node:process';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import Fastify, { FastifyInstance } from 'fastify';
@@ -422,6 +422,7 @@ export const createServer = async ({
 					extraHeaders: headers,
 					tracer: fastify.tracer,
 					traceContext: req.telemetry?.context,
+					customFetch: globalFetch,
 				}),
 				context: await createContext(globalContext),
 			};

--- a/packages/sdk/src/server/server.ts
+++ b/packages/sdk/src/server/server.ts
@@ -287,7 +287,7 @@ export const createServer = async ({
 		},
 	});
 
-	const globalFetch = serverConfig.unsafe_globalFetch || fetch;
+	const globalFetch = serverConfig.__unstable_fetch || fetch;
 
 	const globalContext = serverConfig.context?.global?.create ? await serverConfig.context.global.create() : undefined;
 

--- a/packages/sdk/src/server/server.ts
+++ b/packages/sdk/src/server/server.ts
@@ -287,6 +287,8 @@ export const createServer = async ({
 		},
 	});
 
+	const globalFetch = serverConfig.unsafe_globalFetch || fetch;
+
 	const globalContext = serverConfig.context?.global?.create ? await serverConfig.context.global.create() : undefined;
 
 	/**
@@ -477,6 +479,7 @@ export const createServer = async ({
 						mountPath,
 						upstreamURL,
 						schema,
+						globalFetch,
 					});
 					break;
 				case 'soap':
@@ -484,6 +487,7 @@ export const createServer = async ({
 						serverName,
 						mountPath,
 						schema,
+						globalFetch,
 					});
 					break;
 			}

--- a/packages/sdk/src/server/types.ts
+++ b/packages/sdk/src/server/types.ts
@@ -1,4 +1,4 @@
-import type { Headers } from '@whatwg-node/fetch';
+import type { fetch } from '@whatwg-node/fetch';
 import type { GraphQLServerConfig } from './plugins/graphql';
 import type { ConfigurationVariable, WunderGraphConfiguration } from '@wundergraph/protobuf';
 import type { WebhooksConfig } from '../webhooks/types';
@@ -308,6 +308,11 @@ export interface WunderGraphServerConfig<
 	 * Context creation/release
 	 */
 	context?: WunderGraphServerContext<TRequestContext, TGlobalContext>;
+	/**
+	 * Fetch implementation to use instead of the default `@whatwg-node/fetch`.
+	 * @warning This is used for testing purposes only and might be removed in the future.
+	 */
+	unsafe_globalFetch?: typeof fetch;
 }
 
 // internal representation of the fully resolved server config
@@ -322,6 +327,7 @@ export interface WunderGraphHooksAndServerConfig<
 	graphqlServers?: GraphQLServerConfig[];
 	options?: ServerOptions;
 	integrations?: InternalIntergration[];
+	unsafe_globalFetch?: typeof fetch;
 }
 
 export interface OnConnectionInitHookRequestBody extends FastifyRequestBody {

--- a/packages/sdk/src/server/types.ts
+++ b/packages/sdk/src/server/types.ts
@@ -312,7 +312,7 @@ export interface WunderGraphServerConfig<
 	 * Fetch implementation to use instead of the default `@whatwg-node/fetch`.
 	 * @warning This is used for testing purposes only and might be removed in the future.
 	 */
-	unsafe_globalFetch?: typeof fetch;
+	__unstable_fetch?: typeof fetch;
 }
 
 // internal representation of the fully resolved server config
@@ -327,7 +327,7 @@ export interface WunderGraphHooksAndServerConfig<
 	graphqlServers?: GraphQLServerConfig[];
 	options?: ServerOptions;
 	integrations?: InternalIntergration[];
-	unsafe_globalFetch?: typeof fetch;
+	__unstable_fetch?: typeof fetch;
 }
 
 export interface OnConnectionInitHookRequestBody extends FastifyRequestBody {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

## Marketing Changelog

<!--
What changes does this PR introduce? Please describe the changes in simple terms that a user can understand
without being familiar with the codebase. Mention @advocates for review and tracking.
-->

#### Checklist

- [ ] run `make test`
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)
