### PR TITLE
fix(brew): update homebrew asset link to include v

### DIFF
--- a/.github/goreleaser/.goreleaser-darwin.yml
+++ b/.github/goreleaser/.goreleaser-darwin.yml
@@ -124,7 +124,7 @@ brews:
     # Default for gitea is "https://gitea.com/<repo_owner>/<repo_name>/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
     # https://github.com/wundergraph/wundergraph/releases/download/v0.40.0/wunderctl_0.40.0_Darwin_x86_64.tar.gz
     # url_template: "http://github.com/foo/bar/releases/{{ .Tag }}/{{ .ArtifactName }}"
-    url_template: 'https://github.com/wundergraph/wundergraph/releases/download/{{ .Tag }}/{{ .ArtifactName }}'
+    url_template: 'https://github.com/wundergraph/wundergraph/releases/download/v{{ .Tag }}/{{ .ArtifactName }}'
 
     # Allows you to set a custom download strategy. Note that you'll need
     # to implement the strategy and add it to your tap repository.


### PR DESCRIPTION
`brew install wundergraph/wundergraph/wunderctl` is broken, and returns the following error:

```
==> Fetching wundergraph/wundergraph/wunderctl
==> Downloading https://github.com/wundergraph/wundergraph/releases/download/0.176.2/wunderctl_0.176.2_Da
curl: (22) The requested URL returned error: 404

Error: wunderctl: Failed to download resource "wunderctl"
Download failed: https://github.com/wundergraph/wundergraph/releases/download/0.176.2/wunderctl_0.176.2_Darwin_arm64.tar.gz
```

This is because the string template for the URL to the asset in `.github/goreleaser/.goreleaser-darwin.yml:127` is missing a 'v' after '/releases/downloads/' in the link.
Link from github releases: 
```
https://github.com/wundergraph/wundergraph/releases/download/v0.176.2/wunderctl_0.176.2_Darwin_arm64.tar.gz
                                                           --^---
```

This closes issues:
[https://github.com/wundergraph/homebrew-wundergraph/issues/2](https://github.com/wundergraph/homebrew-wundergraph/issues/2)
[https://github.com/wundergraph/homebrew-wundergraph/issues/3](https://github.com/wundergraph/homebrew-wundergraph/issues/3)
Also related but closed- [https://github.com/wundergraph/homebrew-wundergraph/issues/1](https://github.com/wundergraph/homebrew-wundergraph/issues/1)

## Motivation and Context

Homebrew's so easy!

## Marketing Changelog

<!--
What changes does this PR introduce? Please describe the changes in simple terms that a user can understand
without being familiar with the codebase. Mention @advocates for review and tracking.
-->

#### Checklist

- [ x] run `make test`
- [x ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)
