### PR TITLE
remove erroneous data import from autoprefixer

### DIFF
--- a/examples/nextjs-app-dir/src/app/actions.ts
+++ b/examples/nextjs-app-dir/src/app/actions.ts
@@ -1,7 +1,6 @@
 'use server';
 
 import { client } from '@/lib/wundergraph';
-import { data } from 'autoprefixer';
 import { revalidatePath } from 'next/cache';
 import { AllTodosResponseData } from '../../.wundergraph/generated/models';
 


### PR DESCRIPTION
Noticed an erroneous import for "data" from "autoprefixer" which is not used by the function. This frequently happens with intellisense auto-imports.
