### PR TITLE
feat: allow forwarding query params on login

### DIFF
--- a/packages/sdk/src/client/client.ts
+++ b/packages/sdk/src/client/client.ts
@@ -715,6 +715,19 @@ export class Client {
 		window.location.assign(url);
 	}
 
+	public loginWithQueryParams(authProviderID: string, queryParams: URLSearchParams, redirectURI?: string) {
+		// browser check
+		if (typeof window === 'undefined') {
+			throw new Error('login() can only be called in a browser environment');
+		}
+
+		queryParams.set('redirect_uri', redirectURI || window.location.toString());
+
+		const url = this.addUrlParams(`${this.options.baseURL}/auth/cookie/authorize/${authProviderID}`, queryParams);
+
+		window.location.assign(url);
+	}
+
 	public async logout(options?: LogoutOptions): Promise<boolean> {
 		// browser check
 		if (typeof window === 'undefined') {

--- a/packages/swr/src/hooks.ts
+++ b/packages/swr/src/hooks.ts
@@ -135,6 +135,11 @@ export const createHooks = <Operations extends OperationsDefinition>(client: Cli
 		return {
 			login: (authProviderID: Operations['authProvider'], redirectURI?: string | undefined) =>
 				client.login(authProviderID, redirectURI),
+			loginWithQuery: (
+				authProviderID: Operations['authProvider'],
+				query: URLSearchParams,
+				redirectURI?: string | undefined
+			) => client.loginWithQueryParams(authProviderID, query, redirectURI),
 			logout: async (options?: LogoutOptions | undefined) => {
 				const result = await client.logout(options);
 				// reset user in the cache and don't trigger a refetch

--- a/pkg/authentication/oauth2.go
+++ b/pkg/authentication/oauth2.go
@@ -145,6 +145,18 @@ func (h *OAuth2AuthenticationHandler) Authorize(w http.ResponseWriter, r *http.R
 	for i, p := range h.config.QueryParameters {
 		opts[i] = oauth2.SetAuthURLParam(p.Name, p.Value)
 	}
+WithNext:
+	for k := range r.URL.Query() {
+		if k == "redirect_uri" {
+			continue
+		}
+		for _, p := range h.config.QueryParameters {
+			if p.Name == k {
+				continue WithNext
+			}
+			opts = append(opts, oauth2.SetAuthURLParam(k, r.URL.Query().Get(k)))
+		}
+	}
 
 	redirectToProvider := oauth2Config.AuthCodeURL(state, opts...)
 	h.config.Log.Debug("redirecting to authentication provider", zap.String("url", redirectToProvider))

--- a/testapps/nextjs/pages/authentication.tsx
+++ b/testapps/nextjs/pages/authentication.tsx
@@ -5,11 +5,11 @@ import { useQuery, useUser, useAuth, withWunderGraph } from '../components/gener
 
 const JobsPage: NextPage = () => {
 	const user = useUser();
-	const { login, logout } = useAuth();
+	const { login, loginWithQuery, logout } = useAuth();
 	const [city, setCity] = useState<string>('Berlin');
 	const onClick = () => {
 		if (!user.data) {
-			login('github');
+			loginWithQuery('auth0', new URLSearchParams({ organization: 'wundergraph' }));
 		} else {
 			logout();
 		}


### PR DESCRIPTION
This adds support to forward query params from the client to the auth provider, e.g. the `/authorize?organization=wundergraph` to dynamically pre-select an org when starting the login process.