### PR TITLE
fix: import nuxt composables from #imports

### DIFF
--- a/docs-website/src/pages/docs/examples/nuxt.md
+++ b/docs-website/src/pages/docs/examples/nuxt.md
@@ -55,7 +55,7 @@ Most of the configuration is done in a Nuxt plugin.
 ```ts
 import type { DehydratedState, VueQueryPluginOptions } from '@tanstack/vue-query';
 import { VueQueryPlugin, QueryClient, hydrate, dehydrate } from '@tanstack/vue-query';
-import { useState } from '#app';
+import { useState } from '#imports';
 
 import { createHooks } from '@wundergraph/vue-query';
 import { createClient, Operations } from '../.wundergraph/components/generated/client';

--- a/docs-website/src/pages/docs/supported-frontend-frameworks/nuxt.md
+++ b/docs-website/src/pages/docs/supported-frontend-frameworks/nuxt.md
@@ -9,7 +9,7 @@ Create a `wundergraph.ts` in the `plugins` directory, register the Vue Query plu
 ```ts
 import type { DehydratedState, VueQueryPluginOptions } from '@tanstack/vue-query';
 import { VueQueryPlugin, QueryClient, hydrate, dehydrate } from '@tanstack/vue-query';
-import { useState } from '#app';
+import { useState } from '#imports';
 
 import { createHooks } from '@wundergraph/vue-query';
 import { createClient, Operations } from '../.wundergraph/components/generated/client';

--- a/examples/nuxt/plugins/vue-query.ts
+++ b/examples/nuxt/plugins/vue-query.ts
@@ -1,6 +1,6 @@
 import type { DehydratedState, VueQueryPluginOptions } from '@tanstack/vue-query';
 import { VueQueryPlugin, QueryClient, hydrate, dehydrate } from '@tanstack/vue-query';
-import { useState } from '#app';
+import { useState } from '#imports';
 
 import { createHooks } from '@wundergraph/vue-query';
 import { createClient, Operations } from '../.wundergraph/components/generated/client';


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

## Motivation and Context

This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.

## Marketing Changelog

<!--
What changes does this PR introduce? Please describe the changes in simple terms that a user can understand
without being familiar with the codebase. Mention @advocates for review and tracking.
-->

#### Checklist

- [ ] run `make test`
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)
