### PR TITLE
fix: add generation options

### DIFF
--- a/packages/sdk/src/codegen/generateoperations.ts
+++ b/packages/sdk/src/codegen/generateoperations.ts
@@ -26,10 +26,14 @@ export const generateOperations = async (config: GenerateConfig) => {
 		if (!fs.existsSync(operationDir)) {
 			fs.mkdirSync(operationDir, { recursive: true });
 		}
+
+		const options = config.operationGenerationConfig.getOptions(field.apiNamespace);
+
 		let operationNode = buildOperationNodeForField({
 			field: field.name,
 			schema,
 			kind: field.operationType as OperationTypeNode,
+			...options,
 		});
 		let opType: Maybe<GraphQLObjectType>;
 		if (field.operationType === OperationTypeNode.QUERY) {

--- a/packages/sdk/src/configure/codegeneration.ts
+++ b/packages/sdk/src/configure/codegeneration.ts
@@ -9,11 +9,19 @@ export interface GenerateConfig {
 
 export type OperationsGeneration = (config: OperationsGenerationConfig) => void;
 
+export type OperationsGenerationNamespaceOptions = {
+	depthLimit?: number;
+	circularReferenceDepth?: number;
+	argNames?: string[];
+	ignore?: string[];
+};
+
 export class OperationsGenerationConfig {
 	private rootFields: FieldConfig[] = [];
 	private basePath: string = '';
 	private namespaces: string[];
 	private pristine: boolean = true;
+	private options: Record<string, OperationsGenerationNamespaceOptions> = {};
 
 	constructor(config: {
 		app: WunderGraphConfigApplicationConfig<any, any>;
@@ -107,6 +115,14 @@ export class OperationsGenerationConfig {
 			return [];
 		}
 		return this.rootFields;
+	}
+
+	public setOptions(namespace: string, options: OperationsGenerationNamespaceOptions) {
+		this.options[namespace] = options;
+	}
+
+	public getOptions(namespace: string): OperationsGenerationNamespaceOptions {
+		return this.options[namespace] || {};
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

## Motivation and Context

This adds more fine grained control to the operations generator.

- Filter arguments
- Depth limit
- Circular dept limit
- Ignore fields

## Marketing Changelog

<!--
What changes does this PR introduce? Please describe the changes in simple terms that a user can understand
without being familiar with the codebase. Mention @advocates for review and tracking.
-->

#### Checklist

- [ ] run `make test`
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)
