### PR TITLE
feat: openapi tag support

### DIFF
--- a/docs-website/src/pages/docs/features/openapi-postman.md
+++ b/docs-website/src/pages/docs/features/openapi-postman.md
@@ -31,3 +31,8 @@ configureWunderGraphApplication({
   },
 });
 ```
+
+Additional `openApi` options:
+
+- `enableTagAutoGrouping`: Operations with an ancestor folder `operations/foo/bar/cat` and `operations/foo/dog` will be outputted
+  with a `foo` [tag](https://swagger.io/docs/specification/grouping-operations-with-tags/) in the generated `wundergraph.openapi.json` specification. (Operations without a parent (`e.g. operations/foo`) are not assigned a tag.) The tag generation can be individually overriden with the `tags` field in individual typescript operations

--- a/packages/sdk/src/configure/index.ts
+++ b/packages/sdk/src/configure/index.ts
@@ -181,6 +181,7 @@ export interface WunderGraphConfigApplicationConfig<
 	openApi?: {
 		title?: string;
 		apiVersion?: string;
+		enableTagAutoGrouping?: boolean;
 	};
 
 	/** @deprecated: Not used anymore */
@@ -1192,6 +1193,7 @@ export const configureWunderGraphApplication = <
 			const openApiBuilder = new OpenApiBuilder({
 				title: config.openApi?.title || 'WunderGraph Application',
 				version: config.openApi?.apiVersion || '0',
+				enableTagAutoGrouping: config.openApi?.enableTagAutoGrouping ?? false,
 				baseURL: publicNodeUrl,
 			});
 
@@ -1792,6 +1794,9 @@ const applyNodeJsOperationOverrides = (
 	}
 	if (overrides.description) {
 		operation.Description = overrides.description;
+	}
+	if (overrides.tags) {
+		operation.Tags = overrides.tags;
 	}
 	if (overrides.liveQuery) {
 		operation.LiveQuery = {

--- a/packages/sdk/src/graphql/operations.ts
+++ b/packages/sdk/src/graphql/operations.ts
@@ -58,6 +58,7 @@ export const isInternalOperationByAPIMountPath = (path: string) => {
 export interface GraphQLOperation {
 	Name: string;
 	Description: string;
+	Tags?: string[];
 	PathName: string;
 	Content: string;
 	OperationType: OperationType;

--- a/packages/sdk/src/openapibuilder/index.test.ts
+++ b/packages/sdk/src/openapibuilder/index.test.ts
@@ -457,6 +457,45 @@ describe('OpenAPI builder', () => {
 		expect(schemas?.['User_3']).toEqual(user3Schema);
 	});
 
+	test('Tags generate for operations', async () => {
+		const tagOperations = [
+			{
+				Name: 'QueryWithNoTagAndNoParent',
+				PathName: 'queryone',
+				OperationType: OperationType.QUERY,
+			},
+			{
+				Name: 'QueryWithTagAndNoParent',
+				PathName: 'querytwo',
+				OperationType: OperationType.MUTATION,
+				Tags: ['CustomTagName'],
+			},
+			{
+				Name: 'QueryWithTagAndParent',
+				PathName: 'users/querythree',
+				OperationType: OperationType.MUTATION,
+				Tags: ['Users'],
+			},
+			{
+				Name: 'QueryWithNoTagAndParent',
+				PathName: 'users/queryfour',
+				OperationType: OperationType.MUTATION,
+				Tags: ['CustomTagName2'],
+			},
+		] as GraphQLOperation[];
+		const builder = new OpenApiBuilder({
+			title: 'WunderGraph',
+			version: '0',
+			baseURL: 'http://localhost:9991',
+			enableTagAutoGrouping: true,
+		});
+		const result = builder.build(tagOperations);
+		expect(result.paths['/queryone']['get']?.tags).toBeUndefined();
+		expect(result.paths['/querytwo']['post']?.tags).toEqual(['CustomTagName']);
+		expect(result.paths['/users/querythree']['post']?.tags).toEqual(['Users']);
+		expect(result.paths['/users/queryfour']['post']?.tags).toEqual(['CustomTagName2']);
+	});
+
 	test('OpenAPI Builder', async () => {
 		const builder = new OpenApiBuilder({
 			title: 'WunderGraph',

--- a/packages/sdk/src/operations/operations.ts
+++ b/packages/sdk/src/operations/operations.ts
@@ -116,6 +116,7 @@ const createQuery =
 		input,
 		description = '',
 		response,
+		tags,
 		handler,
 		live,
 		cache,
@@ -127,6 +128,7 @@ const createQuery =
 		input?: Input;
 		description?: string;
 		errors?: { new (): OperationError }[];
+		tags?: string[];
 		response?: ZodResponse;
 		handler: ZodResponse extends z.ZodObject<any>
 			? (
@@ -169,6 +171,7 @@ const createQuery =
 			type: 'query',
 			description,
 			inputSchema: input,
+			tags,
 			responseSchema: response,
 			queryHandler: handler,
 			internal: internal || false,
@@ -200,6 +203,7 @@ const createMutation =
 	<Input extends z.ZodObject<any> = any, InferredResponse = unknown, ZodResponse = unknown>({
 		input,
 		description = '',
+		tags,
 		response,
 		handler,
 		requireAuthentication,
@@ -209,6 +213,7 @@ const createMutation =
 	}: {
 		input?: Input;
 		description?: string;
+		tags?: string[];
 		errors?: { new (): OperationError }[];
 		response?: ZodResponse;
 		handler: ZodResponse extends z.ZodObject<any>
@@ -249,6 +254,7 @@ const createMutation =
 		return {
 			type: 'mutation',
 			description,
+			tags,
 			inputSchema: input,
 			responseSchema: response,
 			mutationHandler: handler,
@@ -277,6 +283,7 @@ const createSubscription =
 	<Input extends z.ZodObject<any> = any, InferredResponse = unknown, ZodResponse = unknown>({
 		input,
 		description = '',
+		tags,
 		handler,
 		response,
 		requireAuthentication,
@@ -286,6 +293,7 @@ const createSubscription =
 	}: {
 		input?: Input;
 		description?: string;
+		tags?: string[];
 		errors?: { new (): OperationError }[];
 		response?: ZodResponse;
 		handler: SubscriptionHandler<
@@ -314,6 +322,7 @@ const createSubscription =
 		return {
 			type: 'subscription',
 			description,
+			tags,
 			subscriptionHandler: handler,
 			inputSchema: input,
 			responseSchema: response,
@@ -373,6 +382,7 @@ export type NodeJSOperation<
 	description?: string;
 	inputSchema?: z.ZodObject<any>;
 	responseSchema?: ZodResponse;
+	tags?: string[];
 	queryHandler?: ZodResponse extends z.ZodObject<any>
 		? (
 				ctx: HandlerContext<


### PR DESCRIPTION
## Motivation and Context
Currently, in the sdk's generated `wundergraph.openapi.json` spec, all operations appear under a `Default` tag section in an openapi swagger viewer. This change enhances the openapi builder spec generation by adding [tag support](https://swagger.io/docs/specification/grouping-operations-with-tags). 
Before            |  After
:-------------------------:|:-------------------------:
<img width="833" alt="Screenshot 2024-04-24 at 9 53 50 AM" src="https://github.com/wundergraph/wundergraph/assets/83970048/bedf8a8c-7611-4ffc-9175-44787d49c330"> | <img width="831" alt="Screenshot 2024-04-24 at 9 53 40 AM" src="https://github.com/wundergraph/wundergraph/assets/83970048/7695d414-73df-4ce4-8d1c-043f605d757e">


With this enhancement, if a user enables `openApi.enableTagAutoGrouping` in the `configureWundergraphApplication` options, operations are organically grouped according to their uppermost ancestor folder (grandparent for `operations/grandparent/parent/foo` and `parent` for `operations/parent/foo`. There is also the option to override this and/or customize tags in the typescript operations with the `tags` parameter.

## Marketing Changelog
Generated OpenAPI Spec Improvement: Tags

#### Checklist

- [x ] run `make test`
- [x ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ x] tests and/or benchmarks are included
- [x ] documentation is changed or added
- [x ] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)
