### PR TITLE
fix: openapi edge case for empty payloads

### DIFF
--- a/packages/sdk/src/openapibuilder/index.test.ts
+++ b/packages/sdk/src/openapibuilder/index.test.ts
@@ -211,6 +211,8 @@ describe('OpenAPI builder', () => {
 				PathName: 'MutationPath',
 				OperationType: OperationType.MUTATION,
 				AuthenticationConfig: { required: true },
+				VariablesSchema: personSchema,
+				ResponseSchema: personSchema,
 			},
 			{
 				Name: 'Subscription',
@@ -457,6 +459,25 @@ describe('OpenAPI builder', () => {
 		expect(schemas?.['User_3']).toEqual(user3Schema);
 	});
 
+	test('Empty payload in mutation returns properly formatted openapi schema', () => {
+		const operations = [
+			{
+				Name: 'Mutate',
+				PathName: 'path/mutate',
+				OperationType: OperationType.MUTATION,
+				ExecutionEngine: OperationExecutionEngine.ENGINE_GRAPHQL,
+				VariablesSchema: emptySchema,
+				ResponseSchema: emptySchema,
+			},
+		] as unknown as GraphQLOperation[];
+
+		const result = build(operations);
+		const operation = result.paths['/path/mutate'].post;
+		const requestBodyContent = operation?.requestBody?.content;
+		const requestBodyRequired = operation?.requestBody?.required;
+		expect(requestBodyRequired).toBeFalsy();
+		expect(requestBodyContent?.['application/json']).toEqual({});
+	});
 	test('OpenAPI Builder', async () => {
 		const builder = new OpenApiBuilder({
 			title: 'WunderGraph',


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

## Motivation and Context
The generated `wundergraph.openapi.json` specification doesn't currently handle mutations that have no input. The [requestBody](https://spec.openapis.org/oas/v3.1.0#request-body-object) shouldn't be required per the OpenAPI 3.1.0 docs, but the `openapibuilder` code currently assumes that we always have an input.

Now, for mutations that have no input, instead of of a payload that shows as an empty object...
<img width="811" alt="Screenshot 2024-04-25 at 12 35 19 PM" src="https://github.com/wundergraph/wundergraph/assets/83970048/0067761d-ed3b-4215-8634-68e45a16662d">
We have a payload that just shows as empty and non-required:
<img width="813" alt="Screenshot 2024-04-25 at 12 35 25 PM" src="https://github.com/wundergraph/wundergraph/assets/83970048/48eeb1c6-cbc6-4a40-899c-9b49ef5ff7ad">

This will correct the generated spec for the small subset mutation operations that don't consume an input.

## Marketing Changelog
OpenAPI Generated Spec now formats POST's with empty payloads correctly
<!--
What changes does this PR introduce? Please describe the changes in simple terms that a user can understand
without being familiar with the codebase. Mention @advocates for review and tracking.
-->

#### Checklist

- [x ] run `make test`
- [x ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
- [ x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ x] commit message and code follows the [Code of conduct](https://github.com/wundergraph/wundergraph/blob/main/CODE_OF_CONDUCT.md)
